### PR TITLE
Add monorepo structure with basic token login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# project-budget-management
+# Project Budget Management
+
+This repository now uses a basic monorepo layout with two folders:
+
+- **client** – small web UI that allows a user to log in.
+- **service** – Express API implementing a token-based login flow using JWT.
+
+## Running the service
+
+```
+cd service
+npm install      # will fail without network but dependencies are express, jsonwebtoken and bcryptjs
+npm start
+```
+
+The API exposes `/login` and `/profile` endpoints. The `/login` route accepts `username` and `password` and returns a JWT token when credentials are valid.
+
+## Running the client
+
+```
+cd client
+npm install      # installs express for a simple static server
+npm start
+```
+
+Open `http://localhost:8080` in a browser and use `admin` / `password` to test.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Login</title>
+</head>
+<body>
+  <h1>Login</h1>
+  <form id="loginForm">
+    <label>Username: <input type="text" id="username" /></label><br />
+    <label>Password: <input type="password" id="password" /></label><br />
+    <button type="submit">Login</button>
+  </form>
+  <pre id="output"></pre>
+<script>
+const form = document.getElementById('loginForm');
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const username = document.getElementById('username').value;
+  const password = document.getElementById('password').value;
+  const res = await fetch('http://localhost:3000/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  const data = await res.json();
+  document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+});
+</script>
+</body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "client",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node server.js",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/client/server.js
+++ b/client/server.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+app.use(express.static(path.join(__dirname)));
+
+const PORT = process.env.PORT || 8080;
+app.listen(PORT, () => console.log(`Client running on port ${PORT}`));

--- a/service/package.json
+++ b/service/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "service",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node server.js",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/service/server.js
+++ b/service/server.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
+
+const app = express();
+app.use(express.json());
+
+// Dummy user database
+const users = [
+  { id: 1, username: 'admin', passwordHash: bcrypt.hashSync('password', 8) }
+];
+
+const SECRET = 'replace_this_secret';
+
+app.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  const user = users.find(u => u.username === username);
+  if (!user) {
+    return res.status(401).json({ error: 'invalid credentials' });
+  }
+  const valid = bcrypt.compareSync(password, user.passwordHash);
+  if (!valid) {
+    return res.status(401).json({ error: 'invalid credentials' });
+  }
+  const token = jwt.sign({ sub: user.id }, SECRET, { expiresIn: '1h' });
+  res.json({ token });
+});
+
+app.get('/profile', (req, res) => {
+  const auth = req.headers.authorization;
+  if (!auth) return res.status(401).json({ error: 'missing token' });
+  const token = auth.replace('Bearer ', '');
+  try {
+    const decoded = jwt.verify(token, SECRET);
+    const user = users.find(u => u.id === decoded.sub);
+    res.json({ id: user.id, username: user.username });
+  } catch (e) {
+    res.status(401).json({ error: 'invalid token' });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Service running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- scaffold client and service directories for a simple monorepo
- implement Express API with JWT-based login flow
- add minimal client with login form
- update README with instructions

## Testing
- `npm test` in `service` *(fails: Cannot find module 'express')*
- `npm test` in `client` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685295f7eb70832880a88e40ed495853