### PR TITLE
Fix client access via CORS

### DIFF
--- a/service/src/main.ts
+++ b/service/src/main.ts
@@ -3,6 +3,8 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  // Enable CORS so the Next.js client can call the API from a different port
+  app.enableCors();
   await app.listen(process.env.PORT || 3000);
 }
 bootstrap();


### PR DESCRIPTION
## Summary
- allow cross-origin requests from the Next.js client by enabling CORS in the NestJS API

## Testing
- `npm install` and `npm run build` in `service`
- `npm install` and `npm run build` in `client`

------
https://chatgpt.com/codex/tasks/task_e_6852a4f84ecc8328bd6b463acf77edcd