### PR TITLE
Add lock file patterns to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,8 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Lock files
+package-lock.json
+pnpm-lock.yaml
+yarn.lock


### PR DESCRIPTION
## Summary
- ignore `package-lock.json`, `pnpm-lock.yaml` and `yarn.lock` in `.gitignore`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68537de83fc88328937871640e8c1f6a