### PR TITLE
Add color theme template

### DIFF
--- a/client/pages/_app.js
+++ b/client/pages/_app.js
@@ -1,0 +1,12 @@
+import { ThemeProvider } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import theme from '../theme';
+
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Component {...pageProps} />
+    </ThemeProvider>
+  );
+}

--- a/client/pages/index.js
+++ b/client/pages/index.js
@@ -32,8 +32,8 @@ export default function Home() {
 
   return (
     <Container maxWidth="sm">
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh">
-        <Paper sx={{ p: 4, width: '100%' }} elevation={3}>
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh', bgcolor: 'background.default' }}>
+        <Paper sx={{ p: 4, width: '100%', bgcolor: 'background.paper' }} elevation={3}>
           <Typography variant="h4" component="h1" gutterBottom align="center">
             Login
           </Typography>

--- a/client/theme.js
+++ b/client/theme.js
@@ -1,0 +1,18 @@
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#89A8B2',
+    },
+    secondary: {
+      main: '#B3C8CF',
+    },
+    background: {
+      default: '#F1F0E8',
+      paper: '#E5E1DA',
+    },
+  },
+});
+
+export default theme;


### PR DESCRIPTION
## Summary
- add MUI theme with color palette
- wrap app with ThemeProvider
- apply themed background colors in login page

## Testing
- `npm run build` in `client`

------
https://chatgpt.com/codex/tasks/task_e_685381b654d48328b73f10d48c265b9f