### PR TITLE
Add logging interceptor and API version prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ with Docker.
 ```
 
 This starts MongoDB, Redis, the NestJS API on port `3000` and the Next.js client
-on `http://localhost:8080`.
+on `http://localhost:8080`. All service endpoints are available under the
+`/api/v1` path prefix.
 
 An admin user is created automatically with username `admin` and password taken
 from the `ADMIN_PASSWORD` environment variable (default `admin`).

--- a/service/src/app.module.ts
+++ b/service/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { LoggerService } from './logger/logger.service';
 import { MongooseModule } from '@nestjs/mongoose';
 import { UsersModule } from './users/users.module';
 import { RedisModule } from './redis.module';
@@ -9,5 +10,7 @@ import { RedisModule } from './redis.module';
     RedisModule,
     UsersModule,
   ],
+  providers: [LoggerService],
+  exports: [LoggerService],
 })
 export class AppModule {}

--- a/service/src/logger/logger.service.ts
+++ b/service/src/logger/logger.service.ts
@@ -1,20 +1,40 @@
 import { Injectable } from '@nestjs/common';
 
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
 @Injectable()
 export class LoggerService {
-  debug(data: any) {
-    console.debug(JSON.stringify(data));
+  private output(level: LogLevel, log: any) {
+    const msg = JSON.stringify(log);
+    switch (level) {
+      case 'debug':
+        console.debug(msg);
+        break;
+      case 'info':
+        console.info(msg);
+        break;
+      case 'warn':
+        console.warn(msg);
+        break;
+      case 'error':
+        console.error(msg);
+        break;
+    }
   }
 
-  info(data: any) {
-    console.info(JSON.stringify(data));
+  private log(log_type: 'info' | 'app' | 'service', level: LogLevel, data: any) {
+    this.output(level, { log_type, level, ...data });
   }
 
-  warn(data: any) {
-    console.warn(JSON.stringify(data));
+  logInfo(level: LogLevel, data: any) {
+    this.log('info', level, data);
   }
 
-  error(data: any) {
-    console.error(JSON.stringify(data));
+  logApp(level: LogLevel, data: any) {
+    this.log('app', level, data);
+  }
+
+  logService(level: LogLevel, data: any) {
+    this.log('service', level, data);
   }
 }

--- a/service/src/logger/logger.service.ts
+++ b/service/src/logger/logger.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class LoggerService {
+  debug(data: any) {
+    console.debug(JSON.stringify(data));
+  }
+
+  info(data: any) {
+    console.info(JSON.stringify(data));
+  }
+
+  warn(data: any) {
+    console.warn(JSON.stringify(data));
+  }
+
+  error(data: any) {
+    console.error(JSON.stringify(data));
+  }
+}

--- a/service/src/logger/logging.interceptor.ts
+++ b/service/src/logger/logging.interceptor.ts
@@ -1,0 +1,49 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap, catchError } from 'rxjs/operators';
+import { LoggerService } from './logger.service';
+
+@Injectable()
+export class LoggingInterceptor implements NestInterceptor {
+  constructor(private readonly logger: LoggerService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const req = context.switchToHttp().getRequest();
+    const res = context.switchToHttp().getResponse();
+    const { method, originalUrl: url } = req;
+    const start = Date.now();
+    this.logger.debug({ event: 'request_received', method, url });
+    return next.handle().pipe(
+      tap((data) => {
+        const process_time = Date.now() - start;
+        const log = {
+          event: 'request_completed',
+          method,
+          url,
+          status_code: res.statusCode,
+          process_time,
+        };
+        if (res.statusCode >= 500) this.logger.error(log);
+        else if (res.statusCode >= 400) this.logger.warn(log);
+        else this.logger.info(log);
+      }),
+      catchError((err) => {
+        const process_time = Date.now() - start;
+        this.logger.error({
+          event: 'request_failed',
+          method,
+          url,
+          status_code: res.statusCode,
+          process_time,
+          error: err.message,
+        });
+        throw err;
+      })
+    );
+  }
+}

--- a/service/src/logger/logging.interceptor.ts
+++ b/service/src/logger/logging.interceptor.ts
@@ -17,7 +17,7 @@ export class LoggingInterceptor implements NestInterceptor {
     const res = context.switchToHttp().getResponse();
     const { method, originalUrl: url } = req;
     const start = Date.now();
-    this.logger.debug({ event: 'request_received', method, url });
+    this.logger.logInfo('debug', { event: 'request_received', method, url });
     return next.handle().pipe(
       tap((data) => {
         const process_time = Date.now() - start;
@@ -28,13 +28,13 @@ export class LoggingInterceptor implements NestInterceptor {
           status_code: res.statusCode,
           process_time,
         };
-        if (res.statusCode >= 500) this.logger.error(log);
-        else if (res.statusCode >= 400) this.logger.warn(log);
-        else this.logger.info(log);
+        if (res.statusCode >= 500) this.logger.logInfo('error', log);
+        else if (res.statusCode >= 400) this.logger.logInfo('warn', log);
+        else this.logger.logInfo('info', log);
       }),
       catchError((err) => {
         const process_time = Date.now() - start;
-        this.logger.error({
+        this.logger.logInfo('error', {
           event: 'request_failed',
           method,
           url,

--- a/service/src/main.ts
+++ b/service/src/main.ts
@@ -1,10 +1,15 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { LoggingInterceptor } from './logger/logging.interceptor';
+import { LoggerService } from './logger/logger.service';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   // Enable CORS so the Next.js client can call the API from a different port
   app.enableCors();
+  app.setGlobalPrefix('api/v1');
+  const logger = app.get(LoggerService);
+  app.useGlobalInterceptors(new LoggingInterceptor(logger));
   await app.listen(process.env.PORT || 3000);
 }
 bootstrap();


### PR DESCRIPTION
## Summary
- log all requests/responses via a new LoggingInterceptor
- emit JSON logs for debug/info/warn/error levels
- register LoggerService and LoggingInterceptor globally
- prefix all API routes with `/api/v1`
- document the API prefix in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685385703c5c83288313ff554ab7f022