### PR TITLE
Add workspace page with auth guard and layout switch

### DIFF
--- a/client/context/AuthContext.js
+++ b/client/context/AuthContext.js
@@ -1,0 +1,43 @@
+import { createContext, useContext, useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [token, setToken] = useState(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('token');
+    if (stored) setToken(stored);
+  }, []);
+
+  const login = (tok) => {
+    localStorage.setItem('token', tok);
+    setToken(tok);
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);
+
+export function withAuth(Component) {
+  return function Authenticated(props) {
+    const { token } = useAuth();
+    const router = useRouter();
+    useEffect(() => {
+      if (!token) router.push('/');
+    }, [token]);
+    if (!token) return null;
+    return <Component {...props} />;
+  };
+}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,7 +11,9 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^7.1.1",
+        "@mui/lab": "^7.0.0-beta.13",
         "@mui/material": "^7.1.1",
+        "@mui/x-date-pickers": "^8.5.2",
         "next": "^13.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
@@ -377,6 +379,50 @@
         }
       }
     },
+    "node_modules/@mui/lab": {
+      "version": "7.0.0-beta.13",
+      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-7.0.0-beta.13.tgz",
+      "integrity": "sha512-wLSeePenug3+/kek4cFMIF3QZVC2fHt2Z3O3HwOFvakgErmT39WltYsNpWNojCnXUqcIExUp9xNW0Wk+tJShgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1",
+        "@mui/system": "^7.1.1",
+        "@mui/types": "^7.4.3",
+        "@mui/utils": "^7.1.1",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material": "^7.1.1",
+        "@mui/material-pigment-css": "^7.1.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@mui/material": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.1.1.tgz",
@@ -572,6 +618,94 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@mui/x-date-pickers": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-8.5.2.tgz",
+      "integrity": "sha512-KN0GK5aVetGFB3n4W7XsUI79uTSxftTEhHtDCdQjOOeri2lZSY55MVn/CeYZdpuWlBOD1eTLPtCFzueeUp3m6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "@mui/utils": "^7.1.1",
+        "@mui/x-internals": "8.5.2",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2 || ^3.0.0",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-internals": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.5.2.tgz",
+      "integrity": "sha512-5YhB2AekK7G8d0YrAjg3WNf0uy3V73JD98WNxJhbIlCraQgl8QOQzr2zNO7MAf/X7mZQtjpjuAsiG3+gI2NVyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "@mui/utils": "^7.1.1",
+        "reselect": "^5.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@next/env": {
@@ -1283,6 +1417,12 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",

--- a/client/package.json
+++ b/client/package.json
@@ -7,12 +7,14 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "^13.0.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
-    "@mui/material": "^7.1.1",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@mui/icons-material": "^7.1.1"
+    "@mui/icons-material": "^7.1.1",
+    "@mui/lab": "^7.0.0-beta.13",
+    "@mui/material": "^7.1.1",
+    "@mui/x-date-pickers": "^8.5.2",
+    "next": "^13.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   }
 }

--- a/client/pages/_app.js
+++ b/client/pages/_app.js
@@ -1,12 +1,15 @@
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../theme';
+import { AuthProvider } from '../context/AuthContext';
 
 export default function MyApp({ Component, pageProps }) {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <Component {...pageProps} />
+      <AuthProvider>
+        <Component {...pageProps} />
+      </AuthProvider>
     </ThemeProvider>
   );
 }

--- a/client/pages/index.js
+++ b/client/pages/index.js
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { useRouter } from 'next/router';
 import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
@@ -7,12 +9,13 @@ import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
 
 export default function Home() {
-  const [token, setToken] = useState(null);
+  const { token, login } = useAuth();
+  const router = useRouter();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [profile, setProfile] = useState(null);
 
-  async function login(e) {
+  async function handleLogin(e) {
     e.preventDefault();
     const res = await fetch('http://localhost:3000/login', {
       method: 'POST',
@@ -20,7 +23,8 @@ export default function Home() {
       body: JSON.stringify({ username, password })
     });
     const data = await res.json();
-    setToken(data.token);
+    login(data.token);
+    router.push('/workspace');
   }
 
   async function getProfile() {
@@ -37,7 +41,7 @@ export default function Home() {
           <Typography variant="h4" component="h1" gutterBottom align="center">
             Login
           </Typography>
-          <Box component="form" onSubmit={login} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+  <Box component="form" onSubmit={handleLogin} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
             <TextField label="Username" value={username} onChange={e => setUsername(e.target.value)} required />
             <TextField label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
             <Button variant="contained" type="submit" fullWidth>

--- a/client/pages/workspace.js
+++ b/client/pages/workspace.js
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import Container from '@mui/material/Container';
+import Box from '@mui/material/Box';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
+import Timeline from '@mui/lab/Timeline';
+import TimelineItem from '@mui/lab/TimelineItem';
+import TimelineSeparator from '@mui/lab/TimelineSeparator';
+import TimelineConnector from '@mui/lab/TimelineConnector';
+import TimelineContent from '@mui/lab/TimelineContent';
+import TimelineDot from '@mui/lab/TimelineDot';
+import { withAuth } from '../context/AuthContext';
+
+function Workspace() {
+  const [view, setView] = useState('calendar');
+
+  return (
+    <Container maxWidth="md" sx={{ mt: 4 }}>
+      <Paper sx={{ p: 2 }} elevation={3}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+          <Typography variant="h5">Workspace</Typography>
+          <ToggleButtonGroup
+            value={view}
+            exclusive
+            onChange={(_, v) => v && setView(v)}
+            size="small"
+          >
+            <ToggleButton value="calendar">Calendar</ToggleButton>
+            <ToggleButton value="timeline">Timeline</ToggleButton>
+          </ToggleButtonGroup>
+        </Box>
+        {view === 'calendar' ? (
+          <DateCalendar />
+        ) : (
+          <Timeline>
+            <TimelineItem>
+              <TimelineSeparator>
+                <TimelineDot />
+                <TimelineConnector />
+              </TimelineSeparator>
+              <TimelineContent>Initial Planning</TimelineContent>
+            </TimelineItem>
+            <TimelineItem>
+              <TimelineSeparator>
+                <TimelineDot />
+                <TimelineConnector />
+              </TimelineSeparator>
+              <TimelineContent>Development</TimelineContent>
+            </TimelineItem>
+            <TimelineItem>
+              <TimelineSeparator>
+                <TimelineDot />
+              </TimelineSeparator>
+              <TimelineContent>Release</TimelineContent>
+            </TimelineItem>
+          </Timeline>
+        )}
+      </Paper>
+    </Container>
+  );
+}
+
+export default withAuth(Workspace);


### PR DESCRIPTION
## Summary
- create `AuthContext` for storing authentication state
- wrap app with `AuthProvider`
- update login page to use context and redirect to new workspace page
- add protected `/workspace` page with calendar and timeline layouts
- install `@mui/lab` and `@mui/x-date-pickers`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685386f0e7888328b8eeac056431b24f