### PR TITLE
Add API version prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install      # will fail without network but dependencies are express, jsonw
 npm start
 ```
 
-The API exposes `/login` and `/profile` endpoints. The `/login` route accepts `username` and `password` and returns a JWT token when credentials are valid.
+The API exposes `/api/v1/login` and `/api/v1/profile` endpoints. The `/api/v1/login` route accepts `username` and `password` and returns a JWT token when credentials are valid. The version prefix (`/api/v1`) can be configured via the `API_PREFIX` environment variable.
 
 ## Running the client
 

--- a/client/index.html
+++ b/client/index.html
@@ -18,7 +18,7 @@ form.addEventListener('submit', async (e) => {
   e.preventDefault();
   const username = document.getElementById('username').value;
   const password = document.getElementById('password').value;
-  const res = await fetch('http://localhost:3000/login', {
+  const res = await fetch('http://localhost:3000/api/v1/login', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ username, password })

--- a/service/server.js
+++ b/service/server.js
@@ -5,6 +5,8 @@ const bcrypt = require('bcryptjs');
 const app = express();
 app.use(express.json());
 
+const API_PREFIX = process.env.API_PREFIX || '/api/v1';
+
 // Dummy user database
 const users = [
   { id: 1, username: 'admin', passwordHash: bcrypt.hashSync('password', 8) }
@@ -12,7 +14,7 @@ const users = [
 
 const SECRET = 'replace_this_secret';
 
-app.post('/login', (req, res) => {
+app.post(`${API_PREFIX}/login`, (req, res) => {
   const { username, password } = req.body;
   const user = users.find(u => u.username === username);
   if (!user) {
@@ -26,7 +28,7 @@ app.post('/login', (req, res) => {
   res.json({ token });
 });
 
-app.get('/profile', (req, res) => {
+app.get(`${API_PREFIX}/profile`, (req, res) => {
   const auth = req.headers.authorization;
   if (!auth) return res.status(401).json({ error: 'missing token' });
   const token = auth.replace('Bearer ', '');


### PR DESCRIPTION
## Summary
- prefix service endpoints with `/api/v1`
- call new API path from client
- mention versioned endpoints in README

## Testing
- `npm test` in `client` *(fails: Cannot find module 'express')*
- `npm test` in `service` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68538b8b04448328855390eae8834c6a