### PR TITLE
Add environment configurations

### DIFF
--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -16,4 +16,5 @@ FROM node:18-alpine
 WORKDIR /app/service
 COPY --from=modules /app/service/node_modules ./node_modules
 COPY --from=build /app/service/dist ./dist
+COPY --from=build /app/service/env ./env
 CMD ["node", "dist/main.js"]

--- a/README.md
+++ b/README.md
@@ -36,3 +36,19 @@ npm install
 npm run build
 npm start
 ```
+
+## Environments
+
+The service loads environment variables from files in `service/env` based on the
+`NODE_ENV` value. Five example configurations are provided:
+
+```
+service/env/local.env
+service/env/development.env
+service/env/staging.env
+service/env/uat.env
+service/env/production.env
+```
+
+Set `NODE_ENV` to one of these names when starting the service to load the
+matching file.

--- a/service/env/development.env
+++ b/service/env/development.env
@@ -1,0 +1,6 @@
+NODE_ENV=development
+MONGO_URL=mongodb://mongo:27017/budget_dev
+REDIS_URL=redis://redis:6379
+SECRET=dev_secret
+ADMIN_PASSWORD=admin
+PORT=3000

--- a/service/env/local.env
+++ b/service/env/local.env
@@ -1,0 +1,6 @@
+NODE_ENV=local
+MONGO_URL=mongodb://mongo:27017/budget_local
+REDIS_URL=redis://redis:6379
+SECRET=local_secret
+ADMIN_PASSWORD=admin
+PORT=3000

--- a/service/env/production.env
+++ b/service/env/production.env
@@ -1,0 +1,6 @@
+NODE_ENV=production
+MONGO_URL=mongodb://mongo:27017/budget
+REDIS_URL=redis://redis:6379
+SECRET=prod_secret
+ADMIN_PASSWORD=admin
+PORT=3000

--- a/service/env/staging.env
+++ b/service/env/staging.env
@@ -1,0 +1,6 @@
+NODE_ENV=staging
+MONGO_URL=mongodb://mongo:27017/budget_staging
+REDIS_URL=redis://redis:6379
+SECRET=staging_secret
+ADMIN_PASSWORD=admin
+PORT=3000

--- a/service/env/uat.env
+++ b/service/env/uat.env
@@ -1,0 +1,6 @@
+NODE_ENV=uat
+MONGO_URL=mongodb://mongo:27017/budget_uat
+REDIS_URL=redis://redis:6379
+SECRET=uat_secret
+ADMIN_PASSWORD=admin
+PORT=3000

--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -13,6 +13,7 @@
         "@nestjs/mongoose": "^9.0.0",
         "@nestjs/platform-express": "^9.0.0",
         "bcryptjs": "^2.4.3",
+        "dotenv": "^16.0.0",
         "ioredis": "^5.0.0",
         "jsonwebtoken": "^9.0.0",
         "mongoose": "^6.0.0",
@@ -3473,6 +3474,18 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/service/package.json
+++ b/service/package.json
@@ -18,7 +18,8 @@
     "mongoose": "^6.0.0",
     "ioredis": "^5.0.0",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.0.0"
+    "rxjs": "^7.0.0",
+    "dotenv": "^16.0.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",

--- a/service/src/main.ts
+++ b/service/src/main.ts
@@ -2,6 +2,11 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { LoggingInterceptor } from './logger/logging.interceptor';
 import { LoggerService } from './logger/logger.service';
+import * as path from 'path';
+import { config } from 'dotenv';
+
+const envFile = path.join(__dirname, '../env', `${process.env.NODE_ENV || 'local'}.env`);
+config({ path: envFile });
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);


### PR DESCRIPTION
## Summary
- add example env files for various deployment stages
- load env configuration in the NestJS service
- include env files in the Docker image
- document how to use environment files

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68538d22b6f48328a20dffba7fa40f64