### PR TITLE
Fix login URL for NestJS service

### DIFF
--- a/client/pages/index.js
+++ b/client/pages/index.js
@@ -17,18 +17,18 @@ export default function Home() {
 
   async function handleLogin(e) {
     e.preventDefault();
-    const res = await fetch('http://localhost:3000/login', {
+    const res = await fetch('http://localhost:3000/api/v1/auth/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password })
     });
     const data = await res.json();
-    login(data.token);
+    login(data.accessToken);
     router.push('/workspace');
   }
 
   async function getProfile() {
-    const res = await fetch('http://localhost:3000/profile', {
+    const res = await fetch('http://localhost:3000/api/v1/profile', {
       headers: { Authorization: `Bearer ${token}` }
     });
     setProfile(await res.json());


### PR DESCRIPTION
## Summary
- call the NestJS API through the correct `/api/v1` path
- store returned access tokens correctly

## Testing
- `npm run build` in `client`
- `npm install` and `npm run build` in `service`

------
https://chatgpt.com/codex/tasks/task_e_6853904f22648328b1c7f62f5c3e251f