### PR TITLE
Add events API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ This starts MongoDB, Redis, the NestJS API on port `3000` and the Next.js client
 on `http://localhost:8080`. All service endpoints are available under the
 `/api/v1` path prefix.
 
+The service now exposes a new endpoint `GET /api/v1/events` which returns the
+timeline/calendar layout entries.
+
 An admin user is created automatically with username `admin` and password taken
 from the `ADMIN_PASSWORD` environment variable (default `admin`).
 

--- a/service/src/app.module.ts
+++ b/service/src/app.module.ts
@@ -3,12 +3,14 @@ import { LoggerService } from './logger/logger.service';
 import { MongooseModule } from '@nestjs/mongoose';
 import { UsersModule } from './users/users.module';
 import { RedisModule } from './redis.module';
+import { EventsModule } from './events/events.module';
 
 @Module({
   imports: [
     MongooseModule.forRoot(process.env.MONGO_URL || 'mongodb://mongo:27017/budget'),
     RedisModule,
     UsersModule,
+    EventsModule,
   ],
   providers: [LoggerService],
   exports: [LoggerService],

--- a/service/src/events/data/event.schema.ts
+++ b/service/src/events/data/event.schema.ts
@@ -1,0 +1,13 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema()
+export class Event extends Document {
+  @Prop({ required: true })
+  title: string;
+
+  @Prop({ required: true })
+  date: Date;
+}
+
+export const EventSchema = SchemaFactory.createForClass(Event);

--- a/service/src/events/data/events.repository.ts
+++ b/service/src/events/data/events.repository.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Event } from './event.schema';
+
+@Injectable()
+export class EventsRepository {
+  constructor(@InjectModel(Event.name) private eventModel: Model<Event>) {}
+
+  findAll(): Promise<Event[]> {
+    return this.eventModel.find().sort({ date: 1 }).exec();
+  }
+
+  create(title: string, date: Date): Promise<Event> {
+    const event = new this.eventModel({ title, date });
+    return event.save();
+  }
+}

--- a/service/src/events/events.controller.ts
+++ b/service/src/events/events.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { EventsService } from './events.service';
+
+@Controller('events')
+export class EventsController {
+  constructor(private readonly eventsService: EventsService) {}
+
+  @Get()
+  getEvents() {
+    return this.eventsService.getEvents();
+  }
+}

--- a/service/src/events/events.initializer.ts
+++ b/service/src/events/events.initializer.ts
@@ -1,0 +1,16 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { EventsRepository } from './data/events.repository';
+
+@Injectable()
+export class EventsInitializer implements OnModuleInit {
+  constructor(private readonly repo: EventsRepository) {}
+
+  async onModuleInit() {
+    const existing = await this.repo.findAll();
+    if (existing.length === 0) {
+      await this.repo.create('Initial Planning', new Date('2023-01-01'));
+      await this.repo.create('Development', new Date('2023-03-01'));
+      await this.repo.create('Release', new Date('2023-06-01'));
+    }
+  }
+}

--- a/service/src/events/events.module.ts
+++ b/service/src/events/events.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { EventsController } from './events.controller';
+import { EventsService } from './events.service';
+import { EventsRepository } from './data/events.repository';
+import { Event, EventSchema } from './data/event.schema';
+import { EventsInitializer } from './events.initializer';
+
+@Module({
+  imports: [MongooseModule.forFeature([{ name: Event.name, schema: EventSchema }])],
+  controllers: [EventsController],
+  providers: [EventsService, EventsRepository, EventsInitializer],
+})
+export class EventsModule {}

--- a/service/src/events/events.service.ts
+++ b/service/src/events/events.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { EventsRepository } from './data/events.repository';
+
+@Injectable()
+export class EventsService {
+  constructor(private readonly repo: EventsRepository) {}
+
+  getEvents() {
+    return this.repo.findAll();
+  }
+}


### PR DESCRIPTION
## Summary
- create Events module with controller, service, repository and schema
- seed sample events on startup
- register EventsModule in AppModule
- document the `/api/v1/events` endpoint in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` in `service`
- `npx nest build` *(fails: could not determine executable)*
- `npm run build` in `service` after installing modules


------
https://chatgpt.com/codex/tasks/task_e_6853911ed8448328b1d75402fb6f5cbd