### PR TITLE
Add SERVICE_URL configuration for client

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ npm run build
 npm start
 ```
 
+Set the `SERVICE_URL` environment variable to control where API requests are
+proxied. Create an `.env` file based on `.env.example` to override the default
+(`http://localhost:3000`).
+
 ## Environments
 
 The service loads environment variables from files in `service/env` based on the

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ npm install
 npm run build
 npm run start:prod
 ```
+Create a `.env` file in the `service` directory based on `.env.example` to set
+database URLs and other options.
 
 To run the client manually:
 
@@ -40,6 +42,10 @@ npm start
 Set the `SERVICE_URL` environment variable to control where API requests are
 proxied. Create an `.env` file based on `.env.example` to override the default
 (`http://localhost:3000`).
+
+The service also provides a `service/.env.example` file. Copy it to
+`service/.env` and adjust values if you prefer not to use the predefined files
+under `service/env`.
 
 ## Environments
 

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,1 @@
+SERVICE_URL=http://localhost:3000

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -1,3 +1,14 @@
+const SERVICE_URL = process.env.SERVICE_URL || 'http://localhost:3000';
+
+/** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${SERVICE_URL}/api/:path*`,
+      },
+    ];
+  },
 };

--- a/client/pages/index.js
+++ b/client/pages/index.js
@@ -17,7 +17,7 @@ export default function Home() {
 
   async function handleLogin(e) {
     e.preventDefault();
-    const res = await fetch('http://localhost:3000/api/v1/auth/login', {
+    const res = await fetch('/api/v1/auth/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password })
@@ -28,7 +28,7 @@ export default function Home() {
   }
 
   async function getProfile() {
-    const res = await fetch('http://localhost:3000/api/v1/profile', {
+    const res = await fetch('/api/v1/profile', {
       headers: { Authorization: `Bearer ${token}` }
     });
     setProfile(await res.json());

--- a/service/.env.example
+++ b/service/.env.example
@@ -1,0 +1,6 @@
+NODE_ENV=local
+MONGO_URL=mongodb://mongo:27017/budget_local
+REDIS_URL=redis://redis:6379
+SECRET=local_secret
+ADMIN_PASSWORD=admin
+PORT=3000


### PR DESCRIPTION
## Summary
- allow configuring service endpoint via `SERVICE_URL`
- rewrite `/api/*` requests to the configured service
- use relative API calls in the login page
- document `SERVICE_URL` environment variable
- provide `.env.example` for the client

## Testing
- `npm run build` (fails: `next` not found)
- `npm run build` in service (fails: `nest` not found)

------
https://chatgpt.com/codex/tasks/task_e_6853918754148328b79b60b93e5b6957