### PR TITLE
Fix client API proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ This starts MongoDB, Redis, the NestJS API on port `3000` and the Next.js client
 on `http://localhost:8080`. All service endpoints are available under the
 `/api/v1` path prefix.
 
+The `docker-compose.yml` file sets `SERVICE_URL` for the client container so
+that API requests are forwarded to the service.
+
 The service now exposes a new endpoint `GET /api/v1/events` which returns the
 timeline/calendar layout entries.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.client
+    environment:
+      - SERVICE_URL=http://service:3000
     ports:
       - "8080:3000"
     depends_on:


### PR DESCRIPTION
## Summary
- configure SERVICE_URL for the client container so API requests reach the service
- note the new variable in the docs

## Testing
- `npm run build` in `service`
- `npm run build` in `client`

------
https://chatgpt.com/codex/tasks/task_e_6853aad7eafc8328937aec7579fdef62