### PR TITLE
Add navigation layout and follower API

### DIFF
--- a/client/components/Layout.js
+++ b/client/components/Layout.js
@@ -1,0 +1,19 @@
+import Box from '@mui/material/Box';
+import Toolbar from '@mui/material/Toolbar';
+import Topbar from './Topbar';
+import Sidebar from './Sidebar';
+import { useState } from 'react';
+
+export default function Layout({ children }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <Topbar onMenuClick={() => setOpen(!open)} />
+      <Sidebar open={open} onClose={() => setOpen(false)} />
+      <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+        <Toolbar />
+        {children}
+      </Box>
+    </Box>
+  );
+}

--- a/client/components/ResourceForm.js
+++ b/client/components/ResourceForm.js
@@ -1,0 +1,29 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import { useState } from 'react';
+import { Input } from '.';
+
+export default function ResourceForm() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [position, setPosition] = useState('');
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    alert(`Created resource ${name}`);
+    setName('');
+    setEmail('');
+    setPosition('');
+  }
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Typography variant="h6">Add Resource</Typography>
+      <Input label="Name" value={name} onChange={e => setName(e.target.value)} required />
+      <Input label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} required />
+      <Input label="Position" value={position} onChange={e => setPosition(e.target.value)} required />
+      <Button variant="contained" type="submit">Create</Button>
+    </Box>
+  );
+}

--- a/client/components/Sidebar.js
+++ b/client/components/Sidebar.js
@@ -1,0 +1,65 @@
+import Drawer from '@mui/material/Drawer';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import IconButton from '@mui/material/IconButton';
+import Divider from '@mui/material/Divider';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import SettingsIcon from '@mui/icons-material/Settings';
+import GroupIcon from '@mui/icons-material/Group';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+
+const drawerWidth = 200;
+
+export default function Sidebar({ open, onClose }) {
+  const router = useRouter();
+  const [collapsed, setCollapsed] = useState(false);
+
+  const width = collapsed ? 60 : drawerWidth;
+
+  return (
+    <Drawer
+      variant="permanent"
+      open
+      sx={{
+        width,
+        flexShrink: 0,
+        [`& .MuiDrawer-paper`]: { width, boxSizing: 'border-box' },
+      }}
+    >
+      <List>
+        <ListItem button onClick={() => setCollapsed(!collapsed)}>
+          <ListItemIcon>
+            {collapsed ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+          </ListItemIcon>
+          {!collapsed && <ListItemText primary="Collapse" />}
+        </ListItem>
+      </List>
+      <Divider />
+      <List>
+        <ListItem button onClick={() => router.push('/workspace')}>
+          <ListItemIcon>
+            <DashboardIcon />
+          </ListItemIcon>
+          {!collapsed && <ListItemText primary="Summary" />}
+        </ListItem>
+        <ListItem button onClick={() => router.push('/project-installation')}>
+          <ListItemIcon>
+            <SettingsIcon />
+          </ListItemIcon>
+          {!collapsed && <ListItemText primary="Project Installation" />}
+        </ListItem>
+        <ListItem button onClick={() => router.push('/team-setting')}>
+          <ListItemIcon>
+            <GroupIcon />
+          </ListItemIcon>
+          {!collapsed && <ListItemText primary="Team Setting" />}
+        </ListItem>
+      </List>
+    </Drawer>
+  );
+}

--- a/client/components/Topbar.js
+++ b/client/components/Topbar.js
@@ -1,0 +1,68 @@
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import IconButton from '@mui/material/IconButton';
+import MenuIcon from '@mui/icons-material/Menu';
+import AccountCircle from '@mui/icons-material/AccountCircle';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Drawer from '@mui/material/Drawer';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+
+export default function Topbar({ onMenuClick }) {
+  const { logout } = useAuth();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [openProfile, setOpenProfile] = useState(false);
+
+  const handleMenu = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <AppBar position="fixed" color="primary" sx={{ zIndex: (t) => t.zIndex.drawer + 1 }}>
+      <Toolbar>
+        <IconButton color="inherit" edge="start" onClick={onMenuClick} sx={{ mr: 2 }}>
+          <MenuIcon />
+        </IconButton>
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          Budget Manager
+        </Typography>
+        <IconButton color="inherit" onClick={handleMenu}>
+          <AccountCircle />
+        </IconButton>
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+          <MenuItem
+            onClick={() => {
+              handleClose();
+              setOpenProfile(true);
+            }}
+          >
+            My Profile
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              handleClose();
+              logout();
+            }}
+          >
+            Logout
+          </MenuItem>
+        </Menu>
+        <Drawer anchor="right" open={openProfile} onClose={() => setOpenProfile(false)}>
+          <Box sx={{ width: 250, p: 2 }}>
+            <Typography variant="h6" gutterBottom>
+              My Profile
+            </Typography>
+            <Typography variant="body2">Profile details go here.</Typography>
+          </Box>
+        </Drawer>
+      </Toolbar>
+    </AppBar>
+  );
+}

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -3,3 +3,7 @@ export { default as lazyLoad } from './LazyLoad';
 export { default as Popup } from './Popup';
 export { default as Input } from './Input';
 export { default as LoadingButton } from './LoadingButton';
+export { default as Topbar } from './Topbar';
+export { default as Sidebar } from './Sidebar';
+export { default as Layout } from './Layout';
+export { default as ResourceForm } from './ResourceForm';

--- a/client/pages/project-installation.js
+++ b/client/pages/project-installation.js
@@ -1,0 +1,22 @@
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+import Container from '@mui/material/Container';
+import { Layout } from '../components';
+import { withAuth } from '../context/AuthContext';
+
+function ProjectInstallation() {
+  return (
+    <Layout>
+      <Container maxWidth="md" sx={{ mt: 4 }}>
+        <Paper sx={{ p: 2 }} elevation={3}>
+          <Typography variant="h5">Project Installation</Typography>
+          <Typography variant="body1" sx={{ mt: 2 }}>
+            Settings and new project creation will go here.
+          </Typography>
+        </Paper>
+      </Container>
+    </Layout>
+  );
+}
+
+export default withAuth(ProjectInstallation);

--- a/client/pages/team-setting.js
+++ b/client/pages/team-setting.js
@@ -1,0 +1,18 @@
+import Paper from '@mui/material/Paper';
+import Container from '@mui/material/Container';
+import { Layout, ResourceForm } from '../components';
+import { withAuth } from '../context/AuthContext';
+
+function TeamSetting() {
+  return (
+    <Layout>
+      <Container maxWidth="sm" sx={{ mt: 4 }}>
+        <Paper sx={{ p: 2 }} elevation={3}>
+          <ResourceForm />
+        </Paper>
+      </Container>
+    </Layout>
+  );
+}
+
+export default withAuth(TeamSetting);

--- a/client/pages/workspace.js
+++ b/client/pages/workspace.js
@@ -13,13 +13,15 @@ import TimelineConnector from '@mui/lab/TimelineConnector';
 import TimelineContent from '@mui/lab/TimelineContent';
 import TimelineDot from '@mui/lab/TimelineDot';
 import { withAuth } from '../context/AuthContext';
+import { Layout } from '../components';
 
 function Workspace() {
   const [view, setView] = useState('calendar');
 
   return (
-    <Container maxWidth="md" sx={{ mt: 4 }}>
-      <Paper sx={{ p: 2 }} elevation={3}>
+    <Layout>
+      <Container maxWidth="md" sx={{ mt: 4 }}>
+        <Paper sx={{ p: 2 }} elevation={3}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
           <Typography variant="h5">Workspace</Typography>
           <ToggleButtonGroup
@@ -60,6 +62,7 @@ function Workspace() {
         )}
       </Paper>
     </Container>
+    </Layout>
   );
 }
 

--- a/service/src/app.module.ts
+++ b/service/src/app.module.ts
@@ -4,6 +4,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { UsersModule } from './users/users.module';
 import { RedisModule } from './redis.module';
 import { EventsModule } from './events/events.module';
+import { FollowersModule } from './followers/followers.module';
 
 @Module({
   imports: [
@@ -11,6 +12,7 @@ import { EventsModule } from './events/events.module';
     RedisModule,
     UsersModule,
     EventsModule,
+    FollowersModule,
   ],
   providers: [LoggerService],
   exports: [LoggerService],

--- a/service/src/followers/data/follower.schema.ts
+++ b/service/src/followers/data/follower.schema.ts
@@ -1,0 +1,13 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class Follower extends Document {
+  @Prop({ required: true })
+  name: string;
+
+  @Prop({ required: true })
+  email: string;
+}
+
+export const FollowerSchema = SchemaFactory.createForClass(Follower);

--- a/service/src/followers/data/followers.repository.ts
+++ b/service/src/followers/data/followers.repository.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Follower } from './follower.schema';
+
+@Injectable()
+export class FollowersRepository {
+  constructor(@InjectModel(Follower.name) private followerModel: Model<Follower>) {}
+
+  create(name: string, email: string): Promise<Follower> {
+    const follower = new this.followerModel({ name, email });
+    return follower.save();
+  }
+}

--- a/service/src/followers/followers.controller.ts
+++ b/service/src/followers/followers.controller.ts
@@ -1,0 +1,12 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { FollowersService } from './followers.service';
+
+@Controller('followers')
+export class FollowersController {
+  constructor(private readonly followersService: FollowersService) {}
+
+  @Post()
+  create(@Body() body: { name: string; email: string }) {
+    return this.followersService.create(body.name, body.email);
+  }
+}

--- a/service/src/followers/followers.module.ts
+++ b/service/src/followers/followers.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { FollowersController } from './followers.controller';
+import { FollowersService } from './followers.service';
+import { FollowersRepository } from './data/followers.repository';
+import { Follower, FollowerSchema } from './data/follower.schema';
+
+@Module({
+  imports: [MongooseModule.forFeature([{ name: Follower.name, schema: FollowerSchema }])],
+  controllers: [FollowersController],
+  providers: [FollowersService, FollowersRepository],
+})
+export class FollowersModule {}

--- a/service/src/followers/followers.service.ts
+++ b/service/src/followers/followers.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { FollowersRepository } from './data/followers.repository';
+
+@Injectable()
+export class FollowersService {
+  constructor(private readonly repo: FollowersRepository) {}
+
+  create(name: string, email: string) {
+    return this.repo.create(name, email);
+  }
+}


### PR DESCRIPTION
## Summary
- add Topbar and Sidebar with collapsible menu
- introduce Layout wrapper and ResourceForm component
- implement pages for project installation and team setting
- integrate layout into workspace page
- create Followers module with POST /followers API

## Testing
- `npm run build` in `service`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6853adbc62f883289abdef3ff178357a