### PR TITLE
Fix client build by using Node 20

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,11 +1,11 @@
 # Modules stage
-FROM node:18-alpine AS modules
+FROM node:20-alpine AS modules
 WORKDIR /app/client
 COPY client/package*.json ./
 RUN npm install
 
 # Build stage
-FROM node:18-alpine AS build
+FROM node:20-alpine AS build
 WORKDIR /app/client
 COPY --from=modules /app/client/node_modules ./node_modules
 COPY client .
@@ -13,7 +13,7 @@ COPY client/env ./env
 RUN npm run build
 
 # Runtime stage with only production files
-FROM node:18-alpine
+FROM node:20-alpine
 WORKDIR /app/client
 COPY --from=modules /app/client/node_modules ./node_modules
 COPY --from=build /app/client/.next ./.next

--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -1,18 +1,18 @@
 # Modules stage
-FROM node:18-alpine AS modules
+FROM node:20-alpine AS modules
 WORKDIR /app/service
 COPY service/package*.json ./
 RUN npm install
 
 # Build stage
-FROM node:18-alpine AS build
+FROM node:20-alpine AS build
 WORKDIR /app/service
 COPY --from=modules /app/service/node_modules ./node_modules
 COPY service .
 RUN npm run build
 
 # Runtime stage with only production files for a smaller image
-FROM node:18-alpine
+FROM node:20-alpine
 WORKDIR /app/service
 COPY --from=modules /app/service/node_modules ./node_modules
 COPY --from=build /app/service/dist ./dist


### PR DESCRIPTION
## Summary
- use Node 20 in both service and client Dockerfiles

This addresses build failures in the client container because Next.js 15 needs a newer Node runtime.

## Testing
- `npm install` and `npm run build` in `service`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6853b8433e08832898ad1830df04ebe4