### PR TITLE
Fix client dependencies

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,11 +1,11 @@
 # Modules stage
-FROM node:18-alpine AS modules
+FROM node:20-alpine AS modules
 WORKDIR /app/client
 COPY client/package*.json ./
 RUN npm install
 
 # Build stage
-FROM node:18-alpine AS build
+FROM node:20-alpine AS build
 WORKDIR /app/client
 COPY --from=modules /app/client/node_modules ./node_modules
 COPY client .
@@ -13,7 +13,7 @@ COPY client/env ./env
 RUN npm run build
 
 # Runtime stage with only production files
-FROM node:18-alpine
+FROM node:20-alpine
 WORKDIR /app/client
 COPY --from=modules /app/client/node_modules ./node_modules
 COPY --from=build /app/client/.next ./.next

--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -1,18 +1,18 @@
 # Modules stage
-FROM node:18-alpine AS modules
+FROM node:20-alpine AS modules
 WORKDIR /app/service
 COPY service/package*.json ./
 RUN npm install
 
 # Build stage
-FROM node:18-alpine AS build
+FROM node:20-alpine AS build
 WORKDIR /app/service
 COPY --from=modules /app/service/node_modules ./node_modules
 COPY service .
 RUN npm run build
 
 # Runtime stage with only production files for a smaller image
-FROM node:18-alpine
+FROM node:20-alpine
 WORKDIR /app/service
 COPY --from=modules /app/service/node_modules ./node_modules
 COPY --from=build /app/service/dist ./dist

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
     "@mui/material": "^7.1.1",
     "@mui/x-date-pickers": "^8.5.2",
     "axios": "^1.6.2",
-    "next": "^15.0.0",
+    "next": "15.3.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "sass": "^1.73.0",


### PR DESCRIPTION
## Summary
- pin Next.js to the latest 15.3.4 version to avoid swc mismatches
- package-lock ignored but updated locally

## Testing
- `npm install` and `npm run build` in `client`
- `npm install` and `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6853b8433e08832898ad1830df04ebe4