### PR TITLE
Remove .env examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ npm install
 npm run build
 npm run start:prod
 ```
-Create a `.env` file in the `service` directory based on `.env.example` to set
-database URLs and other options.
+Create a `.env` file in the `service` directory by copying one of the files
+from `service/env` and adjusting values to set database URLs and other options.
 
 To run the client manually:
 
@@ -46,8 +46,8 @@ npm start
 ```
 
 Set the `SERVICE_URL` environment variable to control where API requests are
-proxied. Create an `.env` file based on `.env.example` to override the default
-(`http://localhost:3000`).
+proxied. You can create an `.env` file in the `client` directory based on one
+of the files in `client/env` to override the default (`http://localhost:3000`).
 
 The client also supports environment files under `client/env` in the same way as
 the service. The file matching the `NODE_ENV` value will be loaded when the
@@ -61,9 +61,8 @@ client/env/uat.env
 client/env/production.env
 ```
 
-The service also provides a `service/.env.example` file. Copy it to
-`service/.env` and adjust values if you prefer not to use the predefined files
-under `service/env`.
+You may also copy one of the files in `service/env` to `service/.env` if you
+prefer not to rely on the predefined `NODE_ENV` values.
 
 ## Environments
 

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,2 +1,0 @@
-NODE_ENV=local
-SERVICE_URL=http://localhost:3000

--- a/service/.env.example
+++ b/service/.env.example
@@ -1,6 +1,0 @@
-NODE_ENV=local
-MONGO_URL=mongodb://mongo:27017/budget_local
-REDIS_URL=redis://redis:6379
-SECRET=local_secret
-ADMIN_PASSWORD=admin
-PORT=3000


### PR DESCRIPTION
## Summary
- delete `.env.example` files for client and service
- update README to describe using env directory instead of `.env.example`

## Testing
- `npm run build` in `service`
- `npm test` in `service` *(fails: Missing script)*
- `npm run build` in `client`
- `npm test` in `client` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853bb31fe4083289f749933b256af52