### PR TITLE
Refactor client to MVP

### DIFF
--- a/client/components/LoginView.js
+++ b/client/components/LoginView.js
@@ -1,0 +1,44 @@
+import Container from '@mui/material/Container';
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import { Input, LoadingButton } from '.';
+import styles from '../styles/index.module.scss';
+
+export default function LoginView({
+  username,
+  setUsername,
+  password,
+  setPassword,
+  profile,
+  loading,
+  token,
+  handleLogin,
+  getProfile,
+}) {
+  return (
+    <Container maxWidth="sm">
+      <Box className={styles.wrapper}>
+        <Paper className={styles.paper} elevation={3}>
+          <Typography variant="h4" component="h1" gutterBottom align="center">
+            Login
+          </Typography>
+          <Box component="form" onSubmit={handleLogin} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Input label="Username" value={username} onChange={e => setUsername(e.target.value)} required />
+            <Input label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+            <LoadingButton loading={loading} variant="contained" type="submit" fullWidth>
+              Login
+            </LoadingButton>
+          </Box>
+          {token && (
+            <Box sx={{ mt: 2, textAlign: 'center' }}>
+              <Button variant="outlined" onClick={getProfile}>Get Profile</Button>
+            </Box>
+          )}
+          {profile && <pre className={styles.profilePre}>{JSON.stringify(profile, null, 2)}</pre>}
+        </Paper>
+      </Box>
+    </Container>
+  );
+}

--- a/client/models/authModel.js
+++ b/client/models/authModel.js
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+export async function loginRequest(username, password) {
+  const { data } = await axios.post('/api/v1/auth/login', { username, password });
+  return data;
+}
+
+export async function fetchProfile(token) {
+  const { data } = await axios.get('/api/v1/profile', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return data;
+}

--- a/client/pages/index.js
+++ b/client/pages/index.js
@@ -1,64 +1,7 @@
-import { useState } from 'react';
-import axios from 'axios';
-import { useAuth } from '../context/AuthContext';
-import { useRouter } from 'next/router';
-import Container from '@mui/material/Container';
-import Box from '@mui/material/Box';
-import { Input, LoadingButton } from '../components';
-import Button from '@mui/material/Button';
-import Typography from '@mui/material/Typography';
-import Paper from '@mui/material/Paper';
-import styles from '../styles/index.module.scss';
+import LoginView from '../components/LoginView';
+import { useLoginPresenter } from '../presenters/loginPresenter';
 
 export default function Home() {
-  const { token, login } = useAuth();
-  const router = useRouter();
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [profile, setProfile] = useState(null);
-  const [loading, setLoading] = useState(false);
-
-  async function handleLogin(e) {
-    e.preventDefault();
-    setLoading(true);
-    const { data } = await axios.post('/api/v1/auth/login', {
-      username,
-      password,
-    });
-    login(data.accessToken);
-    router.push('/workspace');
-    setLoading(false);
-  }
-
-  async function getProfile() {
-    const { data } = await axios.get('/api/v1/profile', {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    setProfile(data);
-  }
-
-  return (
-    <Container maxWidth="sm">
-      <Box className={styles.wrapper}>
-        <Paper className={styles.paper} elevation={3}>
-          <Typography variant="h4" component="h1" gutterBottom align="center">
-            Login
-          </Typography>
-          <Box component="form" onSubmit={handleLogin} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            <Input label="Username" value={username} onChange={e => setUsername(e.target.value)} required />
-            <Input label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
-            <LoadingButton loading={loading} variant="contained" type="submit" fullWidth>
-              Login
-            </LoadingButton>
-          </Box>
-          {token && (
-            <Box sx={{ mt: 2, textAlign: 'center' }}>
-              <Button variant="outlined" onClick={getProfile}>Get Profile</Button>
-            </Box>
-          )}
-          {profile && <pre className={styles.profilePre}>{JSON.stringify(profile, null, 2)}</pre>}
-        </Paper>
-      </Box>
-    </Container>
-  );
+  const presenter = useLoginPresenter();
+  return <LoginView {...presenter} />;
 }

--- a/client/presenters/loginPresenter.js
+++ b/client/presenters/loginPresenter.js
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { loginRequest, fetchProfile } from '../models/authModel';
+import { useAuth } from '../context/AuthContext';
+
+export function useLoginPresenter() {
+  const { token, login } = useAuth();
+  const router = useRouter();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [profile, setProfile] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleLogin(e) {
+    e.preventDefault();
+    setLoading(true);
+    const data = await loginRequest(username, password);
+    login(data.accessToken);
+    router.push('/workspace');
+    setLoading(false);
+  }
+
+  async function getProfile() {
+    const data = await fetchProfile(token);
+    setProfile(data);
+  }
+
+  return {
+    username,
+    setUsername,
+    password,
+    setPassword,
+    profile,
+    loading,
+    token,
+    handleLogin,
+    getProfile,
+  };
+}


### PR DESCRIPTION
## Summary
- apply MVP pattern to the client login page
- create model for API communication
- add presenter hook for login workflow
- move login UI into a view component

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853bb5756c48328b51e3aaf4e1e8009