### PR TITLE
Add project API to service

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ The `docker-compose.yml` file sets `SERVICE_URL` for the client container so
 that API requests are forwarded to the service.
 
 The service now exposes a new endpoint `GET /api/v1/events` which returns the
-timeline/calendar layout entries.
+timeline/calendar layout entries. It also provides a `POST /api/v1/projects`
+endpoint for creating projects with a structured body containing the project
+name, resources, start and end dates, manday estimate and priority.
 
 An admin user is created automatically with username `admin` and password taken
 from the `ADMIN_PASSWORD` environment variable (default `admin`).

--- a/service/src/app.module.ts
+++ b/service/src/app.module.ts
@@ -5,6 +5,7 @@ import { UsersModule } from './users/users.module';
 import { RedisModule } from './redis.module';
 import { EventsModule } from './events/events.module';
 import { FollowersModule } from './followers/followers.module';
+import { ProjectsModule } from './projects/projects.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { FollowersModule } from './followers/followers.module';
     UsersModule,
     EventsModule,
     FollowersModule,
+    ProjectsModule,
   ],
   providers: [LoggerService],
   exports: [LoggerService],

--- a/service/src/projects/data/project.schema.ts
+++ b/service/src/projects/data/project.schema.ts
@@ -1,0 +1,25 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class Project extends Document {
+  @Prop({ required: true })
+  name: string;
+
+  @Prop({ required: true })
+  resources: number;
+
+  @Prop({ required: true })
+  start: Date;
+
+  @Prop({ required: true })
+  end: Date;
+
+  @Prop({ required: true })
+  manday: number;
+
+  @Prop({ required: true })
+  priority: number;
+}
+
+export const ProjectSchema = SchemaFactory.createForClass(Project);

--- a/service/src/projects/data/projects.repository.ts
+++ b/service/src/projects/data/projects.repository.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Project } from './project.schema';
+
+export interface CreateProjectInput {
+  name: string;
+  resources: number;
+  start: Date;
+  end: Date;
+  manday: number;
+  priority: number;
+}
+
+@Injectable()
+export class ProjectsRepository {
+  constructor(@InjectModel(Project.name) private projectModel: Model<Project>) {}
+
+  findAll(): Promise<Project[]> {
+    return this.projectModel.find().sort({ start: 1 }).exec();
+  }
+
+  create(data: CreateProjectInput): Promise<Project> {
+    const project = new this.projectModel(data);
+    return project.save();
+  }
+}

--- a/service/src/projects/projects.controller.ts
+++ b/service/src/projects/projects.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { ProjectsService } from './projects.service';
+import { CreateProjectInput } from './data/projects.repository';
+
+@Controller('projects')
+export class ProjectsController {
+  constructor(private readonly service: ProjectsService) {}
+
+  @Post()
+  create(@Body() body: CreateProjectInput) {
+    return this.service.create(body);
+  }
+
+  @Get()
+  getProjects() {
+    return this.service.getProjects();
+  }
+}

--- a/service/src/projects/projects.module.ts
+++ b/service/src/projects/projects.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { ProjectsController } from './projects.controller';
+import { ProjectsService } from './projects.service';
+import { ProjectsRepository } from './data/projects.repository';
+import { Project, ProjectSchema } from './data/project.schema';
+
+@Module({
+  imports: [MongooseModule.forFeature([{ name: Project.name, schema: ProjectSchema }])],
+  controllers: [ProjectsController],
+  providers: [ProjectsService, ProjectsRepository],
+})
+export class ProjectsModule {}

--- a/service/src/projects/projects.service.ts
+++ b/service/src/projects/projects.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { ProjectsRepository, CreateProjectInput } from './data/projects.repository';
+
+@Injectable()
+export class ProjectsService {
+  constructor(private readonly repo: ProjectsRepository) {}
+
+  create(data: CreateProjectInput) {
+    return this.repo.create(data);
+  }
+
+  getProjects() {
+    return this.repo.findAll();
+  }
+}


### PR DESCRIPTION
## Summary
- create NestJS module for projects
- add `POST /api/v1/projects` endpoint
- import ProjectsModule in AppModule
- document the new API in README

## Testing
- `npm run build` in `service`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853bc64bd848328a194d8d98eb96916