### PR TITLE
Add Swagger in dev environment

### DIFF
--- a/service/package.json
+++ b/service/package.json
@@ -19,7 +19,9 @@
     "ioredis": "^5.0.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.0.0",
-    "dotenv": "^16.0.0"
+    "dotenv": "^16.0.0",
+    "@nestjs/swagger": "^6.3.0",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",

--- a/service/src/main.ts
+++ b/service/src/main.ts
@@ -2,6 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { LoggingInterceptor } from './logger/logging.interceptor';
 import { LoggerService } from './logger/logger.service';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import * as path from 'path';
 import { config } from 'dotenv';
 
@@ -15,6 +16,14 @@ async function bootstrap() {
   app.setGlobalPrefix('api/v1');
   const logger = app.get(LoggerService);
   app.useGlobalInterceptors(new LoggingInterceptor(logger));
+  if (process.env.NODE_ENV !== 'production') {
+    const swaggerConfig = new DocumentBuilder()
+      .setTitle('Budget Management API')
+      .setVersion('1.0')
+      .build();
+    const document = SwaggerModule.createDocument(app, swaggerConfig);
+    SwaggerModule.setup('api-docs', app, document);
+  }
   await app.listen(process.env.PORT || 3000);
 }
 bootstrap();


### PR DESCRIPTION
## Summary
- add `@nestjs/swagger` and `swagger-ui-express` dependencies
- setup Swagger UI in `main.ts` when `NODE_ENV` is not production

## Testing
- `npm install` in `service`
- `npm run build` in `service`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853be05fb448328b4efc98a933cceff