### PR TITLE
Add interactive start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ with Docker.
 ./start.sh
 ```
 
-This starts MongoDB, Redis, the NestJS API on port `3000` and the Next.js client
-on `http://localhost:8080`. All service endpoints are available under the
-`/api/v1` path prefix.
+When run, the script prompts for what to start. Select **1** to launch all
+containers, **2** to start only MongoDB and Redis, or **3** to start the service
+along with its databases. Choosing the first option will also start the Next.js
+client on `http://localhost:8080` while exposing the service on port `3000`.
+All service endpoints are available under the `/api/v1` path prefix.
 
 The `docker-compose.yml` file sets `SERVICE_URL` for the client container so
 that API requests are forwarded to the service.

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,28 @@
 #!/bin/sh
-docker-compose up --build
+
+# Provide menu options to start containers
+cat <<MENU
+Choose an option:
+1) Start all services
+2) Start databases only (MongoDB and Redis)
+3) Start service and databases
+MENU
+
+printf "Enter choice [1-3]: "
+read choice
+
+case "$choice" in
+  1)
+    docker-compose up --build
+    ;;
+  2)
+    docker-compose up --build mongo redis
+    ;;
+  3)
+    docker-compose up --build mongo redis service
+    ;;
+  *)
+    echo "Invalid choice"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add interactive menu to `start.sh` for running select services
- document new script options in README

## Testing
- `npm test --silent` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6853be5cb87c8328bf8d704eb529665c