### PR TITLE
Remove obsolete Compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   mongo:
     image: mongo:6


### PR DESCRIPTION
## Summary
- drop the `version` field from `docker-compose.yml`

## Testing
- `npm test` in `service` *(fails: missing script)*
- `npm test` in `client` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853c3b245008328b613de71491df185