### PR TITLE
Add start scripts for client environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,14 @@ To run the client manually:
 cd client
 npm install
 npm run build
-npm start
+npm run dev
+```
+
+The built client can be started with:
+
+```sh
+npm run start:dev   # uses the development environment
+npm run start:local # uses the local environment
 ```
 
 Set the `SERVICE_URL` environment variable to control where API requests are

--- a/client/package.json
+++ b/client/package.json
@@ -2,9 +2,11 @@
   "name": "client",
   "version": "1.0.0",
   "scripts": {
-    "dev": "next dev",
+    "dev": "NODE_ENV=local next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "start:dev": "NODE_ENV=development next start",
+    "start:local": "NODE_ENV=local next start"
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",


### PR DESCRIPTION
## Summary
- run the Next.js dev server using the `local` environment
- add `start:dev` and `start:local` scripts for the compiled client
- document new client scripts in the README

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c38e5de08328b1ed8d91ea506b0e