### PR TITLE
Fix missing MUI LocalizationProvider

### DIFF
--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -1,17 +1,21 @@
 // @ts-nocheck
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
+import { LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import theme from '../theme';
 import { AuthProvider } from '../context/AuthContext';
 import '../styles/globals.scss';
 
 export default function MyApp({ Component, pageProps }) {
   return (
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      <AuthProvider>
-        <Component {...pageProps} />
-      </AuthProvider>
-    </ThemeProvider>
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <AuthProvider>
+          <Component {...pageProps} />
+        </AuthProvider>
+      </ThemeProvider>
+    </LocalizationProvider>
   );
 }


### PR DESCRIPTION
## Summary
- add MUI LocalizationProvider with AdapterDateFns

## Testing
- `npm run build` in `client` *(fails: `next` not found)*
- `npm run build` in `service` *(fails: `nest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c56820248328b8c306cfe710227f