### PR TITLE
Fix missing dependency for Next.js build

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "@mui/x-date-pickers": "^8.5.2",
     "axios": "^1.6.2",
     "dotenv": "^16.0.0",
+    "date-fns": "^4.1.0",
     "next": "15.3.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",


### PR DESCRIPTION
## Summary
- add `date-fns` to client dependencies so MUI date pickers can compile

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853c782d8e083288b8837f57296dc5f