### PR TITLE
Remove Get Profile option from login page

### DIFF
--- a/client/components/LoginView.tsx
+++ b/client/components/LoginView.tsx
@@ -3,7 +3,6 @@ import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
 import { Input, LoadingButton } from '.';
 import styles from '../styles/index.module.scss';
 
@@ -12,11 +11,8 @@ export default function LoginView({
   setUsername,
   password,
   setPassword,
-  profile,
   loading,
-  token,
   handleLogin,
-  getProfile,
 }) {
   return (
     <Container maxWidth="sm">
@@ -32,12 +28,6 @@ export default function LoginView({
               Login
             </LoadingButton>
           </Box>
-          {token && (
-            <Box sx={{ mt: 2, textAlign: 'center' }}>
-              <Button variant="outlined" onClick={getProfile}>Get Profile</Button>
-            </Box>
-          )}
-          {profile && <pre className={styles.profilePre}>{JSON.stringify(profile, null, 2)}</pre>}
         </Paper>
       </Box>
     </Container>

--- a/client/presenters/loginPresenter.ts
+++ b/client/presenters/loginPresenter.ts
@@ -1,15 +1,14 @@
 // @ts-nocheck
 import { useState } from 'react';
 import { useRouter } from 'next/router';
-import { loginRequest, fetchProfile } from '../models/authModel';
+import { loginRequest } from '../models/authModel';
 import { useAuth } from '../context/AuthContext';
 
 export function useLoginPresenter() {
-  const { token, login } = useAuth();
+  const { login } = useAuth();
   const router = useRouter();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const [profile, setProfile] = useState(null);
   const [loading, setLoading] = useState(false);
 
   async function handleLogin(e) {
@@ -21,20 +20,12 @@ export function useLoginPresenter() {
     setLoading(false);
   }
 
-  async function getProfile() {
-    const data = await fetchProfile(token);
-    setProfile(data);
-  }
-
   return {
     username,
     setUsername,
     password,
     setPassword,
-    profile,
     loading,
-    token,
     handleLogin,
-    getProfile,
   };
 }

--- a/client/styles/index.module.scss
+++ b/client/styles/index.module.scss
@@ -12,13 +12,6 @@
   background-color: #E5E1DA;
 }
 
-.profilePre {
-  background: #272822;
-  color: #F8F8F2;
-  padding: 1rem;
-  overflow: auto;
-}
-
 @media (max-width: 600px) {
   .paper {
     padding: 1rem;


### PR DESCRIPTION
## Summary
- simplify login screen by dropping profile lookup
- clean up unused presenter state and styles

## Testing
- `npm run build` in `client`
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6853cb3d971c8328b3d9d306d667d4c7