### PR TITLE
Add token revoke on logout

### DIFF
--- a/client/context/AuthContext.tsx
+++ b/client/context/AuthContext.tsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { createContext, useContext, useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
+import { revokeRefreshToken } from '../models/authModel';
 
 const AuthContext = createContext(null);
 
@@ -24,7 +25,12 @@ export function AuthProvider({ children }) {
     setRefreshToken(refreshTok);
   };
 
-  const logout = () => {
+  const logout = async () => {
+    if (refreshToken) {
+      try {
+        await revokeRefreshToken(refreshToken);
+      } catch {}
+    }
     localStorage.removeItem('token');
     localStorage.removeItem('refreshToken');
     setToken(null);

--- a/client/models/authModel.ts
+++ b/client/models/authModel.ts
@@ -12,3 +12,7 @@ export async function fetchProfile(token) {
   });
   return data;
 }
+
+export async function revokeRefreshToken(refreshToken) {
+  await axios.post('/api/v1/auth/revoke', { refreshToken });
+}


### PR DESCRIPTION
## Summary
- add a revoke API call
- invoke revoke when logging out so refresh tokens are invalidated

## Testing
- `npm run build` in `client`
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6853cca9c8e4832880c4287d0ae37256