### PR TITLE
Update theme colors

### DIFF
--- a/client/styles/globals.scss
+++ b/client/styles/globals.scss
@@ -3,5 +3,5 @@
 body {
   font-family: 'Fira Code', monospace;
   color: #333;
-  background-color: #F1F0E8;
+  background-color: #E0F7FF;
 }

--- a/client/styles/index.module.scss
+++ b/client/styles/index.module.scss
@@ -3,13 +3,13 @@
   justify-content: center;
   align-items: center;
   min-height: 100vh;
-  background-color: #F1F0E8;
+  background-color: #E0F7FF;
 }
 
 .paper {
   padding: 2rem;
   width: 100%;
-  background-color: #E5E1DA;
+  background-color: #B0C4DE;
 }
 
 @media (max-width: 600px) {

--- a/client/theme.ts
+++ b/client/theme.ts
@@ -4,14 +4,14 @@ import { createTheme } from '@mui/material/styles';
 const theme = createTheme({
   palette: {
     primary: {
-      main: '#89A8B2',
+      main: '#1E90FF', // bright blue
     },
     secondary: {
-      main: '#B3C8CF',
+      main: '#00008B', // dark blue
     },
     background: {
-      default: '#F1F0E8',
-      paper: '#E5E1DA',
+      default: '#E0F7FF',
+      paper: '#B0C4DE',
     },
   },
   typography: {


### PR DESCRIPTION
## Summary
- switch to blue & dark blue color palette
- update global and module styles

## Testing
- `npm run build` in `client`
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6853ccf782b483289e724da3050965be