### PR TITLE
Add calendar timeline events

### DIFF
--- a/client/models/eventsModel.ts
+++ b/client/models/eventsModel.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export async function fetchEvents() {
+  const { data } = await axios.get('/api/v1/events');
+  return data;
+}

--- a/client/pages/workspace.tsx
+++ b/client/pages/workspace.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
 import ToggleButton from '@mui/material/ToggleButton';
@@ -7,6 +7,9 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
+import PickersDay from '@mui/x-date-pickers/PickersDay';
+import { isSameDay } from 'date-fns';
+import { fetchEvents } from '../models/eventsModel';
 import Timeline from '@mui/lab/Timeline';
 import TimelineItem from '@mui/lab/TimelineItem';
 import TimelineSeparator from '@mui/lab/TimelineSeparator';
@@ -18,6 +21,11 @@ import { Layout } from '../components';
 
 function Workspace() {
   const [view, setView] = useState('calendar');
+  const [events, setEvents] = useState([]);
+
+  useEffect(() => {
+    fetchEvents().then(setEvents).catch(console.error);
+  }, []);
 
   return (
     <Layout>
@@ -36,29 +44,32 @@ function Workspace() {
           </ToggleButtonGroup>
         </Box>
         {view === 'calendar' ? (
-          <DateCalendar />
+          <DateCalendar
+            renderDay={(day, _value, DayComponentProps) => {
+              const hasEvent = events.some((ev) =>
+                isSameDay(new Date(ev.date), day)
+              );
+              return (
+                <PickersDay
+                  {...DayComponentProps}
+                  sx={hasEvent ? { bgcolor: 'secondary.main', color: 'white' } : {}}
+                />
+              );
+            }}
+          />
         ) : (
           <Timeline>
-            <TimelineItem>
-              <TimelineSeparator>
-                <TimelineDot />
-                <TimelineConnector />
-              </TimelineSeparator>
-              <TimelineContent>Initial Planning</TimelineContent>
-            </TimelineItem>
-            <TimelineItem>
-              <TimelineSeparator>
-                <TimelineDot />
-                <TimelineConnector />
-              </TimelineSeparator>
-              <TimelineContent>Development</TimelineContent>
-            </TimelineItem>
-            <TimelineItem>
-              <TimelineSeparator>
-                <TimelineDot />
-              </TimelineSeparator>
-              <TimelineContent>Release</TimelineContent>
-            </TimelineItem>
+            {events.map((ev, idx) => (
+              <TimelineItem key={idx}>
+                <TimelineSeparator>
+                  <TimelineDot />
+                  {idx < events.length - 1 && <TimelineConnector />}
+                </TimelineSeparator>
+                <TimelineContent>
+                  {ev.title} - {new Date(ev.date).toLocaleDateString()}
+                </TimelineContent>
+              </TimelineItem>
+            ))}
           </Timeline>
         )}
       </Paper>


### PR DESCRIPTION
## Summary
- fetch events from the API
- show events on the summary page with a calendar view and timeline view

## Testing
- `npm run build` in `client`
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6853ce4363ec83288f7c3670be4a3fed