### PR TITLE
Improve navigation style

### DIFF
--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -1,10 +1,10 @@
 // @ts-nocheck
 import Drawer from '@mui/material/Drawer';
 import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import IconButton from '@mui/material/IconButton';
+import Toolbar from '@mui/material/Toolbar';
 import Divider from '@mui/material/Divider';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
@@ -29,37 +29,52 @@ export default function Sidebar({ open, onClose }) {
       sx={{
         width,
         flexShrink: 0,
-        [`& .MuiDrawer-paper`]: { width, boxSizing: 'border-box' },
+        [`& .MuiDrawer-paper`]: {
+          width,
+          boxSizing: 'border-box',
+          bgcolor: 'background.paper',
+          borderRight: '1px solid #d0d7de',
+        },
       }}
     >
+      <Toolbar />
       <List>
-        <ListItem button onClick={() => setCollapsed(!collapsed)}>
+        <ListItemButton onClick={() => setCollapsed(!collapsed)}>
           <ListItemIcon>
             {collapsed ? <ChevronRightIcon /> : <ChevronLeftIcon />}
           </ListItemIcon>
           {!collapsed && <ListItemText primary="Collapse" />}
-        </ListItem>
+        </ListItemButton>
       </List>
       <Divider />
       <List>
-        <ListItem button onClick={() => router.push('/workspace')}>
+        <ListItemButton
+          selected={router.pathname === '/workspace'}
+          onClick={() => router.push('/workspace')}
+        >
           <ListItemIcon>
             <DashboardIcon />
           </ListItemIcon>
           {!collapsed && <ListItemText primary="Summary" />}
-        </ListItem>
-        <ListItem button onClick={() => router.push('/project-installation')}>
+        </ListItemButton>
+        <ListItemButton
+          selected={router.pathname === '/project-installation'}
+          onClick={() => router.push('/project-installation')}
+        >
           <ListItemIcon>
             <SettingsIcon />
           </ListItemIcon>
           {!collapsed && <ListItemText primary="Project Installation" />}
-        </ListItem>
-        <ListItem button onClick={() => router.push('/team-setting')}>
+        </ListItemButton>
+        <ListItemButton
+          selected={router.pathname === '/team-setting'}
+          onClick={() => router.push('/team-setting')}
+        >
           <ListItemIcon>
             <GroupIcon />
           </ListItemIcon>
           {!collapsed && <ListItemText primary="Team Setting" />}
-        </ListItem>
+        </ListItemButton>
       </List>
     </Drawer>
   );

--- a/client/components/Topbar.tsx
+++ b/client/components/Topbar.tsx
@@ -9,6 +9,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Drawer from '@mui/material/Drawer';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import GitHubIcon from '@mui/icons-material/GitHub';
 import { useState } from 'react';
 import { useAuth } from '../context/AuthContext';
 
@@ -26,17 +27,20 @@ export default function Topbar({ onMenuClick }) {
   };
 
   return (
-    // Lower the app bar so drawers can appear above it
     <AppBar
       position="fixed"
       color="primary"
-      sx={{ zIndex: (t) => t.zIndex.appBar }}
+      sx={{
+        zIndex: (t) => t.zIndex.appBar,
+        borderBottom: '1px solid #d0d7de',
+      }}
     >
-      <Toolbar>
-        <IconButton color="inherit" edge="start" onClick={onMenuClick} sx={{ mr: 2 }}>
+      <Toolbar variant="dense">
+        <IconButton color="inherit" edge="start" onClick={onMenuClick} sx={{ mr: 1 }}>
           <MenuIcon />
         </IconButton>
-        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+        <GitHubIcon sx={{ mr: 1 }} />
+        <Typography variant="h6" sx={{ flexGrow: 1, fontWeight: 500 }}>
           Budget Manager
         </Typography>
         <IconButton color="inherit" onClick={handleMenu}>

--- a/client/styles/globals.scss
+++ b/client/styles/globals.scss
@@ -2,6 +2,6 @@
 
 body {
   font-family: 'Fira Code', monospace;
-  color: #333;
-  background-color: #E0F7FF;
+  color: #24292e;
+  background-color: #f6f8fa;
 }

--- a/client/styles/index.module.scss
+++ b/client/styles/index.module.scss
@@ -3,13 +3,13 @@
   justify-content: center;
   align-items: center;
   min-height: 100vh;
-  background-color: #E0F7FF;
+  background-color: #f6f8fa;
 }
 
 .paper {
   padding: 2rem;
   width: 100%;
-  background-color: #B0C4DE;
+  background-color: #ffffff;
 }
 
 @media (max-width: 600px) {

--- a/client/theme.ts
+++ b/client/theme.ts
@@ -3,15 +3,17 @@ import { createTheme } from '@mui/material/styles';
 
 const theme = createTheme({
   palette: {
+    // GitHub inspired colour scheme
     primary: {
-      main: '#1E90FF', // bright blue
+      main: '#24292e', // dark header grey
+      contrastText: '#fff',
     },
     secondary: {
-      main: '#00008B', // dark blue
+      main: '#0969da', // link blue
     },
     background: {
-      default: '#E0F7FF',
-      paper: '#B0C4DE',
+      default: '#f6f8fa',
+      paper: '#ffffff',
     },
   },
   typography: {


### PR DESCRIPTION
## Summary
- refresh color palette using a GitHub-like theme
- redesign Topbar with GitHub icon and slimmer toolbar
- restyle Sidebar with ListItemButton and active highlighting
- update global styles and login page background

## Testing
- `npm run build` in `client`
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6853cfb7b7508328a580aba66fd1ebed