### PR TITLE
Replace date picker with custom calendar

### DIFF
--- a/client/components/SimpleCalendar.tsx
+++ b/client/components/SimpleCalendar.tsx
@@ -1,0 +1,79 @@
+// @ts-nocheck
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import ArrowBackIosNew from '@mui/icons-material/ArrowBackIosNew';
+import ArrowForwardIos from '@mui/icons-material/ArrowForwardIos';
+import {
+  startOfMonth,
+  startOfWeek,
+  addDays,
+  addMonths,
+  isSameMonth,
+  isSameDay,
+  format
+} from 'date-fns';
+
+export default function SimpleCalendar({ events = [] }) {
+  const [currentDate, setCurrentDate] = useState(new Date());
+
+  const monthStart = startOfMonth(currentDate);
+  const calendarStart = startOfWeek(monthStart, { weekStartsOn: 0 });
+
+  const days = [];
+  for (let i = 0; i < 42; i++) {
+    days.push(addDays(calendarStart, i));
+  }
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+        <IconButton size="small" onClick={() => setCurrentDate(addMonths(currentDate, -1))}>
+          <ArrowBackIosNew fontSize="small" />
+        </IconButton>
+        <Typography variant="h6">
+          {format(monthStart, 'MMMM yyyy')}
+        </Typography>
+        <IconButton size="small" onClick={() => setCurrentDate(addMonths(currentDate, 1))}>
+          <ArrowForwardIos fontSize="small" />
+        </IconButton>
+      </Box>
+      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 1 }}>
+        {["Sun","Mon","Tue","Wed","Thu","Fri","Sat"].map((d) => (
+          <Typography key={d} variant="subtitle2" align="center">
+            {d}
+          </Typography>
+        ))}
+        {days.map((day) => {
+          const inMonth = isSameMonth(day, monthStart);
+          const hasEvent = events.some((ev) =>
+            isSameDay(new Date(ev.date), day)
+          );
+          return (
+            <Box
+              key={day.toString()}
+              sx={{
+                border: '1px solid #ccc',
+                height: 80,
+                bgcolor: inMonth ? 'background.paper' : 'grey.100',
+                p: 0.5,
+                fontSize: 12,
+                position: 'relative'
+              }}
+            >
+              <Typography variant="caption" sx={{ position: 'absolute', top: 2, right: 2 }}>
+                {format(day, 'd')}
+              </Typography>
+              {hasEvent && (
+                <Box sx={{ mt: 3, bgcolor: 'secondary.main', color: 'white', px: 0.5, borderRadius: 1 }}>
+                  {events.find((ev) => isSameDay(new Date(ev.date), day)).title}
+                </Box>
+              )}
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}

--- a/client/components/index.tsx
+++ b/client/components/index.tsx
@@ -8,3 +8,4 @@ export { default as Topbar } from './Topbar';
 export { default as Sidebar } from './Sidebar';
 export { default as Layout } from './Layout';
 export { default as ResourceForm } from './ResourceForm';
+export { default as SimpleCalendar } from './SimpleCalendar';

--- a/client/models/eventsModel.ts
+++ b/client/models/eventsModel.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export async function fetchEvents() {
+  const { data } = await axios.get('/api/v1/events');
+  return data;
+}

--- a/client/pages/workspace.tsx
+++ b/client/pages/workspace.tsx
@@ -1,12 +1,12 @@
 // @ts-nocheck
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
-import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
+import { fetchEvents } from '../models/eventsModel';
 import Timeline from '@mui/lab/Timeline';
 import TimelineItem from '@mui/lab/TimelineItem';
 import TimelineSeparator from '@mui/lab/TimelineSeparator';
@@ -14,10 +14,15 @@ import TimelineConnector from '@mui/lab/TimelineConnector';
 import TimelineContent from '@mui/lab/TimelineContent';
 import TimelineDot from '@mui/lab/TimelineDot';
 import { withAuth } from '../context/AuthContext';
-import { Layout } from '../components';
+import { Layout, SimpleCalendar } from '../components';
 
 function Workspace() {
   const [view, setView] = useState('calendar');
+  const [events, setEvents] = useState([]);
+
+  useEffect(() => {
+    fetchEvents().then(setEvents).catch(console.error);
+  }, []);
 
   return (
     <Layout>
@@ -36,29 +41,20 @@ function Workspace() {
           </ToggleButtonGroup>
         </Box>
         {view === 'calendar' ? (
-          <DateCalendar />
+          <SimpleCalendar events={events} />
         ) : (
           <Timeline>
-            <TimelineItem>
-              <TimelineSeparator>
-                <TimelineDot />
-                <TimelineConnector />
-              </TimelineSeparator>
-              <TimelineContent>Initial Planning</TimelineContent>
-            </TimelineItem>
-            <TimelineItem>
-              <TimelineSeparator>
-                <TimelineDot />
-                <TimelineConnector />
-              </TimelineSeparator>
-              <TimelineContent>Development</TimelineContent>
-            </TimelineItem>
-            <TimelineItem>
-              <TimelineSeparator>
-                <TimelineDot />
-              </TimelineSeparator>
-              <TimelineContent>Release</TimelineContent>
-            </TimelineItem>
+            {events.map((ev, idx) => (
+              <TimelineItem key={idx}>
+                <TimelineSeparator>
+                  <TimelineDot />
+                  {idx < events.length - 1 && <TimelineConnector />}
+                </TimelineSeparator>
+                <TimelineContent>
+                  {ev.title} - {new Date(ev.date).toLocaleDateString()}
+                </TimelineContent>
+              </TimelineItem>
+            ))}
           </Timeline>
         )}
       </Paper>


### PR DESCRIPTION
## Summary
- build a `SimpleCalendar` component without relying on MUI date picker
- export the new component and use it on the workspace page
- drop `DateCalendar` usage so the calendar view is completely custom

## Testing
- `npm run build` in `client`
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6853ce4363ec83288f7c3670be4a3fed