### PR TITLE
Improve sidebar style and remove GitHub logo

### DIFF
--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -3,14 +3,12 @@ import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
 import Topbar from './Topbar';
 import Sidebar from './Sidebar';
-import { useState } from 'react';
 
 export default function Layout({ children }) {
-  const [open, setOpen] = useState(false);
   return (
     <Box sx={{ display: 'flex' }}>
-      <Topbar onMenuClick={() => setOpen(!open)} />
-      <Sidebar open={open} onClose={() => setOpen(false)} />
+      <Topbar />
+      <Sidebar />
       <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
         <Toolbar />
         {children}

--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -14,13 +14,15 @@ import GroupIcon from '@mui/icons-material/Group';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 
-const drawerWidth = 200;
+// width when sidebar is expanded
+const drawerWidth = 220;
 
-export default function Sidebar({ open, onClose }) {
+export default function Sidebar() {
   const router = useRouter();
   const [collapsed, setCollapsed] = useState(false);
 
-  const width = collapsed ? 60 : drawerWidth;
+  // width to use when sidebar is collapsed
+  const width = collapsed ? 72 : drawerWidth;
 
   return (
     <Drawer
@@ -32,8 +34,9 @@ export default function Sidebar({ open, onClose }) {
         [`& .MuiDrawer-paper`]: {
           width,
           boxSizing: 'border-box',
-          bgcolor: 'background.paper',
+          bgcolor: 'background.default',
           borderRight: '1px solid #d0d7de',
+          height: '100vh',
         },
       }}
     >

--- a/client/components/Topbar.tsx
+++ b/client/components/Topbar.tsx
@@ -9,11 +9,10 @@ import MenuItem from '@mui/material/MenuItem';
 import Drawer from '@mui/material/Drawer';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import GitHubIcon from '@mui/icons-material/GitHub';
 import { useState } from 'react';
 import { useAuth } from '../context/AuthContext';
 
-export default function Topbar({ onMenuClick }) {
+export default function Topbar() {
   const { logout } = useAuth();
   const [anchorEl, setAnchorEl] = useState(null);
   const [openProfile, setOpenProfile] = useState(false);
@@ -36,10 +35,9 @@ export default function Topbar({ onMenuClick }) {
       }}
     >
       <Toolbar variant="dense">
-        <IconButton color="inherit" edge="start" onClick={onMenuClick} sx={{ mr: 1 }}>
+        <IconButton color="inherit" edge="start" sx={{ mr: 1 }}>
           <MenuIcon />
         </IconButton>
-        <GitHubIcon sx={{ mr: 1 }} />
         <Typography variant="h6" sx={{ flexGrow: 1, fontWeight: 500 }}>
           Budget Manager
         </Typography>


### PR DESCRIPTION
## Summary
- style Sidebar similar to GitHub
- remove GitHub icon from Topbar
- clean up Topbar/Layout props

## Testing
- `npm run build` in `client`
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6853d24f52e88328a919e029a4374225