### PR TITLE
Implement offcanvas sidebar

### DIFF
--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -3,12 +3,19 @@ import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
 import Topbar from './Topbar';
 import Sidebar from './Sidebar';
+import { useState } from 'react';
 
 export default function Layout({ children }) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const handleToggleSidebar = () => {
+    setSidebarOpen(!sidebarOpen);
+  };
+
   return (
     <Box sx={{ display: 'flex' }}>
-      <Topbar />
-      <Sidebar />
+      <Topbar onMenuClick={handleToggleSidebar} />
+      <Sidebar open={sidebarOpen} onClose={handleToggleSidebar} />
       <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
         <Toolbar />
         {children}

--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -17,7 +17,7 @@ import { useState } from 'react';
 // width when sidebar is expanded
 const drawerWidth = 220;
 
-export default function Sidebar() {
+export default function Sidebar({ open, onClose }) {
   const router = useRouter();
   const [collapsed, setCollapsed] = useState(false);
 
@@ -26,11 +26,12 @@ export default function Sidebar() {
 
   return (
     <Drawer
-      variant="permanent"
-      open
+      anchor="left"
+      variant="temporary"
+      open={open}
+      onClose={onClose}
+      ModalProps={{ keepMounted: true }}
       sx={{
-        width,
-        flexShrink: 0,
         [`& .MuiDrawer-paper`]: {
           width,
           boxSizing: 'border-box',
@@ -53,7 +54,10 @@ export default function Sidebar() {
       <List>
         <ListItemButton
           selected={router.pathname === '/workspace'}
-          onClick={() => router.push('/workspace')}
+          onClick={() => {
+            router.push('/workspace');
+            onClose();
+          }}
         >
           <ListItemIcon>
             <DashboardIcon />
@@ -62,7 +66,10 @@ export default function Sidebar() {
         </ListItemButton>
         <ListItemButton
           selected={router.pathname === '/project-installation'}
-          onClick={() => router.push('/project-installation')}
+          onClick={() => {
+            router.push('/project-installation');
+            onClose();
+          }}
         >
           <ListItemIcon>
             <SettingsIcon />
@@ -71,7 +78,10 @@ export default function Sidebar() {
         </ListItemButton>
         <ListItemButton
           selected={router.pathname === '/team-setting'}
-          onClick={() => router.push('/team-setting')}
+          onClick={() => {
+            router.push('/team-setting');
+            onClose();
+          }}
         >
           <ListItemIcon>
             <GroupIcon />

--- a/client/components/Topbar.tsx
+++ b/client/components/Topbar.tsx
@@ -12,7 +12,7 @@ import Typography from '@mui/material/Typography';
 import { useState } from 'react';
 import { useAuth } from '../context/AuthContext';
 
-export default function Topbar() {
+export default function Topbar({ onMenuClick }) {
   const { logout } = useAuth();
   const [anchorEl, setAnchorEl] = useState(null);
   const [openProfile, setOpenProfile] = useState(false);
@@ -35,7 +35,7 @@ export default function Topbar() {
       }}
     >
       <Toolbar variant="dense">
-        <IconButton color="inherit" edge="start" sx={{ mr: 1 }}>
+        <IconButton color="inherit" edge="start" sx={{ mr: 1 }} onClick={onMenuClick}>
           <MenuIcon />
         </IconButton>
         <Typography variant="h6" sx={{ flexGrow: 1, fontWeight: 500 }}>


### PR DESCRIPTION
## Summary
- convert Sidebar from permanent Drawer to temporary Drawer
- pass open/close state from Layout via Topbar menu button

## Testing
- `npm run build` in `client`
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6853d3e9961483288adf166d488feaee