### PR TITLE
Add Team Management menu

### DIFF
--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -11,6 +11,9 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import SettingsIcon from '@mui/icons-material/Settings';
 import GroupIcon from '@mui/icons-material/Group';
+import ExpandLess from '@mui/icons-material/ExpandLess';
+import ExpandMore from '@mui/icons-material/ExpandMore';
+import Collapse from '@mui/material/Collapse';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 
@@ -20,6 +23,7 @@ const drawerWidth = 220;
 export default function Sidebar() {
   const router = useRouter();
   const [collapsed, setCollapsed] = useState(false);
+  const [openTeamMgmt, setOpenTeamMgmt] = useState(false);
 
   // width to use when sidebar is collapsed
   const width = collapsed ? 72 : drawerWidth;
@@ -69,15 +73,43 @@ export default function Sidebar() {
           </ListItemIcon>
           {!collapsed && <ListItemText primary="Project Installation" />}
         </ListItemButton>
-        <ListItemButton
-          selected={router.pathname === '/team-setting'}
-          onClick={() => router.push('/team-setting')}
-        >
+        <ListItemButton onClick={() => setOpenTeamMgmt(!openTeamMgmt)}>
           <ListItemIcon>
             <GroupIcon />
           </ListItemIcon>
-          {!collapsed && <ListItemText primary="Team Setting" />}
+          {!collapsed && (
+            <>
+              <ListItemText primary="Team Management" />
+              {openTeamMgmt ? <ExpandLess /> : <ExpandMore />}
+            </>
+          )}
         </ListItemButton>
+        {!collapsed && (
+          <Collapse in={openTeamMgmt} timeout="auto" unmountOnExit>
+            <List component="div" disablePadding>
+              <ListItemButton
+                sx={{ pl: 4 }}
+                selected={router.pathname === '/team-setting'}
+                onClick={() => router.push('/team-setting')}
+              >
+                <ListItemIcon>
+                  <GroupIcon fontSize="small" />
+                </ListItemIcon>
+                <ListItemText primary="Resource" />
+              </ListItemButton>
+              <ListItemButton
+                sx={{ pl: 4 }}
+                selected={router.pathname === '/team-setting/team'}
+                onClick={() => router.push('/team-setting/team')}
+              >
+                <ListItemIcon>
+                  <GroupIcon fontSize="small" />
+                </ListItemIcon>
+                <ListItemText primary="Team" />
+              </ListItemButton>
+            </List>
+          </Collapse>
+        )}
       </List>
     </Drawer>
   );

--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -1,8 +1,8 @@
 // @ts-nocheck
 import Paper from '@mui/material/Paper';
 import Container from '@mui/material/Container';
-import { Layout, ResourceForm } from '../components';
-import { withAuth } from '../context/AuthContext';
+import { Layout, ResourceForm } from '../../components';
+import { withAuth } from '../../context/AuthContext';
 
 function TeamSetting() {
   return (

--- a/client/pages/team-setting/team.tsx
+++ b/client/pages/team-setting/team.tsx
@@ -1,0 +1,23 @@
+// @ts-nocheck
+import Paper from '@mui/material/Paper';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import { Layout } from '../../components';
+import { withAuth } from '../../context/AuthContext';
+
+function TeamPage() {
+  return (
+    <Layout>
+      <Container maxWidth="sm" sx={{ mt: 4 }}>
+        <Paper sx={{ p: 2 }} elevation={3}>
+          <Typography variant="h6">Team Management</Typography>
+          <Typography variant="body1" sx={{ mt: 2 }}>
+            Team management features will go here.
+          </Typography>
+        </Paper>
+      </Container>
+    </Layout>
+  );
+}
+
+export default withAuth(TeamPage);


### PR DESCRIPTION
## Summary
- rename Team Setting sidebar item to Team Management
- add collapsible submenu with Resource and Team links
- split the original page into `team-setting/index.tsx`
- add placeholder Team page

## Testing
- `npm run build` in `client`
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6853d4ad12c08328b8379a1095d1b5a8