### PR TITLE
Fix sidebar closing on submenu navigation

### DIFF
--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -3,19 +3,19 @@ import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
 import Topbar from './Topbar';
 import Sidebar from './Sidebar';
-import { useState } from 'react';
+import { useSidebar } from '../context/SidebarContext';
 
 export default function Layout({ children }) {
-  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const { open: sidebarOpen, toggleSidebar, setOpen } = useSidebar();
 
   const handleToggleSidebar = () => {
-    setSidebarOpen(!sidebarOpen);
+    toggleSidebar();
   };
 
   return (
     <Box sx={{ display: 'flex' }}>
       <Topbar onMenuClick={handleToggleSidebar} />
-      <Sidebar open={sidebarOpen} onClose={handleToggleSidebar} />
+      <Sidebar open={sidebarOpen} onClose={() => setOpen(false)} />
       <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
         <Toolbar />
         {children}

--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -81,11 +81,8 @@ export default function Sidebar({ open, onClose }) {
           {!collapsed && <ListItemText primary="Project Management" />}
         </ListItemButton>
         <ListItemButton
-          selected={router.pathname === '/team-setting'}
-          onClick={() => {
-            router.push('/team-setting');
-            onClose();
-          }}
+          selected={router.pathname.startsWith('/team-setting')}
+          onClick={() => setOpenTeamMgmt(!openTeamMgmt)}
         >
           <ListItemIcon>
             <GroupIcon />

--- a/client/context/SidebarContext.tsx
+++ b/client/context/SidebarContext.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext, useState } from 'react';
+
+const SidebarContext = createContext(null);
+
+export function SidebarProvider({ children }) {
+  const [open, setOpen] = useState(false);
+
+  const toggleSidebar = () => setOpen(prev => !prev);
+
+  return (
+    <SidebarContext.Provider value={{ open, toggleSidebar, setOpen }}>
+      {children}
+    </SidebarContext.Provider>
+  );
+}
+
+export const useSidebar = () => useContext(SidebarContext);

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -5,6 +5,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import theme from '../theme';
 import { AuthProvider } from '../context/AuthContext';
+import { SidebarProvider } from '../context/SidebarContext';
 import '../styles/globals.scss';
 
 export default function MyApp({ Component, pageProps }) {
@@ -13,7 +14,9 @@ export default function MyApp({ Component, pageProps }) {
       <ThemeProvider theme={theme}>
         <CssBaseline />
         <AuthProvider>
-          <Component {...pageProps} />
+          <SidebarProvider>
+            <Component {...pageProps} />
+          </SidebarProvider>
         </AuthProvider>
       </ThemeProvider>
     </LocalizationProvider>


### PR DESCRIPTION
## Summary
- keep sidebar visibility across pages
- manage global sidebar state in context
- update layout and sidebar to respect persistent state

## Testing
- `npm run build` in `service`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6853d9bdd99c8328a88ff7dabdb2d27f