### PR TITLE
Add resource table view

### DIFF
--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -1,16 +1,66 @@
 // @ts-nocheck
+import { useEffect, useState } from 'react';
 import Paper from '@mui/material/Paper';
 import Container from '@mui/material/Container';
-import { Layout, ResourceForm } from '../../components';
-import { withAuth } from '../../context/AuthContext';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import axios from 'axios';
+import { Layout, ResourceForm, Popup } from '../../components';
+import { withAuth, useAuth } from '../../context/AuthContext';
 
 function TeamSetting() {
+  const { token } = useAuth();
+  const [resources, setResources] = useState([]);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!token) return;
+    const headers = { Authorization: `Bearer ${token}` };
+    axios
+      .get('/api/v1/users', { headers })
+      .then(res => setResources(res.data))
+      .catch(console.error);
+  }, [token]);
+
+  const columns = [
+    {
+      field: 'no',
+      headerName: 'No.',
+      width: 70,
+      valueGetter: params => resources.indexOf(params.row) + 1,
+      sortable: false,
+    },
+    { field: 'username', headerName: 'Username', flex: 1 },
+  ];
+
   return (
     <Layout>
-      <Container maxWidth="sm" sx={{ mt: 4 }}>
-        <Paper sx={{ p: 2 }} elevation={3}>
-          <ResourceForm />
+      <Container maxWidth="md" sx={{ mt: 4 }}>
+        <Box
+          sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}
+        >
+          <Typography variant="h5">Resources</Typography>
+          <Button variant="contained" onClick={() => setOpen(true)}>
+            New Resource
+          </Button>
+        </Box>
+        <Paper>
+          <DataGrid
+            rows={resources}
+            columns={columns}
+            getRowId={row => row.id}
+            autoHeight
+            pageSize={5}
+            rowsPerPageOptions={[5]}
+            components={{ Toolbar: GridToolbar }}
+            componentsProps={{ toolbar: { showQuickFilter: true } }}
+          />
         </Paper>
+        <Popup open={open} onClose={() => setOpen(false)} title="Add Resource">
+          <ResourceForm />
+        </Popup>
       </Container>
     </Layout>
   );


### PR DESCRIPTION
## Summary
- display resource list for team setting
- enable search, filter, sort and add new resource button

## Testing
- `npm run build` in `client`
- `npm install` && `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6853e1c1d75483288adbea49319dadba