### PR TITLE
Add team management page

### DIFF
--- a/client/components/TeamForm.tsx
+++ b/client/components/TeamForm.tsx
@@ -1,0 +1,52 @@
+// @ts-nocheck
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import FormGroup from '@mui/material/FormGroup';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
+import Autocomplete from '@mui/material/Autocomplete';
+
+export default function TeamForm({ users = [], onSubmit }) {
+  const [name, setName] = useState('');
+  const [lead, setLead] = useState(null);
+  const [members, setMembers] = useState([]);
+
+  const toggleMember = id => {
+    setMembers(prev =>
+      prev.includes(id) ? prev.filter(m => m !== id) : [...prev, id]
+    );
+  };
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    onSubmit({ name, lead: lead?.username, members });
+    setName('');
+    setLead(null);
+    setMembers([]);
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} sx={{ display: 'grid', gap: 2 }}>
+      <TextField label="Team Name" value={name} onChange={e => setName(e.target.value)} required />
+      <Autocomplete
+        options={users}
+        getOptionLabel={o => o.username}
+        value={lead}
+        onChange={(_, v) => setLead(v)}
+        renderInput={params => <TextField {...params} label="Team Lead" />}
+      />
+      <FormGroup>
+        {users.map(u => (
+          <FormControlLabel
+            key={u.id}
+            control={<Checkbox checked={members.includes(u.username)} onChange={() => toggleMember(u.username)} />}
+            label={u.username}
+          />
+        ))}
+      </FormGroup>
+      <Button variant="contained" type="submit">Create</Button>
+    </Box>
+  );
+}

--- a/client/components/index.tsx
+++ b/client/components/index.tsx
@@ -9,3 +9,4 @@ export { default as Sidebar } from './Sidebar';
 export { default as Layout } from './Layout';
 export { default as ResourceForm } from './ResourceForm';
 export { default as SimpleCalendar } from './SimpleCalendar';
+export { default as TeamForm } from './TeamForm';

--- a/client/pages/team-setting/team.tsx
+++ b/client/pages/team-setting/team.tsx
@@ -1,20 +1,102 @@
 // @ts-nocheck
+import { useEffect, useState } from 'react';
 import Paper from '@mui/material/Paper';
 import Container from '@mui/material/Container';
+import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import { Layout } from '../../components';
-import { withAuth } from '../../context/AuthContext';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { DataGrid } from '@mui/x-data-grid';
+import axios from 'axios';
+import { Layout, Popup, TeamForm } from '../../components';
+import { withAuth, useAuth } from '../../context/AuthContext';
+import { format } from 'date-fns';
 
 function TeamPage() {
+  const { token } = useAuth();
+  const [teams, setTeams] = useState([]);
+  const [users, setUsers] = useState([]);
+  const [open, setOpen] = useState(false);
+
+  async function loadData() {
+    const headers = { Authorization: `Bearer ${token}` };
+    const [t, u] = await Promise.all([
+      axios.get('/api/v1/teams', { headers }),
+      axios.get('/api/v1/users', { headers }),
+    ]);
+    setTeams(t.data);
+    setUsers(u.data);
+  }
+
+  useEffect(() => {
+    if (token) loadData();
+  }, [token]);
+
+  const handleCreate = async data => {
+    const headers = { Authorization: `Bearer ${token}` };
+    await axios.post('/api/v1/teams', data, { headers });
+    setOpen(false);
+    loadData();
+  };
+
+  const columns = [
+    { field: 'name', headerName: 'Team Name', flex: 1 },
+    { field: 'lead', headerName: 'Team Lead', flex: 1 },
+    {
+      field: 'totalMember',
+      headerName: 'Total Member',
+      width: 120,
+      valueGetter: params => params.row.members.length,
+    },
+    {
+      field: 'createdAt',
+      headerName: 'Create Date',
+      width: 150,
+      valueGetter: params => format(new Date(params.row.createdAt), 'yyyy-MM-dd'),
+    },
+    {
+      field: 'actions',
+      headerName: 'Action',
+      width: 150,
+      renderCell: () => (
+        <Stack direction="row" spacing={1}>
+          <IconButton size="small">
+            <EditIcon fontSize="small" />
+          </IconButton>
+          <IconButton size="small">
+            <DeleteIcon fontSize="small" />
+          </IconButton>
+        </Stack>
+      ),
+    },
+  ];
+
   return (
     <Layout>
-      <Container maxWidth="sm" sx={{ mt: 4 }}>
-        <Paper sx={{ p: 2 }} elevation={3}>
-          <Typography variant="h6">Team Management</Typography>
-          <Typography variant="body1" sx={{ mt: 2 }}>
-            Team management features will go here.
-          </Typography>
+      <Container maxWidth="lg" sx={{ mt: 4 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
+          <Typography variant="h5">Teams</Typography>
+          <Button variant="contained" onClick={() => setOpen(true)}>
+            New Team
+          </Button>
+        </Box>
+        <Paper>
+          <DataGrid
+            rows={teams}
+            columns={columns}
+            getRowId={row => row._id}
+            autoHeight
+            pageSize={5}
+            rowsPerPageOptions={[5]}
+            checkboxSelection
+          />
         </Paper>
+        <Popup open={open} onClose={() => setOpen(false)} title="Add Team">
+          <TeamForm users={users} onSubmit={handleCreate} />
+        </Popup>
       </Container>
     </Layout>
   );

--- a/service/src/app.module.ts
+++ b/service/src/app.module.ts
@@ -6,6 +6,7 @@ import { RedisModule } from './redis.module';
 import { EventsModule } from './events/events.module';
 import { FollowersModule } from './followers/followers.module';
 import { ProjectsModule } from './projects/projects.module';
+import { TeamsModule } from './teams/teams.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { ProjectsModule } from './projects/projects.module';
     EventsModule,
     FollowersModule,
     ProjectsModule,
+    TeamsModule,
   ],
   providers: [LoggerService],
   exports: [LoggerService],

--- a/service/src/teams/data/team.schema.ts
+++ b/service/src/teams/data/team.schema.ts
@@ -1,0 +1,16 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class Team extends Document {
+  @Prop({ required: true })
+  name: string;
+
+  @Prop()
+  lead: string;
+
+  @Prop({ type: [String], default: [] })
+  members: string[];
+}
+
+export const TeamSchema = SchemaFactory.createForClass(Team);

--- a/service/src/teams/data/teams.repository.ts
+++ b/service/src/teams/data/teams.repository.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Team } from './team.schema';
+
+export interface CreateTeamInput {
+  name: string;
+  lead?: string;
+  members?: string[];
+}
+
+@Injectable()
+export class TeamsRepository {
+  constructor(@InjectModel(Team.name) private teamModel: Model<Team>) {}
+
+  findAll(): Promise<Team[]> {
+    return this.teamModel.find().sort({ createdAt: -1 }).exec();
+  }
+
+  create(data: CreateTeamInput): Promise<Team> {
+    const team = new this.teamModel(data);
+    return team.save();
+  }
+}

--- a/service/src/teams/teams.controller.ts
+++ b/service/src/teams/teams.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { TeamsService } from './teams.service';
+import { CreateTeamInput } from './data/teams.repository';
+
+@Controller('teams')
+export class TeamsController {
+  constructor(private readonly service: TeamsService) {}
+
+  @Post()
+  create(@Body() body: CreateTeamInput) {
+    return this.service.create(body);
+  }
+
+  @Get()
+  getTeams() {
+    return this.service.getTeams();
+  }
+}

--- a/service/src/teams/teams.module.ts
+++ b/service/src/teams/teams.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { TeamsController } from './teams.controller';
+import { TeamsService } from './teams.service';
+import { TeamsRepository } from './data/teams.repository';
+import { Team, TeamSchema } from './data/team.schema';
+
+@Module({
+  imports: [MongooseModule.forFeature([{ name: Team.name, schema: TeamSchema }])],
+  controllers: [TeamsController],
+  providers: [TeamsService, TeamsRepository],
+})
+export class TeamsModule {}

--- a/service/src/teams/teams.service.ts
+++ b/service/src/teams/teams.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { TeamsRepository, CreateTeamInput } from './data/teams.repository';
+
+@Injectable()
+export class TeamsService {
+  constructor(private readonly repo: TeamsRepository) {}
+
+  create(data: CreateTeamInput) {
+    return this.repo.create(data);
+  }
+
+  getTeams() {
+    return this.repo.findAll();
+  }
+}


### PR DESCRIPTION
## Summary
- add backend teams module for creating/listing teams
- create a TeamForm component
- implement Teams page with table and popup form
- export TeamForm from components index

## Testing
- `npx nest build` *(fails: nest not found? but after npm install, build succeeded)*
- `npx next build` *(fails: needed packages not installed due to interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6853eca997788328b29fddcd45e46233