### PR TITLE
Implement resource creation workflow

### DIFF
--- a/client/components/ResourceForm.tsx
+++ b/client/components/ResourceForm.tsx
@@ -23,7 +23,7 @@ const positions = [
   { value: 'qa_jr', label: 'QA - Junior' },
 ];
 
-export default function ResourceForm() {
+export default function ResourceForm({ onSubmit }) {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [position, setPosition] = useState('');
@@ -31,7 +31,9 @@ export default function ResourceForm() {
 
   function handleSubmit(e) {
     e.preventDefault();
-    alert(`Created resource ${name}`);
+    if (onSubmit) {
+      onSubmit({ name, email, position, startDate });
+    }
     setName('');
     setEmail('');
     setPosition('');

--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -15,14 +15,22 @@ function TeamSetting() {
   const [resources, setResources] = useState([]);
   const [open, setOpen] = useState(false);
 
-  useEffect(() => {
-    if (!token) return;
+  async function loadData() {
     const headers = { Authorization: `Bearer ${token}` };
-    axios
-      .get('/api/v1/users', { headers })
-      .then(res => setResources(res.data))
-      .catch(console.error);
+    const res = await axios.get('/api/v1/users', { headers });
+    setResources(res.data);
+  }
+
+  useEffect(() => {
+    if (token) loadData();
   }, [token]);
+
+  const handleCreate = async data => {
+    const headers = { Authorization: `Bearer ${token}` };
+    await axios.post('/api/v1/users', { username: data.name }, { headers });
+    setOpen(false);
+    loadData();
+  };
 
   const columns = [
     {
@@ -59,7 +67,7 @@ function TeamSetting() {
           />
         </Paper>
         <Popup open={open} onClose={() => setOpen(false)} title="Add Resource">
-          <ResourceForm />
+          <ResourceForm onSubmit={handleCreate} />
         </Popup>
       </Container>
     </Layout>

--- a/service/src/users/users.controller.ts
+++ b/service/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Req, UseGuards, UnauthorizedException } from '@nestjs/common';
+import { Body, Controller, Get, Post, Req, UseGuards, UnauthorizedException } from '@nestjs/common';
 import { Request } from 'express';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { UsersService } from './users.service';
@@ -19,5 +19,11 @@ export class UsersController {
   @Get('users')
   getUsers() {
     return this.usersService.getUsers();
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('users')
+  create(@Body() body: { username: string }) {
+    return this.usersService.createUser(body.username);
   }
 }

--- a/service/src/users/users.service.ts
+++ b/service/src/users/users.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import * as bcrypt from 'bcryptjs';
 import { UsersRepository } from './data/users.repository';
 
 @Injectable()
@@ -14,5 +15,10 @@ export class UsersService {
   async getUsers(): Promise<{ id: string; username: string }[]> {
     const users = await this.repo.findAll();
     return users.map(u => ({ id: u._id.toString(), username: u.username }));
+  }
+
+  async createUser(username: string) {
+    const hash = bcrypt.hashSync('changeit', 10);
+    return this.repo.create(username, hash);
   }
 }


### PR DESCRIPTION
## Summary
- allow creating users from resource form
- reload user list after creating a resource
- expose POST `/users` endpoint in the service

## Testing
- `npm run build` *(fails: `nest` not found)*
- `npm run build` in `client` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f3faaebc832884bac4cb082cdeba