### PR TITLE
Add Resources module and update frontend

### DIFF
--- a/client/components/TeamForm.tsx
+++ b/client/components/TeamForm.tsx
@@ -21,7 +21,7 @@ export default function TeamForm({ users = [], onSubmit }) {
 
   const handleSubmit = e => {
     e.preventDefault();
-    onSubmit({ name, lead: lead?.username, members });
+    onSubmit({ name, lead: lead?.name, members });
     setName('');
     setLead(null);
     setMembers([]);
@@ -32,7 +32,7 @@ export default function TeamForm({ users = [], onSubmit }) {
       <TextField label="Team Name" value={name} onChange={e => setName(e.target.value)} required />
       <Autocomplete
         options={users}
-        getOptionLabel={o => o.username}
+        getOptionLabel={o => o.name}
         value={lead}
         onChange={(_, v) => setLead(v)}
         renderInput={params => <TextField {...params} label="Team Lead" />}
@@ -41,8 +41,8 @@ export default function TeamForm({ users = [], onSubmit }) {
         {users.map(u => (
           <FormControlLabel
             key={u.id}
-            control={<Checkbox checked={members.includes(u.username)} onChange={() => toggleMember(u.username)} />}
-            label={u.username}
+            control={<Checkbox checked={members.includes(u.name)} onChange={() => toggleMember(u.name)} />}
+            label={u.name}
           />
         ))}
       </FormGroup>

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -35,7 +35,7 @@ function ProjectManagement() {
     const headers = { Authorization: `Bearer ${token}` };
     const pro = await axios.get('/api/v1/projects', { headers });
     setProjects(pro.data);
-    const usr = await axios.get('/api/v1/users', { headers });
+    const usr = await axios.get('/api/v1/resources', { headers });
     setUsers(usr.data);
   }
 
@@ -142,7 +142,7 @@ function ProjectManagement() {
             <DatePicker label="Start Date" value={start} onChange={setStart} renderInput={params => <TextField {...params} required />} />
             <Autocomplete
               options={users}
-              getOptionLabel={o => o.username}
+              getOptionLabel={o => o.name}
               value={lead}
               onChange={(_, v) => setLead(v)}
               renderInput={params => <TextField {...params} label="Team Lead" required />}
@@ -150,7 +150,7 @@ function ProjectManagement() {
             <Autocomplete
               multiple
               options={users}
-              getOptionLabel={o => o.username}
+              getOptionLabel={o => o.name}
               value={members}
               onChange={(_, v) => setMembers(v)}
               renderInput={params => <TextField {...params} label="Members" />}

--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -17,7 +17,7 @@ function TeamSetting() {
 
   async function loadData() {
     const headers = { Authorization: `Bearer ${token}` };
-    const res = await axios.get('/api/v1/users', { headers });
+    const res = await axios.get('/api/v1/resources', { headers });
     setResources(res.data);
   }
 
@@ -27,7 +27,7 @@ function TeamSetting() {
 
   const handleCreate = async data => {
     const headers = { Authorization: `Bearer ${token}` };
-    await axios.post('/api/v1/users', { username: data.name }, { headers });
+    await axios.post('/api/v1/resources', data, { headers });
     setOpen(false);
     loadData();
   };
@@ -37,10 +37,9 @@ function TeamSetting() {
       field: 'no',
       headerName: 'No.',
       width: 70,
-      // valueGetter: params => params.api.getRowIndex(params.id) + 1,
       sortable: false,
     },
-    { field: 'username', headerName: 'Username', flex: 1 },
+    { field: 'name', headerName: 'Name', flex: 1 },
   ];
 
   return (

--- a/client/pages/team-setting/team.tsx
+++ b/client/pages/team-setting/team.tsx
@@ -25,7 +25,7 @@ function TeamPage() {
     const headers = { Authorization: `Bearer ${token}` };
     const [t, u] = await Promise.all([
       axios.get('/api/v1/teams', { headers }),
-      axios.get('/api/v1/users', { headers }),
+      axios.get('/api/v1/resources', { headers }),
     ]);
     setTeams(t.data);
     setUsers(u.data);

--- a/service/src/app.module.ts
+++ b/service/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { LoggerService } from './logger/logger.service';
 import { MongooseModule } from '@nestjs/mongoose';
 import { UsersModule } from './users/users.module';
+import { ResourcesModule } from './resources/resources.module';
 import { RedisModule } from './redis.module';
 import { EventsModule } from './events/events.module';
 import { FollowersModule } from './followers/followers.module';
@@ -13,6 +14,7 @@ import { TeamsModule } from './teams/teams.module';
     MongooseModule.forRoot(process.env.MONGO_URL || 'mongodb://mongo:27017/budget'),
     RedisModule,
     UsersModule,
+    ResourcesModule,
     EventsModule,
     FollowersModule,
     ProjectsModule,

--- a/service/src/resources/data/resource.schema.ts
+++ b/service/src/resources/data/resource.schema.ts
@@ -1,0 +1,19 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class Resource extends Document {
+  @Prop({ required: true })
+  name: string;
+
+  @Prop({ required: true })
+  email: string;
+
+  @Prop({ required: true })
+  position: string;
+
+  @Prop()
+  startDate: Date;
+}
+
+export const ResourceSchema = SchemaFactory.createForClass(Resource);

--- a/service/src/resources/data/resources.repository.ts
+++ b/service/src/resources/data/resources.repository.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Resource } from './resource.schema';
+
+export interface CreateResourceInput {
+  name: string;
+  email: string;
+  position: string;
+  startDate?: Date;
+}
+
+@Injectable()
+export class ResourcesRepository {
+  constructor(@InjectModel(Resource.name) private resourceModel: Model<Resource>) {}
+
+  findAll(): Promise<Resource[]> {
+    return this.resourceModel.find().sort({ name: 1 }).exec();
+  }
+
+  create(data: CreateResourceInput): Promise<Resource> {
+    const res = new this.resourceModel(data);
+    return res.save();
+  }
+}

--- a/service/src/resources/resources.controller.ts
+++ b/service/src/resources/resources.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { ResourcesService } from './resources.service';
+import { CreateResourceInput } from './data/resources.repository';
+
+@Controller('resources')
+export class ResourcesController {
+  constructor(private readonly service: ResourcesService) {}
+
+  @Get()
+  getResources() {
+    return this.service.getResources();
+  }
+
+  @Post()
+  create(@Body() body: CreateResourceInput) {
+    return this.service.create(body);
+  }
+}

--- a/service/src/resources/resources.module.ts
+++ b/service/src/resources/resources.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { ResourcesController } from './resources.controller';
+import { ResourcesService } from './resources.service';
+import { ResourcesRepository } from './data/resources.repository';
+import { Resource, ResourceSchema } from './data/resource.schema';
+
+@Module({
+  imports: [MongooseModule.forFeature([{ name: Resource.name, schema: ResourceSchema }])],
+  controllers: [ResourcesController],
+  providers: [ResourcesService, ResourcesRepository],
+})
+export class ResourcesModule {}

--- a/service/src/resources/resources.service.ts
+++ b/service/src/resources/resources.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { ResourcesRepository, CreateResourceInput } from './data/resources.repository';
+
+@Injectable()
+export class ResourcesService {
+  constructor(private readonly repo: ResourcesRepository) {}
+
+  getResources() {
+    return this.repo.findAll().then(resources =>
+      resources.map(r => ({
+        id: r._id.toString(),
+        name: r.name,
+        email: r.email,
+        position: r.position,
+        startDate: r.startDate,
+      }))
+    );
+  }
+
+  create(data: CreateResourceInput) {
+    return this.repo.create(data);
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `resources` module to the service
- query/create resources from new endpoints
- use resources API from client pages
- adapt forms and data grids for resource names

## Testing
- `npm run build` in `service` *(fails: nest not found)*
- `npm run build` in `client` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f93208388328ba76f9a7cca0158b