### PR TITLE
Add axios request interceptor

### DIFF
--- a/client/api.ts
+++ b/client/api.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+const api = axios.create();
+
+api.interceptors.request.use(config => {
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('token');
+    if (token) {
+      if (!config.headers) {
+        config.headers = {} as any;
+      }
+      (config.headers as any).Authorization = `Bearer ${token}`;
+    }
+  }
+  return config;
+});
+
+export default api;

--- a/client/models/authModel.ts
+++ b/client/models/authModel.ts
@@ -1,18 +1,16 @@
 // @ts-nocheck
-import axios from 'axios';
+import api from '../api';
 
 export async function loginRequest(username, password) {
-  const { data } = await axios.post('/api/v1/auth/login', { username, password });
+  const { data } = await api.post('/api/v1/auth/login', { username, password });
   return data;
 }
 
-export async function fetchProfile(token) {
-  const { data } = await axios.get('/api/v1/profile', {
-    headers: { Authorization: `Bearer ${token}` },
-  });
+export async function fetchProfile() {
+  const { data } = await api.get('/api/v1/profile');
   return data;
 }
 
 export async function revokeRefreshToken(refreshToken) {
-  await axios.post('/api/v1/auth/revoke', { refreshToken });
+  await api.post('/api/v1/auth/revoke', { refreshToken });
 }

--- a/client/models/eventsModel.ts
+++ b/client/models/eventsModel.ts
@@ -1,6 +1,6 @@
-import axios from 'axios';
+import api from '../api';
 
 export async function fetchEvents() {
-  const { data } = await axios.get('/api/v1/events');
+  const { data } = await api.get('/api/v1/events');
   return data;
 }

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -15,7 +15,7 @@ import DownloadIcon from '@mui/icons-material/Download';
 import { DataGrid } from '@mui/x-data-grid';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { differenceInDays, format } from 'date-fns';
-import axios from 'axios';
+import api from '../api';
 import { Layout } from '../components';
 import { withAuth, useAuth } from '../context/AuthContext';
 
@@ -32,10 +32,9 @@ function ProjectManagement() {
   const [manday, setManday] = useState('');
 
   async function loadData() {
-    const headers = { Authorization: `Bearer ${token}` };
-    const pro = await axios.get('/api/v1/projects', { headers });
+    const pro = await api.get('/api/v1/projects');
     setProjects(pro.data);
-    const usr = await axios.get('/api/v1/users', { headers });
+    const usr = await api.get('/api/v1/users');
     setUsers(usr.data);
   }
 
@@ -45,8 +44,7 @@ function ProjectManagement() {
 
   async function handleSubmit(e) {
     e.preventDefault();
-    const headers = { Authorization: `Bearer ${token}` };
-    await axios.post(
+    await api.post(
       '/api/v1/projects',
       {
         name,
@@ -57,8 +55,7 @@ function ProjectManagement() {
         priority: 1,
         lead: lead?.id,
         members: members.map(m => m.id),
-      },
-      { headers }
+      }
     );
     setName('');
     setDescription('');

--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -6,7 +6,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import { DataGrid, GridToolbar } from '@mui/x-data-grid';
-import axios from 'axios';
+import api from '../../api';
 import { Layout, ResourceForm, Popup } from '../../components';
 import { withAuth, useAuth } from '../../context/AuthContext';
 
@@ -16,8 +16,7 @@ function TeamSetting() {
   const [open, setOpen] = useState(false);
 
   async function loadData() {
-    const headers = { Authorization: `Bearer ${token}` };
-    const res = await axios.get('/api/v1/users', { headers });
+    const res = await api.get('/api/v1/users');
     setResources(res.data);
   }
 
@@ -26,8 +25,7 @@ function TeamSetting() {
   }, [token]);
 
   const handleCreate = async data => {
-    const headers = { Authorization: `Bearer ${token}` };
-    await axios.post('/api/v1/users', { username: data.name }, { headers });
+    await api.post('/api/v1/users', { username: data.name });
     setOpen(false);
     loadData();
   };

--- a/client/pages/team-setting/team.tsx
+++ b/client/pages/team-setting/team.tsx
@@ -10,7 +10,7 @@ import Stack from '@mui/material/Stack';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { DataGrid } from '@mui/x-data-grid';
-import axios from 'axios';
+import api from '../../api';
 import { Layout, Popup, TeamForm } from '../../components';
 import { withAuth, useAuth } from '../../context/AuthContext';
 import { format } from 'date-fns';
@@ -22,10 +22,9 @@ function TeamPage() {
   const [open, setOpen] = useState(false);
 
   async function loadData() {
-    const headers = { Authorization: `Bearer ${token}` };
     const [t, u] = await Promise.all([
-      axios.get('/api/v1/teams', { headers }),
-      axios.get('/api/v1/users', { headers }),
+      api.get('/api/v1/teams'),
+      api.get('/api/v1/users'),
     ]);
     setTeams(t.data);
     setUsers(u.data);
@@ -36,8 +35,7 @@ function TeamPage() {
   }, [token]);
 
   const handleCreate = async data => {
-    const headers = { Authorization: `Bearer ${token}` };
-    await axios.post('/api/v1/teams', data, { headers });
+    await api.post('/api/v1/teams', data);
     setOpen(false);
     loadData();
   };


### PR DESCRIPTION
## Summary
- add a shared axios instance with a request interceptor to attach `Authorization` header
- use the interceptor in pages and models
- remove per-request header logic

## Testing
- `npm run build` in `client`
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6853f8d78bf48328ba3009c4532d79d0