### PR TITLE
Fix Project Management navigation and table layout

### DIFF
--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -60,9 +60,9 @@ export default function Sidebar({ open, onClose }) {
           {!collapsed && <ListItemText primary="Summary" />}
         </ListItemButton>
         <ListItemButton
-          selected={router.pathname === '/project-installation'}
+          selected={router.pathname === '/project-management'}
           onClick={() => {
-            router.push('/project-installation');
+            router.push('/project-management');
             onClose();
           }}
         >

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -159,8 +159,15 @@ function ProjectManagement() {
             <Button type="submit" variant="contained">Create</Button>
           </Box>
         </Paper>
-        <Paper sx={{ height: 400 }}>
-          <DataGrid rows={projects} columns={columns} getRowId={row => row._id} pageSize={5} rowsPerPageOptions={[5]} autoHeight />
+        <Paper>
+          <DataGrid
+            rows={projects}
+            columns={columns}
+            getRowId={row => row._id}
+            pageSize={5}
+            rowsPerPageOptions={[5]}
+            autoHeight
+          />
         </Paper>
       </Container>
     </Layout>


### PR DESCRIPTION
## Summary
- correct sidebar link path to Project Management
- improve project table layout by removing fixed height

## Testing
- `npm run build` in `client`
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6853f9ba85ac8328867e43fd774e1d55