### PR TITLE
Switch project form to popup

### DIFF
--- a/client/components/ProjectForm.tsx
+++ b/client/components/ProjectForm.tsx
@@ -1,0 +1,79 @@
+// @ts-nocheck
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Autocomplete from '@mui/material/Autocomplete';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+
+export default function ProjectForm({ users = [], onSubmit }) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [start, setStart] = useState(null);
+  const [lead, setLead] = useState(null);
+  const [members, setMembers] = useState([]);
+  const [manday, setManday] = useState('');
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    if (onSubmit) {
+      onSubmit({
+        name,
+        description,
+        start,
+        end: start,
+        manday: Number(manday),
+        priority: 1,
+        lead: lead?.id,
+        members: members.map(m => m.id),
+      });
+    }
+    setName('');
+    setDescription('');
+    setStart(null);
+    setLead(null);
+    setMembers([]);
+    setManday('');
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} sx={{ display: 'grid', gap: 2 }}>
+      <TextField label="Name" value={name} onChange={e => setName(e.target.value)} required />
+      <TextField
+        label="Description"
+        value={description}
+        onChange={e => setDescription(e.target.value)}
+        multiline
+      />
+      <DatePicker
+        label="Start Date"
+        value={start}
+        onChange={setStart}
+        renderInput={params => <TextField {...params} required />}
+      />
+      <Autocomplete
+        options={users}
+        getOptionLabel={o => o.name}
+        value={lead}
+        onChange={(_, v) => setLead(v)}
+        renderInput={params => <TextField {...params} label="Team Lead" required />}
+      />
+      <Autocomplete
+        multiple
+        options={users}
+        getOptionLabel={o => o.name}
+        value={members}
+        onChange={(_, v) => setMembers(v)}
+        renderInput={params => <TextField {...params} label="Members" />}
+      />
+      <TextField
+        label="Manday"
+        type="number"
+        value={manday}
+        onChange={e => setManday(e.target.value)}
+        required
+      />
+      <Button type="submit" variant="contained">Create</Button>
+    </Box>
+  );
+}

--- a/client/components/index.tsx
+++ b/client/components/index.tsx
@@ -10,3 +10,4 @@ export { default as Layout } from './Layout';
 export { default as ResourceForm } from './ResourceForm';
 export { default as SimpleCalendar } from './SimpleCalendar';
 export { default as TeamForm } from './TeamForm';
+export { default as ProjectForm } from './ProjectForm';

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -4,37 +4,28 @@ import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
 import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
-import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
-import Autocomplete from '@mui/material/Autocomplete';
 import Stack from '@mui/material/Stack';
 import IconButton from '@mui/material/IconButton';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import DownloadIcon from '@mui/icons-material/Download';
 import { DataGrid } from '@mui/x-data-grid';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { differenceInDays, format } from 'date-fns';
 import api from '../api';
-import { Layout } from '../components';
+import { Layout, Popup, ProjectForm } from '../components';
 import { withAuth, useAuth } from '../context/AuthContext';
 
 function ProjectManagement() {
   const { token } = useAuth();
   const [projects, setProjects] = useState([]);
   const [users, setUsers] = useState([]);
-
-  const [name, setName] = useState('');
-  const [description, setDescription] = useState('');
-  const [start, setStart] = useState(null);
-  const [lead, setLead] = useState(null);
-  const [members, setMembers] = useState([]);
-  const [manday, setManday] = useState('');
+  const [open, setOpen] = useState(false);
 
   async function loadData() {
     const pro = await api.get('/api/v1/projects');
     setProjects(pro.data);
-    const usr = await axios.get('/api/v1/resources', { headers });
+    const usr = await api.get('/api/v1/resources');
     setUsers(usr.data);
   }
 
@@ -42,29 +33,11 @@ function ProjectManagement() {
     if (token) loadData();
   }, [token]);
 
-  async function handleSubmit(e) {
-    e.preventDefault();
-    await api.post(
-      '/api/v1/projects',
-      {
-        name,
-        description,
-        start,
-        end: start,
-        manday: Number(manday),
-        priority: 1,
-        lead: lead?.id,
-        members: members.map(m => m.id),
-      }
-    );
-    setName('');
-    setDescription('');
-    setStart(null);
-    setLead(null);
-    setMembers([]);
-    setManday('');
+  const handleCreate = async data => {
+    await api.post('/api/v1/projects', data);
+    setOpen(false);
     loadData();
-  }
+  };
 
   const columns = [
     {
@@ -126,36 +99,12 @@ function ProjectManagement() {
   return (
     <Layout>
       <Container maxWidth="lg" sx={{ mt: 4 }}>
-        <Typography variant="h5" sx={{ mb: 2 }}>
-          Project Management
-        </Typography>
-        <Paper sx={{ p: 2, mb: 4 }} elevation={3}>
-          <Typography variant="h6" sx={{ mb: 2 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
+          <Typography variant="h5">Project Management</Typography>
+          <Button variant="contained" onClick={() => setOpen(true)}>
             New Project
-          </Typography>
-          <Box component="form" onSubmit={handleSubmit} sx={{ display: 'grid', gap: 2 }}>
-            <TextField label="Name" value={name} onChange={e => setName(e.target.value)} required />
-            <TextField label="Description" value={description} onChange={e => setDescription(e.target.value)} multiline />
-            <DatePicker label="Start Date" value={start} onChange={setStart} renderInput={params => <TextField {...params} required />} />
-            <Autocomplete
-              options={users}
-              getOptionLabel={o => o.name}
-              value={lead}
-              onChange={(_, v) => setLead(v)}
-              renderInput={params => <TextField {...params} label="Team Lead" required />}
-            />
-            <Autocomplete
-              multiple
-              options={users}
-              getOptionLabel={o => o.name}
-              value={members}
-              onChange={(_, v) => setMembers(v)}
-              renderInput={params => <TextField {...params} label="Members" />}
-            />
-            <TextField label="Manday" type="number" value={manday} onChange={e => setManday(e.target.value)} required />
-            <Button type="submit" variant="contained">Create</Button>
-          </Box>
-        </Paper>
+          </Button>
+        </Box>
         <Paper>
           <DataGrid
             rows={projects}
@@ -166,6 +115,9 @@ function ProjectManagement() {
             autoHeight
           />
         </Paper>
+        <Popup open={open} onClose={() => setOpen(false)} title="Add Project">
+          <ProjectForm users={users} onSubmit={handleCreate} />
+        </Popup>
       </Container>
     </Layout>
   );


### PR DESCRIPTION
## Summary
- create `ProjectForm` component for popup use
- show project creation popup in project management page

## Testing
- `npm run build` in `service` *(fails: nest not found)*
- `npm run build` in `client` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853fbfa62188328a2830a53242bcdc2