### PR TITLE
Unify page layout widths

### DIFF
--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -98,7 +98,7 @@ function ProjectManagement() {
 
   return (
     <Layout>
-      <Container maxWidth="lg" sx={{ mt: 4 }}>
+      <Container maxWidth="md" sx={{ mt: 4 }}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
           <Typography variant="h5">Project Management</Typography>
           <Button variant="contained" onClick={() => setOpen(true)}>

--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -49,7 +49,7 @@ function TeamSetting() {
   return (
     <Layout>
       <Container maxWidth="md" sx={{ mt: 4 }}>
-        <Typography variant="h4" gutterBottom>
+        <Typography variant="h5" gutterBottom>
           Team Setting
         </Typography>
         <Box

--- a/client/pages/team-setting/team.tsx
+++ b/client/pages/team-setting/team.tsx
@@ -74,7 +74,7 @@ function TeamPage() {
 
   return (
     <Layout>
-      <Container maxWidth="lg" sx={{ mt: 4 }}>
+      <Container maxWidth="md" sx={{ mt: 4 }}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
           <Typography variant="h5">Teams</Typography>
           <Button variant="contained" onClick={() => setOpen(true)}>


### PR DESCRIPTION
## Summary
- use the same `maxWidth` across pages for a consistent look
- adjust page heading level for team settings

## Testing
- `npm run build` in `client`
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6854d8f7f24483288f71ddb656e57f82