### PR TITLE
Fix team page data loading

### DIFF
--- a/client/pages/team-setting/team.tsx
+++ b/client/pages/team-setting/team.tsx
@@ -23,8 +23,8 @@ function TeamPage() {
 
   async function loadData() {
     const [t, u] = await Promise.all([
-      axios.get('/api/v1/teams', { headers }),
-      axios.get('/api/v1/resources', { headers }),
+      api.get('/api/v1/teams'),
+      api.get('/api/v1/resources'),
     ]);
     setTeams(t.data);
     setUsers(u.data);


### PR DESCRIPTION
## Summary
- fix data fetching on `/team-setting/team`

## Testing
- `npm run build` in `client`
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6854d8c0bd50832897fd8ff1a88ac147