### PR TITLE
Add positions API and service year display

### DIFF
--- a/client/components/ResourceForm.tsx
+++ b/client/components/ResourceForm.tsx
@@ -5,41 +5,60 @@ import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
 import MenuItem from '@mui/material/MenuItem';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Input } from '.';
-import positions from '../models/positions';
+import api from '../api';
 
 export default function ResourceForm({ onSubmit }) {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
-  const [position, setPosition] = useState('');
+  const [role, setRole] = useState('');
+  const [level, setLevel] = useState('');
+  const [positions, setPositions] = useState([]);
   const [startDate, setStartDate] = useState(null);
+
+  useEffect(() => {
+    async function loadPositions() {
+      const { data } = await api.get('/api/v1/positions');
+      setPositions(data);
+    }
+    loadPositions();
+  }, []);
 
   function handleSubmit(e) {
     e.preventDefault();
+    const found = positions.find(
+      p => p.label === `${role} - ${level}`,
+    );
+    const position = found ? found.value : '';
     if (onSubmit) {
       onSubmit({ name, email, position, startDate });
     }
     setName('');
     setEmail('');
-    setPosition('');
+    setRole('');
+    setLevel('');
     setStartDate(null);
   }
+
+  const roles = Array.from(new Set(positions.map(p => p.label.split(' - ')[0])));
+  const levels = Array.from(new Set(positions.map(p => p.label.split(' - ')[1])));
 
   return (
     <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
       <Input label="Name" value={name} onChange={e => setName(e.target.value)} required />
       <Input label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} required />
-      <TextField
-        select
-        label="Position"
-        value={position}
-        onChange={e => setPosition(e.target.value)}
-        required
-      >
-        {positions.map(p => (
-          <MenuItem key={p.value} value={p.value}>
-            {p.label}
+      <TextField select label="Role" value={role} onChange={e => setRole(e.target.value)} required>
+        {roles.map(r => (
+          <MenuItem key={r} value={r}>
+            {r}
+          </MenuItem>
+        ))}
+      </TextField>
+      <TextField select label="Level" value={level} onChange={e => setLevel(e.target.value)} required>
+        {levels.map(l => (
+          <MenuItem key={l} value={l}>
+            {l}
           </MenuItem>
         ))}
       </TextField>

--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -12,7 +12,7 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import axios from 'axios';
-import { format } from 'date-fns';
+import { format, differenceInYears } from 'date-fns';
 import { Layout, ResourceForm, Popup } from '../../components';
 import { withAuth, useAuth } from '../../context/AuthContext';
 
@@ -70,6 +70,7 @@ function TeamSetting() {
                   <TableCell>Email</TableCell>
                   <TableCell>Position</TableCell>
                   <TableCell>Start Date</TableCell>
+                  <TableCell>Service Year</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
@@ -79,13 +80,18 @@ function TeamSetting() {
                     <TableCell>{r.name}</TableCell>
                     <TableCell>{r.email}</TableCell>
                     <TableCell>{r.position}</TableCell>
-                    <TableCell>
-                      {r.startDate
-                        ? format(new Date(r.startDate), 'yyyy-MM-dd')
-                        : ''}
-                    </TableCell>
-                  </TableRow>
-                ))}
+                  <TableCell>
+                    {r.startDate
+                      ? format(new Date(r.startDate), 'yyyy-MM-dd')
+                      : ''}
+                  </TableCell>
+                  <TableCell>
+                    {r.startDate
+                      ? differenceInYears(new Date(), new Date(r.startDate))
+                      : ''}
+                  </TableCell>
+                </TableRow>
+              ))}
               </TableBody>
             </Table>
           </TableContainer>

--- a/service/src/app.module.ts
+++ b/service/src/app.module.ts
@@ -9,6 +9,7 @@ import { FollowersModule } from './followers/followers.module';
 import { ProjectsModule } from './projects/projects.module';
 import { TeamsModule } from './teams/teams.module';
 import { BudgetsModule } from './budgets/budgets.module';
+import { PositionsModule } from './positions/positions.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { BudgetsModule } from './budgets/budgets.module';
     ProjectsModule,
     TeamsModule,
     BudgetsModule,
+    PositionsModule,
   ],
   providers: [LoggerService],
   exports: [LoggerService],

--- a/service/src/positions/data/positions.ts
+++ b/service/src/positions/data/positions.ts
@@ -1,0 +1,16 @@
+const positions = [
+  { value: 'project_manager_sr', label: 'Project Manager - Senior' },
+  { value: 'project_manager_inter', label: 'Project Manager - Intermediate' },
+  { value: 'project_manager_jr', label: 'Project Manager - Junior' },
+  { value: 'sa_sr', label: 'System Analyst - Senior' },
+  { value: 'sa_inter', label: 'System Analyst - Intermediate' },
+  { value: 'sa_jr', label: 'System Analyst - Junior' },
+  { value: 'pa_sr', label: 'PA - Senior' },
+  { value: 'pa_inter', label: 'PA - Intermediate' },
+  { value: 'pa_jr', label: 'PA - Junior' },
+  { value: 'qa_sr', label: 'QA - Senior' },
+  { value: 'qa_inter', label: 'QA - Intermediate' },
+  { value: 'qa_jr', label: 'QA - Junior' },
+];
+
+export default positions;

--- a/service/src/positions/positions.controller.ts
+++ b/service/src/positions/positions.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { PositionsService } from './positions.service';
+
+@Controller('positions')
+export class PositionsController {
+  constructor(private readonly service: PositionsService) {}
+
+  @Get()
+  getPositions() {
+    return this.service.getPositions();
+  }
+}

--- a/service/src/positions/positions.module.ts
+++ b/service/src/positions/positions.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PositionsController } from './positions.controller';
+import { PositionsService } from './positions.service';
+
+@Module({
+  controllers: [PositionsController],
+  providers: [PositionsService],
+  exports: [PositionsService],
+})
+export class PositionsModule {}

--- a/service/src/positions/positions.service.ts
+++ b/service/src/positions/positions.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+import positions from './data/positions';
+
+@Injectable()
+export class PositionsService {
+  getPositions() {
+    return positions;
+  }
+}


### PR DESCRIPTION
## Summary
- add positions module in service
- show service year column in resources table
- fetch positions for resource form and split role & level

## Testing
- `npm run build` in service *(fails: nest not found)*
- `npm run build` in client *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854e29c9bc4832881ead337a3ca0d08