### PR TITLE
Adjust content layout width

### DIFF
--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -16,7 +16,7 @@ export default function Layout({ children }) {
     <Box sx={{ display: 'flex' }}>
       <Topbar onMenuClick={handleToggleSidebar} />
       <Sidebar open={sidebarOpen} onClose={() => setOpen(false)} />
-      <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+      <Box component="main" sx={{ flexGrow: 1, p: 3, width: '90%', mx: 'auto' }}>
         <Toolbar />
         {children}
       </Box>

--- a/client/pages/budget-management.tsx
+++ b/client/pages/budget-management.tsx
@@ -105,7 +105,7 @@ function BudgetManagement() {
 
   return (
     <Layout>
-      <Container maxWidth="md" sx={{ mt: 4 }}>
+      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
           <Typography variant="h5">Budget Management</Typography>
           <Button variant="contained" onClick={() => setOpen(true)}>

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -98,7 +98,7 @@ function ProjectManagement() {
 
   return (
     <Layout>
-      <Container maxWidth="md" sx={{ mt: 4 }}>
+      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
           <Typography variant="h5">Project Management</Typography>
           <Button variant="contained" onClick={() => setOpen(true)}>

--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -48,7 +48,7 @@ function TeamSetting() {
   ];
   return (
     <Layout>
-      <Container maxWidth="md" sx={{ mt: 4 }}>
+      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
         <Typography variant="h5" gutterBottom>
           Team Setting
         </Typography>

--- a/client/pages/team-setting/team.tsx
+++ b/client/pages/team-setting/team.tsx
@@ -74,7 +74,7 @@ function TeamPage() {
 
   return (
     <Layout>
-      <Container maxWidth="md" sx={{ mt: 4 }}>
+      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
           <Typography variant="h5">Teams</Typography>
           <Button variant="contained" onClick={() => setOpen(true)}>

--- a/client/pages/workspace.tsx
+++ b/client/pages/workspace.tsx
@@ -26,7 +26,7 @@ function Workspace() {
 
   return (
     <Layout>
-      <Container maxWidth="md" sx={{ mt: 4 }}>
+      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
         <Paper sx={{ p: 2 }} elevation={3}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
           <Typography variant="h5">Workspace</Typography>


### PR DESCRIPTION
## Summary
- set layout main width to 90% of the viewport
- adjust pages to use wider container

## Testing
- `npm test` *(fails: could not find package.json)*
- `npm test` in `client` *(fails: Missing script)*
- `npm test` in `service` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854e8b82b888328aea8aa56a33645ed