### PR TITLE
Fix undefined api on DataGrid rows

### DIFF
--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -56,7 +56,8 @@ function TeamSetting() {
       headerName: 'No.',
       width: 70,
       sortable: false,
-      valueGetter: params => params.api.getRowIndex(params.id) + 1,
+      valueGetter: params =>
+        params.api ? params.api.getRowIndex(params.id) + 1 : '',
     },
     { field: 'name', headerName: 'Name', flex: 1 },
     { field: 'email', headerName: 'Email', flex: 1 },


### PR DESCRIPTION
## Summary
- prevent crash in team-setting page when `params.api` is undefined

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6854ea60229883288acae522e18e0fc8