### PR TITLE
Fix DataGrid row index retrieval

### DIFF
--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -44,7 +44,10 @@ function ProjectManagement() {
       field: 'no',
       headerName: 'No.',
       width: 70,
-      valueGetter: params => params.api.getRowIndex(params.id) + 1,
+      valueGetter: params =>
+        params.api?.getRowIndexRelativeToVisibleRows
+          ? params.api.getRowIndexRelativeToVisibleRows(params.id) + 1
+          : '',
     },
     { field: 'name', headerName: 'Name', flex: 1 },
     { field: 'description', headerName: 'Description', flex: 1 },

--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -57,7 +57,9 @@ function TeamSetting() {
       width: 70,
       sortable: false,
       valueGetter: params =>
-        params.api ? params.api.getRowIndex(params.id) + 1 : '',
+        params.api?.getRowIndexRelativeToVisibleRows
+          ? params.api.getRowIndexRelativeToVisibleRows(params.id) + 1
+          : '',
     },
     { field: 'name', headerName: 'Name', flex: 1 },
     { field: 'email', headerName: 'Email', flex: 1 },


### PR DESCRIPTION
## Summary
- use `getRowIndexRelativeToVisibleRows` so row numbers reflect current sorting/filtering

## Testing
- `npm run build` in `client`
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6854f813f9388328aa330d2628f71bba