### PR TITLE
Update default rows per page

### DIFF
--- a/client/pages/budget-management.tsx
+++ b/client/pages/budget-management.tsx
@@ -101,8 +101,8 @@ function BudgetManagement() {
             rows={rows}
             columns={columns}
             autoHeight
-            pageSize={5}
-            rowsPerPageOptions={[5]}
+            pageSize={25}
+            rowsPerPageOptions={[25]}
             disableSelectionOnClick
           />
         </Paper>

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -110,8 +110,8 @@ function ProjectManagement() {
             rows={projects}
             columns={columns}
             getRowId={row => row._id}
-            pageSize={5}
-            rowsPerPageOptions={[5]}
+            pageSize={25}
+            rowsPerPageOptions={[25]}
             autoHeight
           />
         </Paper>

--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -101,8 +101,8 @@ function TeamSetting() {
             columns={columns}
             getRowId={row => row.id}
             autoHeight
-            pageSize={5}
-            rowsPerPageOptions={[5]}
+            pageSize={25}
+            rowsPerPageOptions={[25]}
           />
         </Paper>
         <Popup open={open} onClose={() => setOpen(false)} title="Add Resource">

--- a/client/pages/team-setting/team.tsx
+++ b/client/pages/team-setting/team.tsx
@@ -87,8 +87,8 @@ function TeamPage() {
             columns={columns}
             getRowId={row => row._id}
             autoHeight
-            pageSize={5}
-            rowsPerPageOptions={[5]}
+            pageSize={25}
+            rowsPerPageOptions={[25]}
             checkboxSelection
           />
         </Paper>


### PR DESCRIPTION
## Summary
- update MUI DataGrid defaults to show 25 rows instead of 5

## Testing
- `npm run build` in `client`
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6854f86a52108328a128fd9ea58053c9