### PR TITLE
Add detail page and update sidebar menu

### DIFF
--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -6,8 +6,6 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Toolbar from '@mui/material/Toolbar';
 import Divider from '@mui/material/Divider';
-import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import SettingsIcon from '@mui/icons-material/Settings';
 import GroupIcon from '@mui/icons-material/Group';
@@ -24,6 +22,7 @@ const drawerWidth = 220;
 export default function Sidebar({ open, onClose }) {
   const router = useRouter();
   const [collapsed, setCollapsed] = useState(false);
+  const [openSummary, setOpenSummary] = useState(false);
   const [openTeamMgmt, setOpenTeamMgmt] = useState(false);
 
   // width to use when sidebar is collapsed
@@ -49,17 +48,51 @@ export default function Sidebar({ open, onClose }) {
       <Toolbar />
       <List>
         <ListItemButton
-          selected={router.pathname === '/workspace'}
-          onClick={() => {
-            router.push('/workspace');
-            onClose();
-          }}
+          selected={router.pathname.startsWith('/workspace')}
+          onClick={() => setOpenSummary(!openSummary)}
         >
           <ListItemIcon>
             <DashboardIcon />
           </ListItemIcon>
-          {!collapsed && <ListItemText primary="Summary" />}
+          {!collapsed && (
+            <>
+              <ListItemText primary="Summary" />
+              {openSummary ? <ExpandLess /> : <ExpandMore />}
+            </>
+          )}
         </ListItemButton>
+        {!collapsed && (
+          <Collapse in={openSummary} timeout="auto" unmountOnExit>
+            <List component="div" disablePadding>
+              <ListItemButton
+                sx={{ pl: 4 }}
+                selected={router.pathname === '/workspace'}
+                onClick={() => {
+                  router.push('/workspace');
+                  onClose();
+                }}
+              >
+                <ListItemIcon>
+                  <DashboardIcon fontSize="small" />
+                </ListItemIcon>
+                <ListItemText primary="Overview" />
+              </ListItemButton>
+              <ListItemButton
+                sx={{ pl: 4 }}
+                selected={router.pathname === '/workspace/detail'}
+                onClick={() => {
+                  router.push('/workspace/detail');
+                  onClose();
+                }}
+              >
+                <ListItemIcon>
+                  <DashboardIcon fontSize="small" />
+                </ListItemIcon>
+                <ListItemText primary="Detail" />
+              </ListItemButton>
+            </List>
+          </Collapse>
+        )}
         <ListItemButton
           selected={router.pathname === '/project-management'}
           onClick={() => {

--- a/client/pages/workspace/detail.tsx
+++ b/client/pages/workspace/detail.tsx
@@ -1,0 +1,49 @@
+// @ts-nocheck
+import { useEffect, useState } from 'react';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+import { DataGrid } from '@mui/x-data-grid';
+import { Layout } from '../../components';
+import { withAuth } from '../../context/AuthContext';
+import { fetchEvents } from '../../models/eventsModel';
+
+function WorkspaceDetail() {
+  const [events, setEvents] = useState([]);
+
+  useEffect(() => {
+    fetchEvents().then(setEvents).catch(console.error);
+  }, []);
+
+  const columns = [
+    { field: 'title', headerName: 'Title', flex: 1 },
+    {
+      field: 'date',
+      headerName: 'Date',
+      width: 150,
+      valueGetter: params => new Date(params.row.date).toLocaleDateString(),
+    },
+  ];
+
+  return (
+    <Layout>
+      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
+        <Typography variant="h5" gutterBottom>
+          Summary Detail
+        </Typography>
+        <Paper>
+          <DataGrid
+            rows={events}
+            columns={columns}
+            getRowId={row => row._id}
+            autoHeight
+            pageSize={25}
+            rowsPerPageOptions={[25]}
+          />
+        </Paper>
+      </Container>
+    </Layout>
+  );
+}
+
+export default withAuth(WorkspaceDetail);

--- a/client/pages/workspace/index.tsx
+++ b/client/pages/workspace/index.tsx
@@ -6,15 +6,15 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
-import { fetchEvents } from '../models/eventsModel';
+import { fetchEvents } from '../../models/eventsModel';
 import Timeline from '@mui/lab/Timeline';
 import TimelineItem from '@mui/lab/TimelineItem';
 import TimelineSeparator from '@mui/lab/TimelineSeparator';
 import TimelineConnector from '@mui/lab/TimelineConnector';
 import TimelineContent from '@mui/lab/TimelineContent';
 import TimelineDot from '@mui/lab/TimelineDot';
-import { withAuth } from '../context/AuthContext';
-import { Layout, SimpleCalendar } from '../components';
+import { withAuth } from '../../context/AuthContext';
+import { Layout, SimpleCalendar } from '../../components';
 
 function Workspace() {
   const [view, setView] = useState('calendar');


### PR DESCRIPTION
## Summary
- split summary menu into overview and detail pages
- implement detail page with table view of events
- move existing workspace page to overview path

## Testing
- `npm --version`
- `npm --prefix client run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854fba8e628832884b963207a121687