### PR TITLE
Refactor budget model by role and level

### DIFF
--- a/client/components/BudgetForm.tsx
+++ b/client/components/BudgetForm.tsx
@@ -7,14 +7,15 @@ import { useState, useEffect } from 'react';
 import api from '../api';
 
 export default function BudgetForm({ onSubmit }) {
-  const [position, setPosition] = useState('');
+  const [role, setRole] = useState('');
+  const [level, setLevel] = useState('');
   const [rate, setRate] = useState('');
-  const [positions, setPositions] = useState([]);
+  const [roles, setRoles] = useState([]);
 
   useEffect(() => {
     async function load() {
-      const { data } = await api.get('/api/v1/positions');
-      setPositions(data);
+      const { data } = await api.get('/api/v1/roles');
+      setRoles(data);
     }
     load();
   }, []);
@@ -22,24 +23,26 @@ export default function BudgetForm({ onSubmit }) {
   const handleSubmit = e => {
     e.preventDefault();
     if (onSubmit) {
-      onSubmit({ position, rate: Number(rate) });
+      onSubmit({ role, level, rate: Number(rate) });
     }
-    setPosition('');
+    setRole('');
+    setLevel('');
     setRate('');
   };
 
   return (
     <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <TextField
-        select
-        label="Position"
-        value={position}
-        onChange={e => setPosition(e.target.value)}
-        required
-      >
-        {positions.map(p => (
-          <MenuItem key={p.value} value={p.value}>
-            {p.label}
+      <TextField select label="Role" value={role} onChange={e => setRole(e.target.value)} required>
+        {roles.map(r => (
+          <MenuItem key={r.name} value={r.name}>
+            {r.name}
+          </MenuItem>
+        ))}
+      </TextField>
+      <TextField select label="Level" value={level} onChange={e => setLevel(e.target.value)} required>
+        {(roles.find(r => r.name === role)?.levels || []).map(l => (
+          <MenuItem key={l} value={l}>
+            {l}
           </MenuItem>
         ))}
       </TextField>

--- a/client/pages/budget-management.tsx
+++ b/client/pages/budget-management.tsx
@@ -23,10 +23,10 @@ function BudgetManagement() {
   const [open, setOpen] = useState(false);
 
   async function loadData() {
-    const [res, budgets, pos] = await Promise.all([
+    const [res, budgets, roles] = await Promise.all([
       api.get('/api/v1/resources'),
       fetchBudgets(),
-      api.get('/api/v1/positions'),
+      api.get('/api/v1/roles'),
     ]);
     const counts = {} as any;
     res.data.forEach(r => {
@@ -34,18 +34,27 @@ function BudgetManagement() {
     });
     const rateMap = {} as any;
     budgets.forEach(b => {
-      rateMap[b.position] = b.rate;
+      const slug = `${b.role} ${b.level}`
+        .toLowerCase()
+        .replace(/\s+/g, '_');
+      rateMap[slug] = b.rate;
     });
-    const rws = pos.data.map(p => {
-      const [role, level] = p.label.split(' - ');
-      return {
-        id: p.value,
-        role,
-        level,
-        count: counts[p.value] || 0,
-        rate: rateMap[p.value] || 0,
-      };
+    const positions: any[] = [];
+    roles.data.forEach(r => {
+      r.levels.forEach((l: string) => {
+        const slug = `${r.name} ${l}`
+          .toLowerCase()
+          .replace(/\s+/g, '_');
+        positions.push({ value: slug, role: r.name, level: l });
+      });
     });
+    const rws = positions.map(p => ({
+      id: p.value,
+      role: p.role,
+      level: p.level,
+      count: counts[p.value] || 0,
+      rate: rateMap[p.value] || 0,
+    }));
     setRows(rws);
   }
 

--- a/service/src/budgets/budgets.service.ts
+++ b/service/src/budgets/budgets.service.ts
@@ -9,7 +9,8 @@ export class BudgetsService {
     return this.repo.findAll().then(budgets =>
       budgets.map(b => ({
         id: b._id.toString(),
-        position: b.position,
+        role: b.role,
+        level: b.level,
         rate: b.rate,
       })),
     );

--- a/service/src/budgets/data/budget.schema.ts
+++ b/service/src/budgets/data/budget.schema.ts
@@ -4,7 +4,10 @@ import { Document } from 'mongoose';
 @Schema({ timestamps: true })
 export class Budget extends Document {
   @Prop({ required: true })
-  position: string;
+  role: string;
+
+  @Prop({ required: true })
+  level: string;
 
   @Prop({ required: true })
   rate: number;

--- a/service/src/budgets/data/budgets.repository.ts
+++ b/service/src/budgets/data/budgets.repository.ts
@@ -4,7 +4,8 @@ import { Model } from 'mongoose';
 import { Budget } from './budget.schema';
 
 export interface CreateBudgetInput {
-  position: string;
+  role: string;
+  level: string;
   rate: number;
 }
 
@@ -13,7 +14,7 @@ export class BudgetsRepository {
   constructor(@InjectModel(Budget.name) private budgetModel: Model<Budget>) {}
 
   findAll(): Promise<Budget[]> {
-    return this.budgetModel.find().sort({ position: 1 }).exec();
+    return this.budgetModel.find().sort({ role: 1, level: 1 }).exec();
   }
 
   create(data: CreateBudgetInput): Promise<Budget> {


### PR DESCRIPTION
## Summary
- break out `Budget` schema into `role` and `level`
- fetch roles in `BudgetForm` and `BudgetManagement`
- compute rate map based on role and level on the client side

## Testing
- `npm run build` in `service`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6854f9f2946c8328bb591e54615f40c1