### PR TITLE
Fix project creation and rename workspace pages

### DIFF
--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -48,7 +48,7 @@ export default function Sidebar({ open, onClose }) {
       <Toolbar />
       <List>
         <ListItemButton
-          selected={router.pathname.startsWith('/workspace')}
+          selected={router.pathname.startsWith('/summary')}
           onClick={() => setOpenSummary(!openSummary)}
         >
           <ListItemIcon>
@@ -66,9 +66,9 @@ export default function Sidebar({ open, onClose }) {
             <List component="div" disablePadding>
               <ListItemButton
                 sx={{ pl: 4 }}
-                selected={router.pathname === '/workspace'}
+                selected={router.pathname === '/summary'}
                 onClick={() => {
-                  router.push('/workspace');
+                  router.push('/summary');
                   onClose();
                 }}
               >
@@ -79,9 +79,9 @@ export default function Sidebar({ open, onClose }) {
               </ListItemButton>
               <ListItemButton
                 sx={{ pl: 4 }}
-                selected={router.pathname === '/workspace/detail'}
+                selected={router.pathname === '/summary/detail'}
                 onClick={() => {
-                  router.push('/workspace/detail');
+                  router.push('/summary/detail');
                   onClose();
                 }}
               >

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -34,7 +34,11 @@ function ProjectManagement() {
   }, [token]);
 
   const handleCreate = async data => {
-    await api.post('/api/v1/projects', data);
+    const payload = {
+      ...data,
+      resources: (data.members?.length || 0) + (data.lead ? 1 : 0),
+    };
+    await api.post('/api/v1/projects', payload);
     setOpen(false);
     loadData();
   };

--- a/client/pages/summary/detail.tsx
+++ b/client/pages/summary/detail.tsx
@@ -8,7 +8,7 @@ import { Layout } from '../../components';
 import { withAuth } from '../../context/AuthContext';
 import { fetchEvents } from '../../models/eventsModel';
 
-function WorkspaceDetail() {
+function SummaryDetail() {
   const [events, setEvents] = useState([]);
 
   useEffect(() => {
@@ -21,7 +21,8 @@ function WorkspaceDetail() {
       field: 'date',
       headerName: 'Date',
       width: 150,
-      valueGetter: params => new Date(params.row.date).toLocaleDateString(),
+      valueGetter: params =>
+        params.row?.date ? new Date(params.row.date).toLocaleDateString() : '',
     },
   ];
 
@@ -46,4 +47,4 @@ function WorkspaceDetail() {
   );
 }
 
-export default withAuth(WorkspaceDetail);
+export default withAuth(SummaryDetail);

--- a/client/pages/summary/index.tsx
+++ b/client/pages/summary/index.tsx
@@ -16,7 +16,7 @@ import TimelineDot from '@mui/lab/TimelineDot';
 import { withAuth } from '../../context/AuthContext';
 import { Layout, SimpleCalendar } from '../../components';
 
-function Workspace() {
+function Summary() {
   const [view, setView] = useState('calendar');
   const [events, setEvents] = useState([]);
 
@@ -29,7 +29,7 @@ function Workspace() {
       <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
         <Paper sx={{ p: 2 }} elevation={3}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-          <Typography variant="h5">Workspace</Typography>
+          <Typography variant="h5">Summary</Typography>
           <ToggleButtonGroup
             value={view}
             exclusive
@@ -63,4 +63,4 @@ function Workspace() {
   );
 }
 
-export default withAuth(Workspace);
+export default withAuth(Summary);

--- a/client/presenters/loginPresenter.ts
+++ b/client/presenters/loginPresenter.ts
@@ -16,7 +16,7 @@ export function useLoginPresenter() {
     setLoading(true);
     const data = await loginRequest(username, password);
     login(data.accessToken, data.refreshToken);
-    router.push('/workspace');
+    router.push('/summary');
     setLoading(false);
   }
 


### PR DESCRIPTION
## Summary
- rename `/workspace` pages to `/summary`
- adjust sidebar and login flow for `/summary`
- guard against missing date in summary detail page
- include resource count when creating projects

## Testing
- `npm run build` in `service`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6854fdde014883288f36cc1f4b775b21