### PR TITLE
Fetch budget data via API

### DIFF
--- a/client/models/budgetModel.ts
+++ b/client/models/budgetModel.ts
@@ -9,3 +9,8 @@ export async function createBudget(budget) {
   const { data } = await api.post('/api/v1/budgets', budget);
   return data;
 }
+
+export async function fetchBudgetOverview() {
+  const { data } = await api.get('/api/v1/budgets/overview');
+  return data;
+}

--- a/client/pages/budget-management.tsx
+++ b/client/pages/budget-management.tsx
@@ -4,16 +4,14 @@ import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
 import IconButton from '@mui/material/IconButton';
-import Stack from '@mui/material/Stack';
 import EditIcon from '@mui/icons-material/Edit';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import { DataGrid } from '@mui/x-data-grid';
-import api from '../api';
 import { Layout, Popup, BudgetForm } from '../components';
 import { withAuth, useAuth } from '../context/AuthContext';
-import { fetchBudgets, createBudget } from '../models/budgetModel';
+import { createBudget, fetchBudgetOverview } from '../models/budgetModel';
 
 function BudgetManagement() {
   const { token } = useAuth();
@@ -23,39 +21,8 @@ function BudgetManagement() {
   const [open, setOpen] = useState(false);
 
   async function loadData() {
-    const [res, budgets, roles] = await Promise.all([
-      api.get('/api/v1/resources'),
-      fetchBudgets(),
-      api.get('/api/v1/roles'),
-    ]);
-    const counts = {} as any;
-    res.data.forEach(r => {
-      counts[r.position] = (counts[r.position] || 0) + 1;
-    });
-    const rateMap = {} as any;
-    budgets.forEach(b => {
-      const slug = `${b.role} ${b.level}`
-        .toLowerCase()
-        .replace(/\s+/g, '_');
-      rateMap[slug] = b.rate;
-    });
-    const positions: any[] = [];
-    roles.data.forEach(r => {
-      r.levels.forEach((l: string) => {
-        const slug = `${r.name} ${l}`
-          .toLowerCase()
-          .replace(/\s+/g, '_');
-        positions.push({ value: slug, role: r.name, level: l });
-      });
-    });
-    const rws = positions.map(p => ({
-      id: p.value,
-      role: p.role,
-      level: p.level,
-      count: counts[p.value] || 0,
-      rate: rateMap[p.value] || 0,
-    }));
-    setRows(rws);
+    const data = await fetchBudgetOverview();
+    setRows(data);
   }
 
   useEffect(() => {

--- a/service/src/budgets/budgets.controller.ts
+++ b/service/src/budgets/budgets.controller.ts
@@ -11,6 +11,11 @@ export class BudgetsController {
     return this.service.getBudgets();
   }
 
+  @Get('overview')
+  getOverview() {
+    return this.service.getOverview();
+  }
+
   @Post()
   create(@Body() body: CreateBudgetInput) {
     return this.service.create(body);

--- a/service/src/budgets/budgets.module.ts
+++ b/service/src/budgets/budgets.module.ts
@@ -4,9 +4,19 @@ import { BudgetsController } from './budgets.controller';
 import { BudgetsService } from './budgets.service';
 import { BudgetsRepository } from './data/budgets.repository';
 import { Budget, BudgetSchema } from './data/budget.schema';
+import { Resource, ResourceSchema } from '../resources/data/resource.schema';
+import { ResourcesModule } from '../resources/resources.module';
+import { RolesModule } from '../roles/roles.module';
 
 @Module({
-  imports: [MongooseModule.forFeature([{ name: Budget.name, schema: BudgetSchema }])],
+  imports: [
+    MongooseModule.forFeature([
+      { name: Budget.name, schema: BudgetSchema },
+      { name: Resource.name, schema: ResourceSchema },
+    ]),
+    ResourcesModule,
+    RolesModule,
+  ],
   controllers: [BudgetsController],
   providers: [BudgetsService, BudgetsRepository],
 })

--- a/service/src/budgets/budgets.service.ts
+++ b/service/src/budgets/budgets.service.ts
@@ -1,9 +1,17 @@
 import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
 import { BudgetsRepository, CreateBudgetInput } from './data/budgets.repository';
+import { Resource } from '../resources/data/resource.schema';
+import { RolesService } from '../roles/roles.service';
 
 @Injectable()
 export class BudgetsService {
-  constructor(private readonly repo: BudgetsRepository) {}
+  constructor(
+    private readonly repo: BudgetsRepository,
+    @InjectModel(Resource.name) private readonly resourceModel: Model<Resource>,
+    private readonly rolesService: RolesService,
+  ) {}
 
   getBudgets() {
     return this.repo.findAll().then(budgets =>
@@ -18,5 +26,40 @@ export class BudgetsService {
 
   create(data: CreateBudgetInput) {
     return this.repo.create(data);
+  }
+
+  async getOverview() {
+    const [resources, budgets, roles] = await Promise.all([
+      this.resourceModel.find().exec(),
+      this.repo.findAll(),
+      this.rolesService.getRoles(),
+    ]);
+
+    const counts: Record<string, number> = {};
+    resources.forEach(r => {
+      counts[r.position] = (counts[r.position] || 0) + 1;
+    });
+
+    const rateMap: Record<string, number> = {};
+    budgets.forEach(b => {
+      const slug = `${b.role} ${b.level}`.toLowerCase().replace(/\s+/g, '_');
+      rateMap[slug] = b.rate;
+    });
+
+    const positions: any[] = [];
+    roles.forEach(role => {
+      role.levels.forEach((level: string) => {
+        const slug = `${role.name} ${level}`.toLowerCase().replace(/\s+/g, '_');
+        positions.push({ slug, role: role.name, level });
+      });
+    });
+
+    return positions.map(p => ({
+      id: p.slug,
+      role: p.role,
+      level: p.level,
+      count: counts[p.slug] || 0,
+      rate: rateMap[p.slug] || 0,
+    }));
   }
 }

--- a/service/src/resources/resources.module.ts
+++ b/service/src/resources/resources.module.ts
@@ -9,5 +9,6 @@ import { Resource, ResourceSchema } from './data/resource.schema';
   imports: [MongooseModule.forFeature([{ name: Resource.name, schema: ResourceSchema }])],
   controllers: [ResourcesController],
   providers: [ResourcesService, ResourcesRepository],
+  exports: [ResourcesService],
 })
 export class ResourcesModule {}


### PR DESCRIPTION
## Summary
- expose ResourcesService for use in other modules
- extend budgets module to include resources and roles
- add budget overview endpoint to API
- aggregate budget data in BudgetsService
- update frontend to load budget overview from API

## Testing
- `npm -C client run build`
- `npm -C service run build`


------
https://chatgpt.com/codex/tasks/task_e_685500b1fe848328a575fbc845e6234d