### PR TITLE
Fix DataGrid value getters

### DIFF
--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -48,12 +48,16 @@ function ProjectManagement() {
       field: 'no',
       headerName: 'No.',
       width: 70,
-      valueGetter: params =>
-        params.api?.getRowIndexRelativeToVisibleRows
-          ? params.api.getRowIndexRelativeToVisibleRows(params.id) + 1
-          : params.api?.getRowIndex
-          ? params.api.getRowIndex(params.id) + 1
-          : '',
+      valueGetter: params => {
+        if (!params) return '';
+        if (typeof params.rowIndex === 'number') {
+          return params.rowIndex + 1;
+        }
+        if (typeof params.id === 'number') {
+          return params.id;
+        }
+        return '';
+      },
     },
     { field: 'name', headerName: 'Name', flex: 1 },
     { field: 'description', headerName: 'Description', flex: 1 },

--- a/client/pages/team-setting/team.tsx
+++ b/client/pages/team-setting/team.tsx
@@ -47,13 +47,29 @@ function TeamPage() {
       field: 'totalMember',
       headerName: 'Total Member',
       width: 120,
-      valueGetter: params => params.row.members.length,
+      valueGetter: params => {
+        if (!params) return '';
+        if (Array.isArray(params.row?.members)) {
+          return params.row.members.length;
+        }
+        return '';
+      },
     },
     {
       field: 'createdAt',
       headerName: 'Create Date',
       width: 150,
-      valueGetter: params => format(new Date(params.row.createdAt), 'yyyy-MM-dd'),
+      valueGetter: params => {
+        if (!params) return '';
+        if (params.row?.createdAt) {
+          try {
+            return format(new Date(params.row.createdAt), 'yyyy-MM-dd');
+          } catch {
+            return '';
+          }
+        }
+        return '';
+      },
     },
     {
       field: 'actions',


### PR DESCRIPTION
## Summary
- make project management grid numbering more defensive
- fix null safety in team page value getters

## Testing
- `npm run build` in `client`
- `npm run build` in `service`

------
https://chatgpt.com/codex/tasks/task_e_6855066ed0548328a32ed82d9aacf802