### PR TITLE
Add collapsible budget table

### DIFF
--- a/client/components/BudgetTable.tsx
+++ b/client/components/BudgetTable.tsx
@@ -1,0 +1,93 @@
+// @ts-nocheck
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Collapse from '@mui/material/Collapse';
+import IconButton from '@mui/material/IconButton';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import EditIcon from '@mui/icons-material/Edit';
+
+export default function BudgetTable({ data, onEdit }) {
+  const groups = data.reduce((acc, item) => {
+    const list = acc[item.role] || [];
+    list.push(item);
+    acc[item.role] = list;
+    return acc;
+  }, {});
+
+  return (
+    <TableContainer component={Paper}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell />
+            <TableCell>Role</TableCell>
+            <TableCell align="right">Total Count</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {Object.entries(groups).map(([role, rows]) => (
+            <RoleRow key={role} role={role} rows={rows} onEdit={onEdit} />
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+function RoleRow({ role, rows, onEdit }) {
+  const [open, setOpen] = useState(false);
+  const total = rows.reduce((sum, r) => sum + (r.count || 0), 0);
+  return (
+    <>
+      <TableRow>
+        <TableCell>
+          <IconButton size="small" onClick={() => setOpen(!open)}>
+            {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+          </IconButton>
+        </TableCell>
+        <TableCell>{role}</TableCell>
+        <TableCell align="right">{total}</TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={3}>
+          <Collapse in={open} timeout="auto" unmountOnExit>
+            <Box sx={{ margin: 1 }}>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Level</TableCell>
+                    <TableCell align="right">Count</TableCell>
+                    <TableCell align="right">Baht/MD</TableCell>
+                    <TableCell align="right">Action</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {rows.map(r => (
+                    <TableRow key={r.id}>
+                      <TableCell>{r.level}</TableCell>
+                      <TableCell align="right">{r.count}</TableCell>
+                      <TableCell align="right">{r.rate}</TableCell>
+                      <TableCell align="right">
+                        <IconButton size="small" onClick={() => onEdit(r)}>
+                          <EditIcon fontSize="small" />
+                        </IconButton>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </Box>
+          </Collapse>
+        </TableCell>
+      </TableRow>
+    </>
+  );
+}

--- a/client/components/index.tsx
+++ b/client/components/index.tsx
@@ -12,3 +12,4 @@ export { default as SimpleCalendar } from './SimpleCalendar';
 export { default as TeamForm } from './TeamForm';
 export { default as ProjectForm } from './ProjectForm';
 export { default as BudgetForm } from './BudgetForm';
+export { default as BudgetTable } from './BudgetTable';

--- a/client/pages/budget-management.tsx
+++ b/client/pages/budget-management.tsx
@@ -2,14 +2,10 @@
 import { useEffect, useState } from 'react';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
-import Paper from '@mui/material/Paper';
-import IconButton from '@mui/material/IconButton';
-import EditIcon from '@mui/icons-material/Edit';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
-import { DataGrid } from '@mui/x-data-grid';
-import { Layout, Popup, BudgetForm } from '../components';
+import { Layout, Popup, BudgetForm, BudgetTable } from '../components';
 import { withAuth, useAuth } from '../context/AuthContext';
 import { createBudget, fetchBudgetOverview } from '../models/budgetModel';
 
@@ -40,28 +36,10 @@ function BudgetManagement() {
     loadData();
   };
 
-  const columns = [
-    { field: 'role', headerName: 'Role', flex: 1 },
-    { field: 'level', headerName: 'Level', width: 130 },
-    { field: 'count', headerName: 'Count', width: 100 },
-    { field: 'rate', headerName: 'Baht/MD', width: 120 },
-    {
-      field: 'actions',
-      headerName: 'Action',
-      width: 100,
-      renderCell: params => (
-        <IconButton
-          size="small"
-          onClick={() => {
-            setEditId(params.row.id);
-            setRate(String(params.row.rate));
-          }}
-        >
-          <EditIcon fontSize="small" />
-        </IconButton>
-      ),
-    },
-  ];
+  const handleEdit = row => {
+    setEditId(row.id);
+    setRate(String(row.rate));
+  };
 
   return (
     <Layout>
@@ -72,16 +50,7 @@ function BudgetManagement() {
             New Rate
           </Button>
         </Box>
-        <Paper>
-          <DataGrid
-            rows={rows}
-            columns={columns}
-            autoHeight
-            pageSize={25}
-            rowsPerPageOptions={[25]}
-            disableSelectionOnClick
-          />
-        </Paper>
+        <BudgetTable data={rows} onEdit={handleEdit} />
         <Popup open={!!editId} onClose={() => setEditId(null)} title="Edit Rate">
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
             <TextField


### PR DESCRIPTION
## Summary
- introduce `BudgetTable` for expandable role rows
- use the new table in Budget Management page
- export the new component

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685505cdc754832887d2c8ba5a66d208