### PR TITLE
Improve popup layout

### DIFF
--- a/client/components/BudgetForm.tsx
+++ b/client/components/BudgetForm.tsx
@@ -31,7 +31,15 @@ export default function BudgetForm({ onSubmit }) {
   };
 
   return (
-    <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{
+        display: 'grid',
+        gap: 2,
+        gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+      }}
+    >
       <TextField select label="Role" value={role} onChange={e => setRole(e.target.value)} required>
         {roles.map(r => (
           <MenuItem key={r.name} value={r.name}>
@@ -53,7 +61,7 @@ export default function BudgetForm({ onSubmit }) {
         onChange={e => setRate(e.target.value)}
         required
       />
-      <Button variant="contained" type="submit">
+      <Button variant="contained" type="submit" sx={{ gridColumn: 'span 2' }}>
         Create
       </Button>
     </Box>

--- a/client/components/Popup.tsx
+++ b/client/components/Popup.tsx
@@ -5,7 +5,12 @@ import DialogContent from '@mui/material/DialogContent';
 
 export default function Popup({ open, onClose, title, children }) {
   return (
-    <Dialog open={open} onClose={onClose}>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      PaperProps={{ sx: { width: { xs: '90%', md: '50%' } } }}
+    >
       {title && <DialogTitle>{title}</DialogTitle>}
       <DialogContent>{children}</DialogContent>
     </Dialog>

--- a/client/components/ProjectForm.tsx
+++ b/client/components/ProjectForm.tsx
@@ -37,13 +37,22 @@ export default function ProjectForm({ users = [], onSubmit }) {
   };
 
   return (
-    <Box component="form" onSubmit={handleSubmit} sx={{ display: 'grid', gap: 2 }}>
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{
+        display: 'grid',
+        gap: 2,
+        gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+      }}
+    >
       <TextField label="Name" value={name} onChange={e => setName(e.target.value)} required />
       <TextField
         label="Description"
         value={description}
         onChange={e => setDescription(e.target.value)}
         multiline
+        sx={{ gridColumn: 'span 2' }}
       />
       <DatePicker
         label="Start Date"
@@ -65,6 +74,7 @@ export default function ProjectForm({ users = [], onSubmit }) {
         value={members}
         onChange={(_, v) => setMembers(v)}
         renderInput={params => <TextField {...params} label="Members" />}
+        sx={{ gridColumn: 'span 2' }}
       />
       <TextField
         label="Manday"
@@ -73,7 +83,9 @@ export default function ProjectForm({ users = [], onSubmit }) {
         onChange={e => setManday(e.target.value)}
         required
       />
-      <Button type="submit" variant="contained">Create</Button>
+      <Button type="submit" variant="contained" sx={{ gridColumn: 'span 2' }}>
+        Create
+      </Button>
     </Box>
   );
 }

--- a/client/components/ResourceForm.tsx
+++ b/client/components/ResourceForm.tsx
@@ -45,7 +45,15 @@ export default function ResourceForm({ onSubmit }) {
   const levels = Array.from(new Set(positions.map(p => p.label.split(' - ')[1])));
 
   return (
-    <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{
+        display: 'grid',
+        gap: 2,
+        gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+      }}
+    >
       <Input label="Name" value={name} onChange={e => setName(e.target.value)} required />
       <Input label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} required />
       <TextField select label="Role" value={role} onChange={e => setRole(e.target.value)} required>
@@ -68,7 +76,9 @@ export default function ResourceForm({ onSubmit }) {
         onChange={setStartDate}
         renderInput={params => <TextField {...params} required />}
       />
-      <Button variant="contained" type="submit">Create</Button>
+      <Button variant="contained" type="submit" sx={{ gridColumn: 'span 2' }}>
+        Create
+      </Button>
     </Box>
   );
 }

--- a/client/components/TeamForm.tsx
+++ b/client/components/TeamForm.tsx
@@ -28,7 +28,15 @@ export default function TeamForm({ users = [], onSubmit }) {
   };
 
   return (
-    <Box component="form" onSubmit={handleSubmit} sx={{ display: 'grid', gap: 2 }}>
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{
+        display: 'grid',
+        gap: 2,
+        gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+      }}
+    >
       <TextField label="Team Name" value={name} onChange={e => setName(e.target.value)} required />
       <Autocomplete
         options={users}
@@ -37,7 +45,7 @@ export default function TeamForm({ users = [], onSubmit }) {
         onChange={(_, v) => setLead(v)}
         renderInput={params => <TextField {...params} label="Team Lead" />}
       />
-      <FormGroup>
+      <FormGroup sx={{ gridColumn: 'span 2' }}>
         {users.map(u => (
           <FormControlLabel
             key={u.id}
@@ -46,7 +54,9 @@ export default function TeamForm({ users = [], onSubmit }) {
           />
         ))}
       </FormGroup>
-      <Button variant="contained" type="submit">Create</Button>
+      <Button variant="contained" type="submit" sx={{ gridColumn: 'span 2' }}>
+        Create
+      </Button>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- adjust Popup width to half the page for better UX
- switch all creation forms to responsive grid layout
- span wide inputs and buttons across the grid

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68550df50294832892dc6a058f2ae844