### PR TITLE
Improve service duration display

### DIFF
--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -87,7 +87,7 @@ function TeamSetting() {
       valueGetter: (_value, row) => {
         if (row && row.startDate) {
           try {
-            return differenceInYears(new Date(), new Date(row.startDate));
+            return getServiceDuration(row.startDate);
           } catch {
             return '';
           }


### PR DESCRIPTION
## Summary
- show the full service duration on the Resources table

## Testing
- `npm run build` in `client`
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_68550ea7be648328a8acf0e41139c216