### PR TITLE
Add budget editing API and update form

### DIFF
--- a/client/components/BudgetForm.tsx
+++ b/client/components/BudgetForm.tsx
@@ -6,11 +6,23 @@ import Button from '@mui/material/Button';
 import { useState, useEffect } from 'react';
 import api from '../api';
 
-export default function BudgetForm({ onSubmit }) {
-  const [role, setRole] = useState('');
-  const [level, setLevel] = useState('');
-  const [rate, setRate] = useState('');
+interface Props {
+  onSubmit?: (data: { role: string; level: string; rate: number }) => void;
+  initial?: { role?: string; level?: string; rate?: number };
+  submitText?: string;
+}
+
+export default function BudgetForm({ onSubmit, initial, submitText = 'Create' }: Props) {
+  const [role, setRole] = useState(initial?.role || '');
+  const [level, setLevel] = useState(initial?.level || '');
+  const [rate, setRate] = useState(initial?.rate != null ? String(initial.rate) : '');
   const [roles, setRoles] = useState([]);
+
+  useEffect(() => {
+    setRole(initial?.role || '');
+    setLevel(initial?.level || '');
+    setRate(initial?.rate != null ? String(initial.rate) : '');
+  }, [initial]);
 
   useEffect(() => {
     async function load() {
@@ -25,9 +37,6 @@ export default function BudgetForm({ onSubmit }) {
     if (onSubmit) {
       onSubmit({ role, level, rate: Number(rate) });
     }
-    setRole('');
-    setLevel('');
-    setRate('');
   };
 
   return (
@@ -54,7 +63,7 @@ export default function BudgetForm({ onSubmit }) {
         required
       />
       <Button variant="contained" type="submit">
-        Create
+        {submitText}
       </Button>
     </Box>
   );

--- a/client/models/budgetModel.ts
+++ b/client/models/budgetModel.ts
@@ -10,6 +10,11 @@ export async function createBudget(budget) {
   return data;
 }
 
+export async function updateBudget(id, budget) {
+  const { data } = await api.patch(`/api/v1/budgets/${id}`, budget);
+  return data;
+}
+
 export async function fetchBudgetOverview() {
   const { data } = await api.get('/api/v1/budgets/overview');
   return data;

--- a/service/src/budgets/budgets.controller.ts
+++ b/service/src/budgets/budgets.controller.ts
@@ -1,6 +1,6 @@
-import { Body, Controller, Get, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post, Patch, Param } from '@nestjs/common';
 import { BudgetsService } from './budgets.service';
-import { CreateBudgetInput } from './data/budgets.repository';
+import { CreateBudgetInput, UpdateBudgetInput } from './data/budgets.repository';
 
 @Controller('budgets')
 export class BudgetsController {
@@ -19,5 +19,10 @@ export class BudgetsController {
   @Post()
   create(@Body() body: CreateBudgetInput) {
     return this.service.create(body);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() body: UpdateBudgetInput) {
+    return this.service.update(id, body);
   }
 }

--- a/service/src/budgets/budgets.service.ts
+++ b/service/src/budgets/budgets.service.ts
@@ -1,7 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
-import { BudgetsRepository, CreateBudgetInput } from './data/budgets.repository';
+import {
+  BudgetsRepository,
+  CreateBudgetInput,
+  UpdateBudgetInput,
+} from './data/budgets.repository';
 import { Resource } from '../resources/data/resource.schema';
 import { RolesService } from '../roles/roles.service';
 
@@ -28,6 +32,10 @@ export class BudgetsService {
     return this.repo.create(data);
   }
 
+  update(id: string, data: UpdateBudgetInput) {
+    return this.repo.update(id, data);
+  }
+
   async getOverview() {
     const [resources, budgets, roles] = await Promise.all([
       this.resourceModel.find().exec(),
@@ -41,9 +49,11 @@ export class BudgetsService {
     });
 
     const rateMap: Record<string, number> = {};
+    const idMap: Record<string, string> = {};
     budgets.forEach(b => {
       const slug = `${b.role} ${b.level}`.toLowerCase().replace(/\s+/g, '_');
       rateMap[slug] = b.rate;
+      idMap[slug] = b._id.toString();
     });
 
     const positions: any[] = [];
@@ -56,6 +66,7 @@ export class BudgetsService {
 
     return positions.map(p => ({
       id: p.slug,
+      budgetId: idMap[p.slug],
       role: p.role,
       level: p.level,
       count: counts[p.slug] || 0,

--- a/service/src/budgets/data/budgets.repository.ts
+++ b/service/src/budgets/data/budgets.repository.ts
@@ -9,6 +9,12 @@ export interface CreateBudgetInput {
   rate: number;
 }
 
+export interface UpdateBudgetInput {
+  role?: string;
+  level?: string;
+  rate?: number;
+}
+
 @Injectable()
 export class BudgetsRepository {
   constructor(@InjectModel(Budget.name) private budgetModel: Model<Budget>) {}
@@ -20,5 +26,11 @@ export class BudgetsRepository {
   create(data: CreateBudgetInput): Promise<Budget> {
     const budget = new this.budgetModel(data);
     return budget.save();
+  }
+
+  update(id: string, data: UpdateBudgetInput): Promise<Budget | null> {
+    return this.budgetModel
+      .findByIdAndUpdate(id, data, { new: true })
+      .exec();
   }
 }


### PR DESCRIPTION
## Summary
- support updating budgets in service API
- include budgetId in budget overview
- add updateBudget client call
- make BudgetForm support initial values and custom submit text
- enable editing full budget record in budget management page

## Testing
- `npm run build` in `service`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_68550f40a64c832884c8ad996467d63f