### PR TITLE
Add edit and delete actions to resources table

### DIFF
--- a/client/components/ResourceForm.tsx
+++ b/client/components/ResourceForm.tsx
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
 import MenuItem from '@mui/material/MenuItem';
@@ -9,13 +8,13 @@ import { useState, useEffect } from 'react';
 import { Input } from '.';
 import api from '../api';
 
-export default function ResourceForm({ onSubmit }) {
-  const [name, setName] = useState('');
-  const [email, setEmail] = useState('');
+export default function ResourceForm({ onSubmit, initial, submitText = 'Create' }) {
+  const [name, setName] = useState(initial?.name || '');
+  const [email, setEmail] = useState(initial?.email || '');
   const [role, setRole] = useState('');
   const [level, setLevel] = useState('');
   const [positions, setPositions] = useState([]);
-  const [startDate, setStartDate] = useState(null);
+  const [startDate, setStartDate] = useState(initial?.startDate ? new Date(initial.startDate) : null);
 
   useEffect(() => {
     async function loadPositions() {
@@ -24,6 +23,23 @@ export default function ResourceForm({ onSubmit }) {
     }
     loadPositions();
   }, []);
+
+  useEffect(() => {
+    setName(initial?.name || '');
+    setEmail(initial?.email || '');
+    setStartDate(initial?.startDate ? new Date(initial.startDate) : null);
+    if (initial?.position && positions.length > 0) {
+      const pos = positions.find(p => p.value === initial.position);
+      if (pos) {
+        const [r, l] = pos.label.split(' - ');
+        setRole(r || '');
+        setLevel(l || '');
+      }
+    } else {
+      setRole('');
+      setLevel('');
+    }
+  }, [initial, positions]);
 
   function handleSubmit(e) {
     e.preventDefault();
@@ -34,11 +50,6 @@ export default function ResourceForm({ onSubmit }) {
     if (onSubmit) {
       onSubmit({ name, email, position, startDate });
     }
-    setName('');
-    setEmail('');
-    setRole('');
-    setLevel('');
-    setStartDate(null);
   }
 
   const roles = Array.from(new Set(positions.map(p => p.label.split(' - ')[0])));
@@ -77,7 +88,7 @@ export default function ResourceForm({ onSubmit }) {
         renderInput={params => <TextField {...params} required />}
       />
       <Button variant="contained" type="submit" sx={{ gridColumn: 'span 2' }}>
-        Create
+        {submitText}
       </Button>
     </Box>
   );

--- a/client/models/resourceModel.ts
+++ b/client/models/resourceModel.ts
@@ -1,0 +1,21 @@
+import api from '../api';
+
+export async function fetchResources() {
+  const { data } = await api.get('/api/v1/resources');
+  return data;
+}
+
+export async function createResource(resource) {
+  const { data } = await api.post('/api/v1/resources', resource);
+  return data;
+}
+
+export async function updateResource(id, resource) {
+  const { data } = await api.patch(`/api/v1/resources/${id}`, resource);
+  return data;
+}
+
+export async function deleteResource(id) {
+  const { data } = await api.delete(`/api/v1/resources/${id}`);
+  return data;
+}

--- a/service/src/resources/data/resources.repository.ts
+++ b/service/src/resources/data/resources.repository.ts
@@ -10,6 +10,13 @@ export interface CreateResourceInput {
   startDate?: Date;
 }
 
+export interface UpdateResourceInput {
+  name?: string;
+  email?: string;
+  position?: string;
+  startDate?: Date;
+}
+
 @Injectable()
 export class ResourcesRepository {
   constructor(@InjectModel(Resource.name) private resourceModel: Model<Resource>) {}
@@ -21,5 +28,15 @@ export class ResourcesRepository {
   create(data: CreateResourceInput): Promise<Resource> {
     const res = new this.resourceModel(data);
     return res.save();
+  }
+
+  update(id: string, data: UpdateResourceInput): Promise<Resource | null> {
+    return this.resourceModel
+      .findByIdAndUpdate(id, data, { new: true })
+      .exec();
+  }
+
+  remove(id: string): Promise<Resource | null> {
+    return this.resourceModel.findByIdAndDelete(id).exec();
   }
 }

--- a/service/src/resources/resources.controller.ts
+++ b/service/src/resources/resources.controller.ts
@@ -1,6 +1,17 @@
-import { Body, Controller, Get, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Param,
+} from '@nestjs/common';
 import { ResourcesService } from './resources.service';
-import { CreateResourceInput } from './data/resources.repository';
+import {
+  CreateResourceInput,
+  UpdateResourceInput,
+} from './data/resources.repository';
 
 @Controller('resources')
 export class ResourcesController {
@@ -14,5 +25,15 @@ export class ResourcesController {
   @Post()
   create(@Body() body: CreateResourceInput) {
     return this.service.create(body);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() body: UpdateResourceInput) {
+    return this.service.update(id, body);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
   }
 }

--- a/service/src/resources/resources.service.ts
+++ b/service/src/resources/resources.service.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { ResourcesRepository, CreateResourceInput } from './data/resources.repository';
+import {
+  ResourcesRepository,
+  CreateResourceInput,
+  UpdateResourceInput,
+} from './data/resources.repository';
 
 @Injectable()
 export class ResourcesService {
@@ -19,5 +23,13 @@ export class ResourcesService {
 
   create(data: CreateResourceInput) {
     return this.repo.create(data);
+  }
+
+  update(id: string, data: UpdateResourceInput) {
+    return this.repo.update(id, data);
+  }
+
+  remove(id: string) {
+    return this.repo.remove(id);
   }
 }


### PR DESCRIPTION
## Summary
- implement update and delete operations in the resources repository, service and controller
- create a `resourceModel` helper for the client
- enhance `ResourceForm` to support editing
- add edit/delete actions to the Resources table page

## Testing
- `npm run build` in `service` *(fails: `nest` not found)*
- `npm run build` in `client` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855143926c083289bccc426c863eedf