### PR TITLE
Enable project lead name and detail page

### DIFF
--- a/client/components/ProjectForm.tsx
+++ b/client/components/ProjectForm.tsx
@@ -22,7 +22,7 @@ export default function ProjectForm({ users = [], onSubmit }) {
         description,
         start,
         end: start,
-        manday: Number(manday),
+        ...(manday ? { manday: Number(manday) } : {}),
         priority: 1,
         lead: lead?.id,
         members: members.map(m => m.id),
@@ -81,7 +81,6 @@ export default function ProjectForm({ users = [], onSubmit }) {
         type="number"
         value={manday}
         onChange={e => setManday(e.target.value)}
-        required
       />
       <Button type="submit" variant="contained" sx={{ gridColumn: 'span 2' }}>
         Create

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
 import Container from '@mui/material/Container';
@@ -17,6 +18,7 @@ import { Layout, Popup, ProjectForm } from '../components';
 import { withAuth, useAuth } from '../context/AuthContext';
 
 function ProjectManagement() {
+  const router = useRouter();
   const { token } = useAuth();
   const [projects, setProjects] = useState([]);
   const [users, setUsers] = useState([]);
@@ -60,7 +62,7 @@ function ProjectManagement() {
       field: 'lead',
       headerName: 'Lead',
       flex: 1,
-      valueGetter: (_value, row) => row.lead || '',
+      valueGetter: (_value, row) => row.lead?.name || '',
     },
     { field: 'status', headerName: 'Status', flex: 1 },
     {
@@ -123,6 +125,7 @@ function ProjectManagement() {
             pageSize={25}
             rowsPerPageOptions={[25]}
             autoHeight
+            onRowClick={params => router.push(`/project/${params.row._id}`)}
           />
         </Paper>
         <Popup open={open} onClose={() => setOpen(false)} title="Add Project">

--- a/client/pages/project/[id].tsx
+++ b/client/pages/project/[id].tsx
@@ -1,0 +1,64 @@
+// @ts-nocheck
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+import Box from '@mui/material/Box';
+import api from '../../api';
+import { Layout } from '../../components';
+import { withAuth } from '../../context/AuthContext';
+
+function ProjectDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [project, setProject] = useState(null);
+
+  useEffect(() => {
+    if (id) {
+      api.get(`/api/v1/projects/${id}`).then(res => setProject(res.data));
+    }
+  }, [id]);
+
+  if (!project) {
+    return (
+      <Layout>
+        <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
+          <Typography>Loading...</Typography>
+        </Container>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
+        <Typography variant="h5" gutterBottom>
+          {project.name}
+        </Typography>
+        <Paper sx={{ p: 2 }}>
+          <Box sx={{ display: 'grid', rowGap: 1 }}>
+            <Typography>
+              <strong>Description:</strong> {project.description}
+            </Typography>
+            <Typography>
+              <strong>Lead:</strong> {project.lead?.name || ''}
+            </Typography>
+            <Typography>
+              <strong>Status:</strong> {project.status || ''}
+            </Typography>
+            <Typography>
+              <strong>Manday:</strong> {project.manday ?? ''}
+            </Typography>
+            <Typography>
+              <strong>Start:</strong>{' '}
+              {project.start ? new Date(project.start).toLocaleDateString() : ''}
+            </Typography>
+          </Box>
+        </Paper>
+      </Container>
+    </Layout>
+  );
+}
+
+export default withAuth(ProjectDetail);

--- a/service/src/projects/data/project.schema.ts
+++ b/service/src/projects/data/project.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Document } from 'mongoose';
+import { Document, Types } from 'mongoose';
 
 @Schema({ timestamps: true })
 export class Project extends Document {
@@ -18,14 +18,14 @@ export class Project extends Document {
   @Prop({ required: true })
   end: Date;
 
-  @Prop({ required: true })
+  @Prop()
   manday: number;
 
   @Prop({ required: true })
   priority: number;
 
-  @Prop()
-  lead: string;
+  @Prop({ type: Types.ObjectId, ref: 'Resource' })
+  lead: Types.ObjectId;
 
   @Prop()
   status: string;

--- a/service/src/projects/data/projects.repository.ts
+++ b/service/src/projects/data/projects.repository.ts
@@ -9,7 +9,7 @@ export interface CreateProjectInput {
   resources: number;
   start: Date;
   end: Date;
-  manday: number;
+  manday?: number;
   priority: number;
   lead?: string;
   status?: string;
@@ -21,7 +21,11 @@ export class ProjectsRepository {
   constructor(@InjectModel(Project.name) private projectModel: Model<Project>) {}
 
   findAll(): Promise<Project[]> {
-    return this.projectModel.find().sort({ start: 1 }).exec();
+    return this.projectModel.find().sort({ start: 1 }).populate('lead', 'name').exec();
+  }
+
+  findOne(id: string): Promise<Project | null> {
+    return this.projectModel.findById(id).populate('lead', 'name').exec();
   }
 
   create(data: CreateProjectInput): Promise<Project> {

--- a/service/src/projects/projects.controller.ts
+++ b/service/src/projects/projects.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post, Param } from '@nestjs/common';
 import { ProjectsService } from './projects.service';
 import { CreateProjectInput } from './data/projects.repository';
 
@@ -14,5 +14,10 @@ export class ProjectsController {
   @Get()
   getProjects() {
     return this.service.getProjects();
+  }
+
+  @Get(':id')
+  getProject(@Param('id') id: string) {
+    return this.service.getProject(id);
   }
 }

--- a/service/src/projects/projects.service.ts
+++ b/service/src/projects/projects.service.ts
@@ -12,4 +12,8 @@ export class ProjectsService {
   getProjects() {
     return this.repo.findAll();
   }
+
+  getProject(id: string) {
+    return this.repo.findOne(id);
+  }
 }


### PR DESCRIPTION
## Summary
- include Resource relation in project schema
- populate lead's name when listing projects
- support getting a single project
- make manday optional on creation form and API
- link to a new project detail page from the project list

## Testing
- `npm run build` in `service`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_68551629ad6c8328b678f227e6611572