### PR TITLE
Fix double API calls

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -8,7 +8,9 @@ const SERVICE_URL = process.env.SERVICE_URL || 'http://localhost:3000';
 
 /** @type {import('next').NextConfig} */
 module.exports = {
-  reactStrictMode: true,
+  // Disable React Strict Mode to avoid duplicate API calls during development
+  // See https://react.dev/learn/synchronizing-with-effects#fetching-data for details
+  reactStrictMode: false,
   async rewrites() {
     return [
       {


### PR DESCRIPTION
## Summary
- disable React strict mode to stop Next.js from calling `useEffect` twice in development

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685518d85b248328832020a55a439dc7