### PR TITLE
Add Dashboard rename and plan management menu

### DIFF
--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -22,7 +22,8 @@ const drawerWidth = 220;
 export default function Sidebar({ open, onClose }) {
   const router = useRouter();
   const [collapsed, setCollapsed] = useState(false);
-  const [openSummary, setOpenSummary] = useState(false);
+  const [openDashboard, setOpenDashboard] = useState(false);
+  const [openPlanMgmt, setOpenPlanMgmt] = useState(false);
   const [openTeamMgmt, setOpenTeamMgmt] = useState(false);
 
   // width to use when sidebar is collapsed
@@ -49,20 +50,20 @@ export default function Sidebar({ open, onClose }) {
       <List>
         <ListItemButton
           selected={router.pathname.startsWith('/summary')}
-          onClick={() => setOpenSummary(!openSummary)}
+          onClick={() => setOpenDashboard(!openDashboard)}
         >
           <ListItemIcon>
             <DashboardIcon />
           </ListItemIcon>
           {!collapsed && (
             <>
-              <ListItemText primary="Summary" />
-              {openSummary ? <ExpandLess /> : <ExpandMore />}
+              <ListItemText primary="Dashboard" />
+              {openDashboard ? <ExpandLess /> : <ExpandMore />}
             </>
           )}
         </ListItemButton>
         {!collapsed && (
-          <Collapse in={openSummary} timeout="auto" unmountOnExit>
+          <Collapse in={openDashboard} timeout="auto" unmountOnExit>
             <List component="div" disablePadding>
               <ListItemButton
                 sx={{ pl: 4 }}
@@ -117,6 +118,52 @@ export default function Sidebar({ open, onClose }) {
           </ListItemIcon>
           {!collapsed && <ListItemText primary="Budget Management" />}
         </ListItemButton>
+        <ListItemButton
+          selected={router.pathname.startsWith('/plan-management')}
+          onClick={() => setOpenPlanMgmt(!openPlanMgmt)}
+        >
+          <ListItemIcon>
+            <SettingsIcon />
+          </ListItemIcon>
+          {!collapsed && (
+            <>
+              <ListItemText primary="Plan Management" />
+              {openPlanMgmt ? <ExpandLess /> : <ExpandMore />}
+            </>
+          )}
+        </ListItemButton>
+        {!collapsed && (
+          <Collapse in={openPlanMgmt} timeout="auto" unmountOnExit>
+            <List component="div" disablePadding>
+              <ListItemButton
+                sx={{ pl: 4 }}
+                selected={router.pathname === '/plan-management'}
+                onClick={() => {
+                  router.push('/plan-management');
+                  onClose();
+                }}
+              >
+                <ListItemIcon>
+                  <SettingsIcon fontSize="small" />
+                </ListItemIcon>
+                <ListItemText primary="Overview" />
+              </ListItemButton>
+              <ListItemButton
+                sx={{ pl: 4 }}
+                selected={router.pathname === '/plan-management/planing-setting'}
+                onClick={() => {
+                  router.push('/plan-management/planing-setting');
+                  onClose();
+                }}
+              >
+                <ListItemIcon>
+                  <SettingsIcon fontSize="small" />
+                </ListItemIcon>
+                <ListItemText primary="Planing Setting" />
+              </ListItemButton>
+            </List>
+          </Collapse>
+        )}
         <ListItemButton
           selected={router.pathname.startsWith('/team-setting')}
           onClick={() => setOpenTeamMgmt(!openTeamMgmt)}

--- a/client/pages/plan-management/index.tsx
+++ b/client/pages/plan-management/index.tsx
@@ -1,0 +1,20 @@
+// @ts-nocheck
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import { Layout } from '../../components';
+import { withAuth } from '../../context/AuthContext';
+
+function PlanManagementOverview() {
+  return (
+    <Layout>
+      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
+        <Typography variant="h5" gutterBottom>
+          Plan Management Overview
+        </Typography>
+        <Typography variant="body2">Content coming soon.</Typography>
+      </Container>
+    </Layout>
+  );
+}
+
+export default withAuth(PlanManagementOverview);

--- a/client/pages/plan-management/planing-setting.tsx
+++ b/client/pages/plan-management/planing-setting.tsx
@@ -1,0 +1,20 @@
+// @ts-nocheck
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import { Layout } from '../../components';
+import { withAuth } from '../../context/AuthContext';
+
+function PlanManagementSetting() {
+  return (
+    <Layout>
+      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
+        <Typography variant="h5" gutterBottom>
+          Planing Setting
+        </Typography>
+        <Typography variant="body2">Content coming soon.</Typography>
+      </Container>
+    </Layout>
+  );
+}
+
+export default withAuth(PlanManagementSetting);


### PR DESCRIPTION
## Summary
- rename Summary menu item to Dashboard
- introduce Plan Management menu with Overview and Planing Setting pages

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68551baaee948328b1a7018c81523fcb