### PR TITLE
Add update and delete endpoints for Teams

### DIFF
--- a/service/src/teams/data/teams.repository.ts
+++ b/service/src/teams/data/teams.repository.ts
@@ -9,6 +9,12 @@ export interface CreateTeamInput {
   members?: string[];
 }
 
+export interface UpdateTeamInput {
+  name?: string;
+  lead?: string;
+  members?: string[];
+}
+
 @Injectable()
 export class TeamsRepository {
   constructor(@InjectModel(Team.name) private teamModel: Model<Team>) {}
@@ -20,5 +26,15 @@ export class TeamsRepository {
   create(data: CreateTeamInput): Promise<Team> {
     const team = new this.teamModel(data);
     return team.save();
+  }
+
+  update(id: string, data: UpdateTeamInput): Promise<Team | null> {
+    return this.teamModel
+      .findByIdAndUpdate(id, data, { new: true })
+      .exec();
+  }
+
+  remove(id: string): Promise<Team | null> {
+    return this.teamModel.findByIdAndDelete(id).exec();
   }
 }

--- a/service/src/teams/teams.controller.ts
+++ b/service/src/teams/teams.controller.ts
@@ -1,6 +1,14 @@
-import { Body, Controller, Get, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Param,
+} from '@nestjs/common';
 import { TeamsService } from './teams.service';
-import { CreateTeamInput } from './data/teams.repository';
+import { CreateTeamInput, UpdateTeamInput } from './data/teams.repository';
 
 @Controller('teams')
 export class TeamsController {
@@ -14,5 +22,15 @@ export class TeamsController {
   @Get()
   getTeams() {
     return this.service.getTeams();
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() body: UpdateTeamInput) {
+    return this.service.update(id, body);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
   }
 }

--- a/service/src/teams/teams.service.ts
+++ b/service/src/teams/teams.service.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { TeamsRepository, CreateTeamInput } from './data/teams.repository';
+import {
+  TeamsRepository,
+  CreateTeamInput,
+  UpdateTeamInput,
+} from './data/teams.repository';
 
 @Injectable()
 export class TeamsService {
@@ -11,5 +15,13 @@ export class TeamsService {
 
   getTeams() {
     return this.repo.findAll();
+  }
+
+  update(id: string, data: UpdateTeamInput) {
+    return this.repo.update(id, data);
+  }
+
+  remove(id: string) {
+    return this.repo.remove(id);
   }
 }


### PR DESCRIPTION
## Summary
- extend team repository with `update` and `remove`
- expose update/delete in Teams service and controller

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68551cf7c15083288e821bf81bb8d128