### PR TITLE
Add edit/delete functionality for teams

### DIFF
--- a/client/components/TeamForm.tsx
+++ b/client/components/TeamForm.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
@@ -8,10 +8,15 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import Checkbox from '@mui/material/Checkbox';
 import Autocomplete from '@mui/material/Autocomplete';
 
-export default function TeamForm({ users = [], onSubmit }) {
-  const [name, setName] = useState('');
-  const [lead, setLead] = useState(null);
-  const [members, setMembers] = useState([]);
+export default function TeamForm({ users = [], onSubmit, initial, submitText = 'Create' }) {
+  const [name, setName] = useState(initial?.name || '');
+  const [lead, setLead] = useState(() => {
+    if (initial?.lead) {
+      return users.find(u => u.name === initial.lead) || null;
+    }
+    return null;
+  });
+  const [members, setMembers] = useState(initial?.members || []);
 
   const toggleMember = id => {
     setMembers(prev =>
@@ -19,12 +24,26 @@ export default function TeamForm({ users = [], onSubmit }) {
     );
   };
 
+  useEffect(() => {
+    setName(initial?.name || '');
+    setMembers(initial?.members || []);
+    if (initial?.lead) {
+      setLead(users.find(u => u.name === initial.lead) || null);
+    } else {
+      setLead(null);
+    }
+  }, [initial, users]);
+
   const handleSubmit = e => {
     e.preventDefault();
-    onSubmit({ name, lead: lead?.name, members });
-    setName('');
-    setLead(null);
-    setMembers([]);
+    if (onSubmit) {
+      onSubmit({ name, lead: lead?.name, members });
+    }
+    if (!initial) {
+      setName('');
+      setLead(null);
+      setMembers([]);
+    }
   };
 
   return (
@@ -55,7 +74,7 @@ export default function TeamForm({ users = [], onSubmit }) {
         ))}
       </FormGroup>
       <Button variant="contained" type="submit" sx={{ gridColumn: 'span 2' }}>
-        Create
+        {submitText}
       </Button>
     </Box>
   );

--- a/client/models/teamModel.ts
+++ b/client/models/teamModel.ts
@@ -1,0 +1,21 @@
+import api from '../api';
+
+export async function fetchTeams() {
+  const { data } = await api.get('/api/v1/teams');
+  return data;
+}
+
+export async function createTeam(team) {
+  const { data } = await api.post('/api/v1/teams', team);
+  return data;
+}
+
+export async function updateTeam(id, team) {
+  const { data } = await api.patch(`/api/v1/teams/${id}`, team);
+  return data;
+}
+
+export async function deleteTeam(id) {
+  const { data } = await api.delete(`/api/v1/teams/${id}`);
+  return data;
+}


### PR DESCRIPTION
## Summary
- enable editing and deleting teams in team management page
- add TeamForm support for editing
- create client-side team API helpers

## Testing
- `npm run build` in `service`
- `npm run build` in `client`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68551f5949748328afe925ee7bdefb6e