### PR TITLE
Enhance project detail page

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "@mui/material": "^7.1.1",
     "@mui/x-data-grid": "^7.29.6",
     "@mui/x-date-pickers": "^8.5.2",
+    "@mui/x-charts": "^8.5.3",
     "axios": "^1.6.2",
     "date-fns": "^4.1.0",
     "dotenv": "^16.0.0",

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -8,7 +8,7 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import IconButton from '@mui/material/IconButton';
-import EditIcon from '@mui/icons-material/Edit';
+import InfoIcon from '@mui/icons-material/Info';
 import DeleteIcon from '@mui/icons-material/Delete';
 import DownloadIcon from '@mui/icons-material/Download';
 import { DataGrid } from '@mui/x-data-grid';
@@ -98,7 +98,7 @@ function ProjectManagement() {
             size="small"
             onClick={() => router.push(`/project/${params.row._id}`)}
           >
-            <EditIcon fontSize="small" />
+            <InfoIcon fontSize="small" />
           </IconButton>
           <IconButton size="small">
             <DownloadIcon fontSize="small" />

--- a/client/pages/project/[id].tsx
+++ b/client/pages/project/[id].tsx
@@ -8,21 +8,75 @@ import Box from '@mui/material/Box';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
 import Link from '@mui/material/Link';
 import IconButton from '@mui/material/IconButton';
+import Button from '@mui/material/Button';
 import ArrowBackIosNew from '@mui/icons-material/ArrowBackIosNew';
+import { DataGrid } from '@mui/x-data-grid';
+import { BarChart, PieChart } from '@mui/x-charts';
 import api from '../../api';
-import { Layout } from '../../components';
+import { Layout, Popup, ProjectForm } from '../../components';
 import { withAuth } from '../../context/AuthContext';
+import { differenceInDays, addDays, format } from 'date-fns';
 
 function ProjectDetail() {
   const router = useRouter();
   const { id } = router.query;
   const [project, setProject] = useState(null);
+  const [users, setUsers] = useState([]);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     if (id) {
-      api.get(`/api/v1/projects/${id}`).then(res => setProject(res.data));
+      Promise.all([
+        api.get(`/api/v1/projects/${id}`),
+        api.get('/api/v1/resources'),
+      ]).then(([p, u]) => {
+        setProject(p.data);
+        setUsers(u.data);
+      });
     }
   }, [id]);
+
+  const members = users.filter(u => project?.members?.includes(u.id));
+  const leadResource = users.find(u => u.id === project?.lead?._id);
+  const resourceCount = members.length + (leadResource ? 1 : 0);
+  const days = project?.start
+    ? differenceInDays(new Date(), new Date(project.start)) + 1
+    : 0;
+  const dailyData = Array.from({ length: days }, (_, i) => {
+    const date = addDays(new Date(project.start), i);
+    const manday = resourceCount;
+    return {
+      day: format(date, 'MM-dd'),
+      manday,
+      money: manday * 100,
+    };
+  });
+  const roleMap = {} as Record<string, number>;
+  [...(leadResource ? [leadResource] : []), ...members].forEach(m => {
+    const key = m.position.replace('_', ' ');
+    roleMap[key] = (roleMap[key] || 0) + 1;
+  });
+  const roleData = Object.entries(roleMap).map(([label, value]) => ({
+    label,
+    value,
+  }));
+
+  const memberColumns = [
+    { field: 'name', headerName: 'Name', flex: 1 },
+    { field: 'email', headerName: 'Email', flex: 1 },
+    { field: 'position', headerName: 'Position', flex: 1 },
+  ];
+
+  const handleSave = async data => {
+    const payload = {
+      ...data,
+      resources: (data.members?.length || 0) + (data.lead ? 1 : 0),
+    };
+    await api.patch(`/api/v1/projects/${id}`, payload);
+    const res = await api.get(`/api/v1/projects/${id}`);
+    setProject(res.data);
+    setOpen(false);
+  };
 
   if (!project) {
     return (
@@ -44,6 +98,10 @@ function ProjectDetail() {
           <Typography variant="h5" gutterBottom>
             {project.name}
           </Typography>
+          <Box sx={{ flexGrow: 1 }} />
+          <Button variant="outlined" onClick={() => setOpen(true)}>
+            Edit
+          </Button>
         </Box>
         <Breadcrumbs aria-label="breadcrumb" sx={{ mb: 2 }}>
           <Link
@@ -76,6 +134,67 @@ function ProjectDetail() {
             </Typography>
           </Box>
         </Paper>
+        {dailyData.length > 0 && (
+          <Paper sx={{ mt: 2, p: 2 }}>
+            <Typography variant="h6" gutterBottom>
+              Manday & Money Usage Per Day
+            </Typography>
+            <BarChart
+              height={300}
+              dataset={dailyData}
+              xAxis={[{ dataKey: 'day', scaleType: 'band' }]}
+              series={[
+                { dataKey: 'manday', label: 'Manday' },
+                { dataKey: 'money', label: 'Money' },
+              ]}
+            />
+          </Paper>
+        )}
+        {roleData.length > 0 && (
+          <Paper sx={{ mt: 2, p: 2 }}>
+            <Typography variant="h6" gutterBottom>
+              Manday By Role & Level
+            </Typography>
+            <PieChart
+              height={200}
+              series={[{
+                data: roleData.map(r => ({ id: r.label, value: r.value, label: r.label }))
+              }]}
+            />
+          </Paper>
+        )}
+        {members.length > 0 && (
+          <Paper sx={{ mt: 2 }}>
+            <Typography variant="h6" sx={{ p: 2 }}>
+              Members
+            </Typography>
+            <DataGrid
+              rows={[...(leadResource ? [leadResource] : []), ...members]}
+              columns={memberColumns}
+              autoHeight
+              pageSize={5}
+              rowsPerPageOptions={[5]}
+              getRowId={row => row.id}
+            />
+          </Paper>
+        )}
+        <Popup open={open} onClose={() => setOpen(false)} title="Edit Project">
+          {project && (
+            <ProjectForm
+              users={users}
+              onSubmit={handleSave}
+              initial={{
+                name: project.name,
+                description: project.description,
+                start: project.start ? new Date(project.start) : null,
+                lead: leadResource || null,
+                members,
+                manday: project.manday ?? ''
+              }}
+              submitText="Save"
+            />
+          )}
+        </Popup>
       </Container>
     </Layout>
   );

--- a/service/src/projects/data/projects.repository.ts
+++ b/service/src/projects/data/projects.repository.ts
@@ -16,6 +16,19 @@ export interface CreateProjectInput {
   members?: string[];
 }
 
+export interface UpdateProjectInput {
+  name?: string;
+  description?: string;
+  resources?: number;
+  start?: Date;
+  end?: Date;
+  manday?: number;
+  priority?: number;
+  lead?: string;
+  status?: string;
+  members?: string[];
+}
+
 @Injectable()
 export class ProjectsRepository {
   constructor(@InjectModel(Project.name) private projectModel: Model<Project>) {}
@@ -31,5 +44,11 @@ export class ProjectsRepository {
   create(data: CreateProjectInput): Promise<Project> {
     const project = new this.projectModel(data);
     return project.save();
+  }
+
+  update(id: string, data: UpdateProjectInput): Promise<Project | null> {
+    return this.projectModel
+      .findByIdAndUpdate(id, data, { new: true })
+      .exec();
   }
 }

--- a/service/src/projects/projects.controller.ts
+++ b/service/src/projects/projects.controller.ts
@@ -1,6 +1,6 @@
-import { Body, Controller, Get, Post, Param } from '@nestjs/common';
+import { Body, Controller, Get, Post, Patch, Param } from '@nestjs/common';
 import { ProjectsService } from './projects.service';
-import { CreateProjectInput } from './data/projects.repository';
+import { CreateProjectInput, UpdateProjectInput } from './data/projects.repository';
 
 @Controller('projects')
 export class ProjectsController {
@@ -19,5 +19,10 @@ export class ProjectsController {
   @Get(':id')
   getProject(@Param('id') id: string) {
     return this.service.getProject(id);
+  }
+
+  @Patch(':id')
+  updateProject(@Param('id') id: string, @Body() body: UpdateProjectInput) {
+    return this.service.updateProject(id, body);
   }
 }

--- a/service/src/projects/projects.service.ts
+++ b/service/src/projects/projects.service.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { ProjectsRepository, CreateProjectInput } from './data/projects.repository';
+import {
+  ProjectsRepository,
+  CreateProjectInput,
+  UpdateProjectInput,
+} from './data/projects.repository';
 
 @Injectable()
 export class ProjectsService {
@@ -15,5 +19,9 @@ export class ProjectsService {
 
   getProject(id: string) {
     return this.repo.findOne(id);
+  }
+
+  updateProject(id: string, data: UpdateProjectInput) {
+    return this.repo.update(id, data);
   }
 }


### PR DESCRIPTION
## Summary
- use a more appropriate info icon in project list
- allow editing projects from the detail page
- display basic charts of manday and money usage
- show members in a table
- add backend endpoints for updating projects

## Testing
- `npm run build` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_685522af57508328965fb3f0f2e6d7f9