### PR TITLE
Update icons for plan and detail

### DIFF
--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import Toolbar from '@mui/material/Toolbar';
 import Divider from '@mui/material/Divider';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import SettingsIcon from '@mui/icons-material/Settings';
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import GroupIcon from '@mui/icons-material/Group';
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
 import ExpandLess from '@mui/icons-material/ExpandLess';
@@ -99,7 +100,7 @@ export default function Sidebar({ open, onClose }) {
           onClick={() => setOpenPlanMgmt(!openPlanMgmt)}
         >
           <ListItemIcon>
-            <SettingsIcon />
+            <CalendarMonthIcon />
           </ListItemIcon>
           {!collapsed && (
             <>
@@ -120,7 +121,7 @@ export default function Sidebar({ open, onClose }) {
                 }}
               >
                 <ListItemIcon>
-                  <SettingsIcon fontSize="small" />
+                  <CalendarMonthIcon fontSize="small" />
                 </ListItemIcon>
                 <ListItemText primary="Overview" />
               </ListItemButton>
@@ -133,7 +134,7 @@ export default function Sidebar({ open, onClose }) {
                 }}
               >
                 <ListItemIcon>
-                  <SettingsIcon fontSize="small" />
+                  <CalendarMonthIcon fontSize="small" />
                 </ListItemIcon>
                 <ListItemText primary="Planing Setting" />
               </ListItemButton>

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -8,7 +8,7 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import IconButton from '@mui/material/IconButton';
-import InfoIcon from '@mui/icons-material/Info';
+import DescriptionIcon from '@mui/icons-material/Description';
 import DeleteIcon from '@mui/icons-material/Delete';
 import DownloadIcon from '@mui/icons-material/Download';
 import { DataGrid } from '@mui/x-data-grid';
@@ -98,7 +98,7 @@ function ProjectManagement() {
             size="small"
             onClick={() => router.push(`/project/${params.row._id}`)}
           >
-            <InfoIcon fontSize="small" />
+            <DescriptionIcon fontSize="small" />
           </IconButton>
           <IconButton size="small">
             <DownloadIcon fontSize="small" />


### PR DESCRIPTION
## Summary
- use calendar icon for plan management menu
- use description icon for project detail button

## Testing
- `npm --prefix client run build` *(fails: next not found)*
- `npm --prefix service run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685525d958888328b8298f9ede63e412