### PR TITLE
Add basic Jest setup for client and service

### DIFF
--- a/client/__tests__/app.test.tsx
+++ b/client/__tests__/app.test.tsx
@@ -1,0 +1,5 @@
+describe('Client basic test', () => {
+  it('should pass', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  testMatch: ['**/__tests__/**/*.test.ts?(x)'],
+};

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,9 @@
     "build": "next build",
     "start": "next start",
     "start:dev": "NODE_ENV=development next start",
-    "start:local": "NODE_ENV=local next start"
+    "start:local": "NODE_ENV=local next start",
+    "test": "jest",
+    "check": "npm run build"
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",
@@ -28,6 +30,10 @@
   "devDependencies": {
     "@types/node": "24.0.3",
     "@types/react": "19.1.8",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "typescript": "5.8.3"
   }
 }

--- a/service/__tests__/app.test.ts
+++ b/service/__tests__/app.test.ts
@@ -1,0 +1,5 @@
+describe('Service basic test', () => {
+  it('should pass', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/service/jest.config.js
+++ b/service/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts'],
+};

--- a/service/package.json
+++ b/service/package.json
@@ -6,7 +6,9 @@
     "build": "nest build",
     "start": "nest start",
     "start:prod": "node dist/main.js",
-    "dev": "nest start --watch"
+    "dev": "nest start --watch",
+    "test": "jest",
+    "check": "npm run build"
   },
   "dependencies": {
     "@nestjs/common": "^9.0.0",
@@ -28,6 +30,9 @@
     "@types/bcryptjs": "^2.4.2",
     "@types/jsonwebtoken": "^9.0.1",
     "@types/express": "^4.17.17",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "ts-node": "^10.0.0",
     "typescript": "^4.8.4"
   },


### PR DESCRIPTION
## Summary
- add Jest configs for client and service
- add placeholder tests
- update package.json scripts and dev dependencies for testing

## Testing
- `npm test --silent` in `service`
- `npm test --silent` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6855264bf29483288ecd64ef0ff13c76