### PR TITLE
Fix sidebar close behavior for team management menu

### DIFF
--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -171,7 +171,10 @@ export default function Sidebar({ open, onClose }) {
               <ListItemButton
                 sx={{ pl: 4 }}
                 selected={router.pathname === '/team-setting'}
-                onClick={() => router.push('/team-setting')}
+                onClick={() => {
+                  router.push('/team-setting');
+                  onClose();
+                }}
               >
                 <ListItemIcon>
                   <GroupIcon fontSize="small" />
@@ -181,7 +184,10 @@ export default function Sidebar({ open, onClose }) {
               <ListItemButton
                 sx={{ pl: 4 }}
                 selected={router.pathname === '/team-setting/team'}
-                onClick={() => router.push('/team-setting/team')}
+                onClick={() => {
+                  router.push('/team-setting/team');
+                  onClose();
+                }}
               >
                 <ListItemIcon>
                   <GroupIcon fontSize="small" />


### PR DESCRIPTION
## Summary
- close sidebar when navigating within Team Management

## Testing
- `npm run build` in `client`
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_68552712fe44832882e5209516445303