### PR TITLE
Fix env file path for built service

### DIFF
--- a/service/src/main.ts
+++ b/service/src/main.ts
@@ -6,7 +6,15 @@ import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import * as path from 'path';
 import { config } from 'dotenv';
 
-const envFile = path.join(__dirname, '../env', `${process.env.NODE_ENV || 'local'}.env`);
+// When compiled the entry point lives in dist/src so we need to go two levels up
+// to reach the original env directory.
+const envFile = path.join(
+  __dirname,
+  '..',
+  '..',
+  'env',
+  `${process.env.NODE_ENV || 'local'}.env`,
+);
 config({ path: envFile });
 
 async function bootstrap() {


### PR DESCRIPTION
## Summary
- fix path to env files in `service` when running compiled code

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685529a1d4ec8328857d0d7031c0dff9