### PR TITLE
Add toast notifications

### DIFF
--- a/client/components/index.tsx
+++ b/client/components/index.tsx
@@ -13,3 +13,4 @@ export { default as TeamForm } from './TeamForm';
 export { default as ProjectForm } from './ProjectForm';
 export { default as BudgetForm } from './BudgetForm';
 export { default as BudgetTable } from './BudgetTable';
+export { ToastProvider, useToast } from '../context/ToastContext';

--- a/client/context/ToastContext.tsx
+++ b/client/context/ToastContext.tsx
@@ -1,0 +1,51 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+import Snackbar from '@mui/material/Snackbar';
+import Alert, { AlertColor } from '@mui/material/Alert';
+
+interface ToastOptions {
+  severity?: AlertColor;
+}
+
+interface ToastContextProps {
+  showToast: (message: string, options?: ToastOptions) => void;
+}
+
+const ToastContext = createContext<ToastContextProps>({
+  showToast: () => {},
+});
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState('');
+  const [severity, setSeverity] = useState<AlertColor>('success');
+
+  const showToast = (msg: string, options?: ToastOptions) => {
+    setMessage(msg);
+    setSeverity(options?.severity || 'success');
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <Snackbar
+        open={open}
+        autoHideDuration={3000}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={handleClose} severity={severity} sx={{ width: '100%' }}>
+          {message}
+        </Alert>
+      </Snackbar>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  return useContext(ToastContext);
+}

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -7,6 +7,7 @@ import Head from 'next/head';
 import theme from '../theme';
 import { AuthProvider } from '../context/AuthContext';
 import { SidebarProvider } from '../context/SidebarContext';
+import { ToastProvider } from '../components';
 import '../styles/globals.scss';
 
 export default function MyApp({ Component, pageProps }) {
@@ -19,7 +20,9 @@ export default function MyApp({ Component, pageProps }) {
         </Head>
         <AuthProvider>
           <SidebarProvider>
-            <Component {...pageProps} />
+            <ToastProvider>
+              <Component {...pageProps} />
+            </ToastProvider>
           </SidebarProvider>
         </AuthProvider>
       </ThemeProvider>

--- a/client/pages/budget-management.tsx
+++ b/client/pages/budget-management.tsx
@@ -4,7 +4,7 @@ import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
-import { Layout, Popup, BudgetForm, BudgetTable } from '../components';
+import { Layout, Popup, BudgetForm, BudgetTable, useToast } from '../components';
 import { withAuth, useAuth } from '../context/AuthContext';
 import {
   createBudget,
@@ -14,6 +14,7 @@ import {
 
 function BudgetManagement() {
   const { token } = useAuth();
+  const { showToast } = useToast();
   const [rows, setRows] = useState([]);
   const [editRow, setEditRow] = useState(null);
   const [open, setOpen] = useState(false);
@@ -28,19 +29,30 @@ function BudgetManagement() {
   }, [token]);
 
   const handleSave = async data => {
-    if (editRow?.budgetId) {
-      await updateBudget(editRow.budgetId, data);
-    } else {
-      await createBudget(data);
+    try {
+      if (editRow?.budgetId) {
+        await updateBudget(editRow.budgetId, data);
+        showToast('Rate updated');
+      } else {
+        await createBudget(data);
+        showToast('Rate created');
+      }
+      setEditRow(null);
+      loadData();
+    } catch (e) {
+      showToast('Error saving rate', { severity: 'error' });
     }
-    setEditRow(null);
-    loadData();
   };
 
   const handleCreate = async data => {
-    await createBudget(data);
-    setOpen(false);
-    loadData();
+    try {
+      await createBudget(data);
+      showToast('Rate created');
+      setOpen(false);
+      loadData();
+    } catch (e) {
+      showToast('Error creating rate', { severity: 'error' });
+    }
   };
 
   const handleEdit = row => {

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -14,12 +14,13 @@ import DownloadIcon from '@mui/icons-material/Download';
 import { DataGrid } from '@mui/x-data-grid';
 import { differenceInDays, format } from 'date-fns';
 import api from '../api';
-import { Layout, Popup, ProjectForm } from '../components';
+import { Layout, Popup, ProjectForm, useToast } from '../components';
 import { withAuth, useAuth } from '../context/AuthContext';
 
 function ProjectManagement() {
   const router = useRouter();
   const { token } = useAuth();
+  const { showToast } = useToast();
   const [projects, setProjects] = useState([]);
   const [users, setUsers] = useState([]);
   const [open, setOpen] = useState(false);
@@ -36,13 +37,18 @@ function ProjectManagement() {
   }, [token]);
 
   const handleCreate = async data => {
-    const payload = {
-      ...data,
-      resources: (data.members?.length || 0) + (data.lead ? 1 : 0),
-    };
-    await api.post('/api/v1/projects', payload);
-    setOpen(false);
-    loadData();
+    try {
+      const payload = {
+        ...data,
+        resources: (data.members?.length || 0) + (data.lead ? 1 : 0),
+      };
+      await api.post('/api/v1/projects', payload);
+      showToast('Project created');
+      setOpen(false);
+      loadData();
+    } catch (e) {
+      showToast('Error creating project', { severity: 'error' });
+    }
   };
 
   const columns = [

--- a/client/pages/project/[id].tsx
+++ b/client/pages/project/[id].tsx
@@ -13,13 +13,14 @@ import ArrowBackIosNew from '@mui/icons-material/ArrowBackIosNew';
 import { DataGrid } from '@mui/x-data-grid';
 import { BarChart, PieChart } from '@mui/x-charts';
 import api from '../../api';
-import { Layout, Popup, ProjectForm } from '../../components';
+import { Layout, Popup, ProjectForm, useToast } from '../../components';
 import { withAuth } from '../../context/AuthContext';
 import { differenceInDays, addDays, format } from 'date-fns';
 
 function ProjectDetail() {
   const router = useRouter();
   const { id } = router.query;
+  const { showToast } = useToast();
   const [project, setProject] = useState(null);
   const [users, setUsers] = useState([]);
   const [open, setOpen] = useState(false);
@@ -68,14 +69,19 @@ function ProjectDetail() {
   ];
 
   const handleSave = async data => {
-    const payload = {
-      ...data,
-      resources: (data.members?.length || 0) + (data.lead ? 1 : 0),
-    };
-    await api.patch(`/api/v1/projects/${id}`, payload);
-    const res = await api.get(`/api/v1/projects/${id}`);
-    setProject(res.data);
-    setOpen(false);
+    try {
+      const payload = {
+        ...data,
+        resources: (data.members?.length || 0) + (data.lead ? 1 : 0),
+      };
+      await api.patch(`/api/v1/projects/${id}`, payload);
+      const res = await api.get(`/api/v1/projects/${id}`);
+      setProject(res.data);
+      showToast('Project updated');
+      setOpen(false);
+    } catch (e) {
+      showToast('Error updating project', { severity: 'error' });
+    }
   };
 
   if (!project) {

--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -18,7 +18,7 @@ import {
   addYears,
   addMonths,
 } from 'date-fns';
-import { Layout, ResourceForm, Popup } from '../../components';
+import { Layout, ResourceForm, Popup, useToast } from '../../components';
 import { withAuth, useAuth } from '../../context/AuthContext';
 import {
   fetchResources,
@@ -30,6 +30,7 @@ import api from '../../api';
 
 function TeamSetting() {
   const { token } = useAuth();
+  const { showToast } = useToast();
   const [resources, setResources] = useState([]);
   const [open, setOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
@@ -68,23 +69,38 @@ function TeamSetting() {
   }, [token]);
 
   const handleCreate = async data => {
-    await createResource(data);
-    setOpen(false);
-    loadData();
+    try {
+      await createResource(data);
+      showToast('Resource created');
+      setOpen(false);
+      loadData();
+    } catch (e) {
+      showToast('Error creating resource', { severity: 'error' });
+    }
   };
 
   const handleSave = async data => {
-    if (editRow?.id) {
-      await updateResource(editRow.id, data);
-      setEditRow(null);
-      loadData();
+    try {
+      if (editRow?.id) {
+        await updateResource(editRow.id, data);
+        showToast('Resource updated');
+        setEditRow(null);
+        loadData();
+      }
+    } catch (e) {
+      showToast('Error updating resource', { severity: 'error' });
     }
   };
 
   const handleDelete = async row => {
     if (window.confirm('Delete this resource?')) {
-      await deleteResource(row.id);
-      loadData();
+      try {
+        await deleteResource(row.id);
+        showToast('Resource deleted');
+        loadData();
+      } catch (e) {
+        showToast('Error deleting resource', { severity: 'error' });
+      }
     }
   };
   const columns = [

--- a/client/pages/team-setting/team.tsx
+++ b/client/pages/team-setting/team.tsx
@@ -11,7 +11,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { DataGrid } from '@mui/x-data-grid';
 import api from '../../api';
-import { Layout, Popup, TeamForm } from '../../components';
+import { Layout, Popup, TeamForm, useToast } from '../../components';
 import {
   fetchTeams,
   createTeam,
@@ -23,6 +23,7 @@ import { format } from 'date-fns';
 
 function TeamPage() {
   const { token } = useAuth();
+  const { showToast } = useToast();
   const [teams, setTeams] = useState([]);
   const [users, setUsers] = useState([]);
   const [open, setOpen] = useState(false);
@@ -42,23 +43,38 @@ function TeamPage() {
   }, [token]);
 
   const handleCreate = async data => {
-    await createTeam(data);
-    setOpen(false);
-    loadData();
+    try {
+      await createTeam(data);
+      showToast('Team created');
+      setOpen(false);
+      loadData();
+    } catch (e) {
+      showToast('Error creating team', { severity: 'error' });
+    }
   };
 
   const handleSave = async data => {
-    if (editRow?._id) {
-      await updateTeam(editRow._id, data);
-      setEditRow(null);
-      loadData();
+    try {
+      if (editRow?._id) {
+        await updateTeam(editRow._id, data);
+        showToast('Team updated');
+        setEditRow(null);
+        loadData();
+      }
+    } catch (e) {
+      showToast('Error updating team', { severity: 'error' });
     }
   };
 
   const handleDelete = async row => {
     if (window.confirm('Delete this team?')) {
-      await deleteTeam(row._id);
-      loadData();
+      try {
+        await deleteTeam(row._id);
+        showToast('Team deleted');
+        loadData();
+      } catch (e) {
+        showToast('Error deleting team', { severity: 'error' });
+      }
     }
   };
 

--- a/client/presenters/loginPresenter.ts
+++ b/client/presenters/loginPresenter.ts
@@ -3,9 +3,11 @@ import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { loginRequest } from '../models/authModel';
 import { useAuth } from '../context/AuthContext';
+import { useToast } from '../components';
 
 export function useLoginPresenter() {
   const { login } = useAuth();
+  const { showToast } = useToast();
   const router = useRouter();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
@@ -14,10 +16,16 @@ export function useLoginPresenter() {
   async function handleLogin(e) {
     e.preventDefault();
     setLoading(true);
-    const data = await loginRequest(username, password);
-    login(data.accessToken, data.refreshToken);
-    router.push('/plan-management');
-    setLoading(false);
+    try {
+      const data = await loginRequest(username, password);
+      login(data.accessToken, data.refreshToken);
+      showToast('Login successful');
+      router.push('/plan-management');
+    } catch (err) {
+      showToast('Login failed', { severity: 'error' });
+    } finally {
+      setLoading(false);
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary
- add ToastContext for showing notifications
- wire ToastProvider into app layout
- show toasts on create, edit, delete and login

## Testing
- `npm run check` in `client` *(fails: next not found)*
- `npm run check` in `service` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685529dfb72c83288a2b2e74103af233