### PR TITLE
Fix local dev DB connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ npm run start:prod
 ```
 Create a `.env` file in the `service` directory by copying one of the files
 from `service/env` and adjusting values to set database URLs and other options.
+If the databases run inside Docker while the service runs locally (for example
+inside the VS Code devcontainer), use `host.docker.internal` instead of
+`localhost` so the service can reach the containers.
 
 To run the client manually:
 
@@ -73,6 +76,10 @@ client/env/staging.env
 client/env/uat.env
 client/env/production.env
 ```
+
+When running the Next.js client inside a container while the service runs
+locally, update `client/env/local.env` to point `SERVICE_URL` at
+`http://host.docker.internal:3000`.
 
 You may also copy one of the files in `service/env` to `service/.env` if you
 prefer not to rely on the predefined `NODE_ENV` values.

--- a/client/env/local.env
+++ b/client/env/local.env
@@ -1,2 +1,2 @@
 NODE_ENV=local
-SERVICE_URL=http://localhost:3000
+SERVICE_URL=http://host.docker.internal:3000

--- a/service/env/local.env
+++ b/service/env/local.env
@@ -1,6 +1,6 @@
 NODE_ENV=local
-MONGO_URL=mongodb://localhost:27017/budget_local
-REDIS_URL=redis://localhost:6379
+MONGO_URL=mongodb://host.docker.internal:27017/budget_local
+REDIS_URL=redis://host.docker.internal:6379
 SECRET=local_secret
 ADMIN_PASSWORD=admin
 PORT=3000


### PR DESCRIPTION
## Summary
- update local env files to use `host.docker.internal`
- note dev container setup tips in README

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6858c689ca6c8328b31ffbb5988d0851