### PR TITLE
Add detached mode option for start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ with Docker.
 ## Running with Docker
 
 ```sh
-./start.sh
+./start.sh [-d]
 ```
+
+Add `-d` to start the containers in detached mode so they run in the background.
 
 When run, the script prompts for what to start. Select **1** to launch all
 containers, **2** to start only MongoDB and Redis, or **3** to start the service

--- a/start.sh
+++ b/start.sh
@@ -8,18 +8,25 @@ Choose an option:
 3) Start service and databases
 MENU
 
+# Optional detached mode
+DETACHED=""
+if [ "$1" = "-d" ]; then
+  DETACHED="-d"
+  shift
+fi
+
 printf "Enter choice [1-3]: "
 read choice
 
 case "$choice" in
   1)
-    docker-compose up --build
+    docker-compose up --build $DETACHED
     ;;
   2)
-    docker-compose up --build mongo redis
+    docker-compose up --build $DETACHED mongo redis
     ;;
   3)
-    docker-compose up --build mongo redis service
+    docker-compose up --build $DETACHED mongo redis service
     ;;
   *)
     echo "Invalid choice"


### PR DESCRIPTION
## Summary
- allow `./start.sh -d` to run services in detached mode
- document `-d` option in README

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6858cac78f448328ac130595efb892f9