### PR TITLE
Fix env loading

### DIFF
--- a/service/src/load-env.ts
+++ b/service/src/load-env.ts
@@ -1,0 +1,16 @@
+import * as path from 'path';
+import { config } from 'dotenv';
+import * as fs from 'fs';
+
+const envName = `${process.env.NODE_ENV || 'local'}.env`;
+const searchPaths = [
+  path.join(__dirname, '..', '..', 'env', envName),
+  path.join(__dirname, '..', 'env', envName),
+];
+
+for (const envFile of searchPaths) {
+  if (fs.existsSync(envFile)) {
+    config({ path: envFile });
+    break;
+  }
+}

--- a/service/src/main.ts
+++ b/service/src/main.ts
@@ -1,22 +1,9 @@
+import './load-env';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { LoggingInterceptor } from './logger/logging.interceptor';
 import { LoggerService } from './logger/logger.service';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
-import * as path from 'path';
-import { config } from 'dotenv';
-
-// When compiled the entry point lives in dist/src so we need to go two levels up
-// to reach the original env directory.
-const envFile = path.join(
-  __dirname,
-  '..',
-  '..',
-  'env',
-  `${process.env.NODE_ENV || 'local'}.env`,
-);
-config({ path: envFile });
-console.log('envFile: ', envFile);
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);


### PR DESCRIPTION
## Summary
- ensure environment variables are loaded before starting NestJS
- add helper to load env files correctly

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_68591dc1c8cc83288cd6e51418f3d24a