### PR TITLE
Update BudgetForm inputs

### DIFF
--- a/client/components/BudgetForm.tsx
+++ b/client/components/BudgetForm.tsx
@@ -1,10 +1,8 @@
 // @ts-nocheck
 import Box from '@mui/material/Box';
-import TextField from '@mui/material/TextField';
-import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
 import { useState, useEffect } from 'react';
-import api from '../api';
+import { Input } from '.';
 
 interface Props {
   onSubmit?: (data: { role: string; level: string; rate: number }) => void;
@@ -16,21 +14,12 @@ export default function BudgetForm({ onSubmit, initial, submitText = 'Create' }:
   const [role, setRole] = useState(initial?.role || '');
   const [level, setLevel] = useState(initial?.level || '');
   const [rate, setRate] = useState(initial?.rate != null ? String(initial.rate) : '');
-  const [roles, setRoles] = useState([]);
 
   useEffect(() => {
     setRole(initial?.role || '');
     setLevel(initial?.level || '');
     setRate(initial?.rate != null ? String(initial.rate) : '');
   }, [initial]);
-
-  useEffect(() => {
-    async function load() {
-      const { data } = await api.get('/api/v1/roles');
-      setRoles(data);
-    }
-    load();
-  }, []);
 
   const handleSubmit = e => {
     e.preventDefault();
@@ -49,28 +38,16 @@ export default function BudgetForm({ onSubmit, initial, submitText = 'Create' }:
         gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
       }}
     >
-      <TextField select label="Role" value={role} onChange={e => setRole(e.target.value)} required>
-        {roles.map(r => (
-          <MenuItem key={r.name} value={r.name}>
-            {r.name}
-          </MenuItem>
-        ))}
-      </TextField>
-      <TextField select label="Level" value={level} onChange={e => setLevel(e.target.value)} required>
-        {(roles.find(r => r.name === role)?.levels || []).map(l => (
-          <MenuItem key={l} value={l}>
-            {l}
-          </MenuItem>
-        ))}
-      </TextField>
-      <TextField
+      <Input label="Role" value={role} onChange={e => setRole(e.target.value)} required />
+      <Input label="Level" value={level} onChange={e => setLevel(e.target.value)} required />
+      <Input
         label="Baht / MD"
         type="number"
         value={rate}
         onChange={e => setRate(e.target.value)}
         required
       />
-      <Button variant="contained" type="submit">
+      <Button variant="contained" type="submit" sx={{ gridColumn: 'span 2' }}>
         {submitText}
       </Button>
     </Box>


### PR DESCRIPTION
## Summary
- simplify budget creation form
- place submit button on its own row

## Testing
- `npm test` in `client`
- `npm test` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6859250e08ac8328b42746bd3685201a