### PR TITLE
Add delete budget API and client support

### DIFF
--- a/client/components/BudgetTable.tsx
+++ b/client/components/BudgetTable.tsx
@@ -13,8 +13,9 @@ import Paper from '@mui/material/Paper';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
 
-export default function BudgetTable({ data, onEdit }) {
+export default function BudgetTable({ data, onEdit, onDelete }) {
   const groups = data.reduce((acc, item) => {
     const list = acc[item.role] || [];
     list.push(item);
@@ -36,7 +37,7 @@ export default function BudgetTable({ data, onEdit }) {
         </TableHead>
         <TableBody>
           {Object.entries(groups).map(([role, rows]) => (
-            <RoleRow key={role} role={role} rows={rows} onEdit={onEdit} />
+            <RoleRow key={role} role={role} rows={rows} onEdit={onEdit} onDelete={onDelete} />
           ))}
         </TableBody>
       </Table>
@@ -44,7 +45,7 @@ export default function BudgetTable({ data, onEdit }) {
   );
 }
 
-function RoleRow({ role, rows, onEdit }) {
+function RoleRow({ role, rows, onEdit, onDelete }) {
   const [open, setOpen] = useState(false);
   const total = rows.reduce((sum, r) => sum + (r.count || 0), 0);
   return (
@@ -87,6 +88,11 @@ function RoleRow({ role, rows, onEdit }) {
                         <IconButton size="small" onClick={() => onEdit(r)}>
                           <EditIcon fontSize="small" />
                         </IconButton>
+                        {onDelete && (
+                          <IconButton size="small" onClick={() => onDelete(r)}>
+                            <DeleteIcon fontSize="small" />
+                          </IconButton>
+                        )}
                       </TableCell>
                     </TableRow>
                   ))}

--- a/client/models/budgetModel.ts
+++ b/client/models/budgetModel.ts
@@ -15,6 +15,11 @@ export async function updateBudget(id, budget) {
   return data;
 }
 
+export async function deleteBudget(id) {
+  const { data } = await api.delete(`/api/v1/budgets/${id}`);
+  return data;
+}
+
 export async function fetchBudgetOverview() {
   const { data } = await api.get('/api/v1/budgets/overview');
   return data;

--- a/client/pages/budget-management.tsx
+++ b/client/pages/budget-management.tsx
@@ -9,6 +9,7 @@ import { withAuth, useAuth } from '../context/AuthContext';
 import {
   createBudget,
   updateBudget,
+  deleteBudget,
   fetchBudgetOverview,
 } from '../models/budgetModel';
 
@@ -59,6 +60,18 @@ function BudgetManagement() {
     setEditRow(row);
   };
 
+  const handleDelete = async row => {
+    if (window.confirm('Delete this rate?')) {
+      try {
+        await deleteBudget(row.budgetId);
+        showToast('Rate deleted');
+        loadData();
+      } catch (e) {
+        showToast('Error deleting rate', { severity: 'error' });
+      }
+    }
+  };
+
   return (
     <Layout>
       <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
@@ -68,7 +81,7 @@ function BudgetManagement() {
             New Rate
           </Button>
         </Box>
-        <BudgetTable data={rows} onEdit={handleEdit} />
+        <BudgetTable data={rows} onEdit={handleEdit} onDelete={handleDelete} />
         <Popup open={!!editRow} onClose={() => setEditRow(null)} title="Edit Rate">
           {editRow && (
             <BudgetForm

--- a/service/src/budgets/budgets.controller.ts
+++ b/service/src/budgets/budgets.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Patch, Param } from '@nestjs/common';
+import { Body, Controller, Get, Post, Patch, Delete, Param } from '@nestjs/common';
 import { BudgetsService } from './budgets.service';
 import { CreateBudgetInput, UpdateBudgetInput } from './data/budgets.repository';
 
@@ -24,5 +24,10 @@ export class BudgetsController {
   @Patch(':id')
   update(@Param('id') id: string, @Body() body: UpdateBudgetInput) {
     return this.service.update(id, body);
+  }
+
+  @Delete(':id')
+  delete(@Param('id') id: string) {
+    return this.service.delete(id);
   }
 }

--- a/service/src/budgets/budgets.service.ts
+++ b/service/src/budgets/budgets.service.ts
@@ -36,6 +36,10 @@ export class BudgetsService {
     return this.repo.update(id, data);
   }
 
+  delete(id: string) {
+    return this.repo.delete(id);
+  }
+
   async getOverview() {
     const [resources, budgets, roles] = await Promise.all([
       this.resourceModel.find().exec(),

--- a/service/src/budgets/data/budgets.repository.ts
+++ b/service/src/budgets/data/budgets.repository.ts
@@ -33,4 +33,8 @@ export class BudgetsRepository {
       .findByIdAndUpdate(id, data, { new: true })
       .exec();
   }
+
+  delete(id: string): Promise<Budget | null> {
+    return this.budgetModel.findByIdAndDelete(id).exec();
+  }
 }


### PR DESCRIPTION
## Summary
- add delete method to budgets repository, service and controller
- expose deleteBudget in client model
- show delete action in budget table UI
- support deletion in budget management page

## Testing
- `npm test --prefix service`
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_68592b56cc3483289395a5ba7830ac8d