### PR TITLE
Add budget lookup endpoint

### DIFF
--- a/service/src/budgets/budgets.controller.ts
+++ b/service/src/budgets/budgets.controller.ts
@@ -16,6 +16,11 @@ export class BudgetsController {
     return this.service.getOverview();
   }
 
+  @Get(':id')
+  getBudget(@Param('id') id: string) {
+    return this.service.getBudget(id);
+  }
+
   @Post()
   create(@Body() body: CreateBudgetInput) {
     return this.service.create(body);

--- a/service/src/budgets/budgets.service.ts
+++ b/service/src/budgets/budgets.service.ts
@@ -40,6 +40,13 @@ export class BudgetsService {
     return this.repo.delete(id);
   }
 
+  async getBudget(id: string) {
+    const b = await this.repo.findById(id);
+    return (
+      b && { id: b._id.toString(), role: b.role, level: b.level, rate: b.rate }
+    );
+  }
+
   async getOverview() {
     const [resources, budgets, roles] = await Promise.all([
       this.resourceModel.find().exec(),

--- a/service/src/budgets/data/budgets.repository.ts
+++ b/service/src/budgets/data/budgets.repository.ts
@@ -34,6 +34,10 @@ export class BudgetsRepository {
       .exec();
   }
 
+  findById(id: string): Promise<Budget | null> {
+    return this.budgetModel.findById(id).exec();
+  }
+
   delete(id: string): Promise<Budget | null> {
     return this.budgetModel.findByIdAndDelete(id).exec();
   }


### PR DESCRIPTION
## Summary
- expose GET `/budgets/:id` API
- support loading a single budget in the service repository and service layer

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685937cd8dc08328bd68f120994ec216