### PR TITLE
Add role and budget setting menu

### DIFF
--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -25,6 +25,7 @@ export default function Sidebar({ open, onClose }) {
   const [collapsed, setCollapsed] = useState(false);
   const [openDashboard, setOpenDashboard] = useState(false);
   const [openPlanMgmt, setOpenPlanMgmt] = useState(false);
+  const [openBudgetMgmt, setOpenBudgetMgmt] = useState(false);
   const [openTeamMgmt, setOpenTeamMgmt] = useState(false);
 
   // width to use when sidebar is collapsed
@@ -141,17 +142,51 @@ export default function Sidebar({ open, onClose }) {
           {!collapsed && <ListItemText primary="Project Management" />}
         </ListItemButton>
         <ListItemButton
-          selected={router.pathname === '/budget-management'}
-          onClick={() => {
-            router.push('/budget-management');
-            onClose();
-          }}
+          selected={router.pathname.startsWith('/budget-management')}
+          onClick={() => setOpenBudgetMgmt(!openBudgetMgmt)}
         >
           <ListItemIcon>
             <AttachMoneyIcon />
           </ListItemIcon>
-          {!collapsed && <ListItemText primary="Budget Management" />}
+          {!collapsed && (
+            <>
+              <ListItemText primary="Budget Management" />
+              {openBudgetMgmt ? <ExpandLess /> : <ExpandMore />}
+            </>
+          )}
         </ListItemButton>
+        {!collapsed && (
+          <Collapse in={openBudgetMgmt} timeout="auto" unmountOnExit>
+            <List component="div" disablePadding>
+              <ListItemButton
+                sx={{ pl: 4 }}
+                selected={router.pathname === '/budget-management'}
+                onClick={() => {
+                  router.push('/budget-management');
+                  onClose();
+                }}
+              >
+                <ListItemIcon>
+                  <AttachMoneyIcon fontSize="small" />
+                </ListItemIcon>
+                <ListItemText primary="Budget Setting" />
+              </ListItemButton>
+              <ListItemButton
+                sx={{ pl: 4 }}
+                selected={router.pathname === '/budget-management/role-setting'}
+                onClick={() => {
+                  router.push('/budget-management/role-setting');
+                  onClose();
+                }}
+              >
+                <ListItemIcon>
+                  <SettingsIcon fontSize="small" />
+                </ListItemIcon>
+                <ListItemText primary="Role Setting" />
+              </ListItemButton>
+            </List>
+          </Collapse>
+        )}
         <ListItemButton
           selected={router.pathname.startsWith('/team-setting')}
           onClick={() => setOpenTeamMgmt(!openTeamMgmt)}

--- a/client/models/roleModel.ts
+++ b/client/models/roleModel.ts
@@ -1,0 +1,21 @@
+import api from '../api';
+
+export async function fetchRoles() {
+  const { data } = await api.get('/api/v1/roles');
+  return data;
+}
+
+export async function createRole(role: { name: string }) {
+  const { data } = await api.post('/api/v1/roles', role);
+  return data;
+}
+
+export async function addLevel(roleId: string, level: string) {
+  const { data } = await api.post(`/api/v1/roles/${roleId}/levels`, { name: level });
+  return data;
+}
+
+export async function removeLevel(roleId: string, level: string) {
+  const { data } = await api.delete(`/api/v1/roles/${roleId}/levels/${level}`);
+  return data;
+}

--- a/client/pages/budget-management/index.tsx
+++ b/client/pages/budget-management/index.tsx
@@ -4,14 +4,20 @@ import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
-import { Layout, Popup, BudgetForm, BudgetTable, useToast } from '../components';
-import { withAuth, useAuth } from '../context/AuthContext';
+import {
+  Layout,
+  Popup,
+  BudgetForm,
+  BudgetTable,
+  useToast,
+} from '../../components';
+import { withAuth, useAuth } from '../../context/AuthContext';
 import {
   createBudget,
   updateBudget,
   deleteBudget,
   fetchBudgetOverview,
-} from '../models/budgetModel';
+} from '../../models/budgetModel';
 
 function BudgetManagement() {
   const { token } = useAuth();

--- a/client/pages/budget-management/role-setting.tsx
+++ b/client/pages/budget-management/role-setting.tsx
@@ -1,0 +1,119 @@
+// @ts-nocheck
+import { useEffect, useState } from 'react';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import { Layout, useToast } from '../../components';
+import { withAuth, useAuth } from '../../context/AuthContext';
+import {
+  fetchRoles,
+  createRole,
+  addLevel,
+  removeLevel,
+} from '../../models/roleModel';
+
+function RoleSetting() {
+  const { token } = useAuth();
+  const { showToast } = useToast();
+  const [roles, setRoles] = useState([]);
+  const [newRole, setNewRole] = useState('');
+  const [levelInputs, setLevelInputs] = useState({});
+
+  async function loadData() {
+    const data = await fetchRoles();
+    setRoles(data);
+  }
+
+  useEffect(() => {
+    if (token) loadData();
+  }, [token]);
+
+  const handleCreateRole = async () => {
+    try {
+      await createRole({ name: newRole });
+      showToast('Role created');
+      setNewRole('');
+      loadData();
+    } catch (e) {
+      showToast('Error creating role', { severity: 'error' });
+    }
+  };
+
+  const handleAddLevel = async roleId => {
+    const level = levelInputs[roleId];
+    if (!level) return;
+    try {
+      await addLevel(roleId, level);
+      showToast('Level added');
+      setLevelInputs({ ...levelInputs, [roleId]: '' });
+      loadData();
+    } catch (e) {
+      showToast('Error adding level', { severity: 'error' });
+    }
+  };
+
+  const handleRemoveLevel = async (roleId, level) => {
+    if (!window.confirm('Remove this level?')) return;
+    try {
+      await removeLevel(roleId, level);
+      showToast('Level removed');
+      loadData();
+    } catch (e) {
+      showToast('Error removing level', { severity: 'error' });
+    }
+  };
+
+  return (
+    <Layout>
+      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
+        <Typography variant="h5" gutterBottom>
+          Role Setting
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
+          <TextField
+            label="New Role"
+            value={newRole}
+            onChange={e => setNewRole(e.target.value)}
+            size="small"
+          />
+          <Button variant="contained" onClick={handleCreateRole}>
+            Add
+          </Button>
+        </Box>
+        {roles.map(r => (
+          <Box key={r._id} sx={{ mb: 2 }}>
+            <Typography variant="h6">{r.name}</Typography>
+            <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+              {r.levels.map(level => (
+                <Chip
+                  key={level}
+                  label={level}
+                  onDelete={() => handleRemoveLevel(r._id, level)}
+                />
+              ))}
+            </Stack>
+            <Box sx={{ display: 'flex', gap: 1, mt: 1 }}>
+              <TextField
+                label="New Level"
+                size="small"
+                value={levelInputs[r._id] || ''}
+                onChange={e =>
+                  setLevelInputs({ ...levelInputs, [r._id]: e.target.value })
+                }
+              />
+              <Button variant="outlined" onClick={() => handleAddLevel(r._id)}>
+                Add Level
+              </Button>
+            </Box>
+          </Box>
+        ))}
+      </Container>
+    </Layout>
+  );
+}
+
+export default withAuth(RoleSetting);


### PR DESCRIPTION
## Summary
- split budget management pages into folder
- add role management UI and API helper
- expand sidebar with new Budget Management sub menu

## Testing
- `npm --prefix service run check` *(fails: nest not found)*
- `npm --prefix client run check` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593fadec8883288cbdc1754522f8e9