### PR TITLE
Add endpoint to create role via budgets API

### DIFF
--- a/service/src/budgets/budgets.controller.ts
+++ b/service/src/budgets/budgets.controller.ts
@@ -26,6 +26,11 @@ export class BudgetsController {
     return this.service.create(body);
   }
 
+  @Post('roles')
+  createRole(@Body() body: { name: string }) {
+    return this.service.createRole(body.name);
+  }
+
   @Patch(':id')
   update(@Param('id') id: string, @Body() body: UpdateBudgetInput) {
     return this.service.update(id, body);

--- a/service/src/budgets/budgets.service.ts
+++ b/service/src/budgets/budgets.service.ts
@@ -32,6 +32,10 @@ export class BudgetsService {
     return this.repo.create(data);
   }
 
+  createRole(name: string) {
+    return this.rolesService.createRole({ name });
+  }
+
   update(id: string, data: UpdateBudgetInput) {
     return this.repo.update(id, data);
   }


### PR DESCRIPTION
## Summary
- extend budgets controller with a `POST /budgets/roles` endpoint
- delegate to `RolesService.createRole` from `BudgetsService`

## Testing
- `npm test --prefix service`
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_685942f312a883288afd0e8a65f34d89