### PR TITLE
Fix level chip click handler

### DIFF
--- a/client/pages/budget-management/role-setting.tsx
+++ b/client/pages/budget-management/role-setting.tsx
@@ -92,6 +92,7 @@ function RoleSetting() {
                 <Chip
                   key={level}
                   label={level}
+                  onClick={() => handleRemoveLevel(r._id, level)}
                   onDelete={() => handleRemoveLevel(r._id, level)}
                 />
               ))}


### PR DESCRIPTION
## Summary
- fix role-setting page to use click event on level chips

## Testing
- `npm test` in client
- `npm test` in service

------
https://chatgpt.com/codex/tasks/task_e_685a1e5f0d3c8328873c48f774e54029