### PR TITLE
Format currency on budget table

### DIFF
--- a/client/components/BudgetTable.tsx
+++ b/client/components/BudgetTable.tsx
@@ -6,6 +6,11 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import { DataGrid } from '@mui/x-data-grid';
 import Paper from '@mui/material/Paper';
 
+const currencyFormatter = new Intl.NumberFormat('th-TH', {
+  style: 'currency',
+  currency: 'THB',
+});
+
 export default function BudgetTable({ data, onEdit, onDelete }) {
   const columns = [
     {
@@ -22,7 +27,13 @@ export default function BudgetTable({ data, onEdit, onDelete }) {
     { field: 'role', headerName: 'Role', flex: 1 },
     { field: 'level', headerName: 'Level', width: 130 },
     { field: 'count', headerName: 'Count', width: 100 },
-    { field: 'rate', headerName: 'Baht/MD', width: 120 },
+    {
+      field: 'rate',
+      headerName: 'Baht/MD',
+      width: 120,
+      valueFormatter: ({ value }) =>
+        typeof value === 'number' ? currencyFormatter.format(value) : value,
+    },
     {
       field: 'actions',
       headerName: 'Action',

--- a/client/pages/budget-management/index.tsx
+++ b/client/pages/budget-management/index.tsx
@@ -2,7 +2,6 @@
 import { useEffect, useState } from 'react';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import {
   Layout,
@@ -24,7 +23,6 @@ function BudgetManagement() {
   const { showToast } = useToast();
   const [rows, setRows] = useState([]);
   const [editRow, setEditRow] = useState(null);
-  const [open, setOpen] = useState(false);
 
   async function loadData() {
     const data = await fetchBudgetOverview();
@@ -51,16 +49,6 @@ function BudgetManagement() {
     }
   };
 
-  const handleCreate = async data => {
-    try {
-      await createBudget(data);
-      showToast('Rate created');
-      setOpen(false);
-      loadData();
-    } catch (e) {
-      showToast('Error creating rate', { severity: 'error' });
-    }
-  };
 
   const handleEdit = row => {
     setEditRow(row);
@@ -83,9 +71,6 @@ function BudgetManagement() {
       <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
           <Typography variant="h5">Budget Management</Typography>
-          <Button variant="contained" onClick={() => setOpen(true)}>
-            New Rate
-          </Button>
         </Box>
         <BudgetTable data={rows} onEdit={handleEdit} onDelete={handleDelete} />
         <Popup open={!!editRow} onClose={() => setEditRow(null)} title="Edit Rate">
@@ -100,9 +85,6 @@ function BudgetManagement() {
               submitText="Save"
             />
           )}
-        </Popup>
-        <Popup open={open} onClose={() => setOpen(false)} title="Add Rate">
-          <BudgetForm onSubmit={handleCreate} />
         </Popup>
       </Container>
     </Layout>


### PR DESCRIPTION
## Summary
- format budget rates as currency
- remove `New Rate` button from budget management

## Testing
- `npm --prefix client test`
- `npm --prefix service test`


------
https://chatgpt.com/codex/tasks/task_e_685a332a11708328ab34ffcd8b5f767f