### PR TITLE
Set default rows per page to 25

### DIFF
--- a/client/pages/project/[id].tsx
+++ b/client/pages/project/[id].tsx
@@ -178,8 +178,8 @@ function ProjectDetail() {
               rows={[...(leadResource ? [leadResource] : []), ...members]}
               columns={memberColumns}
               autoHeight
-              pageSize={5}
-              rowsPerPageOptions={[5]}
+              pageSize={25}
+              rowsPerPageOptions={[25]}
               getRowId={row => row.id}
             />
           </Paper>


### PR DESCRIPTION
## Summary
- ensure DataGrid uses 25 rows per page on project detail page

## Testing
- `npm test` in `client`
- `npm run check` in `client`
- `npm test` in `service`
- `npm run check` in `service`


------
https://chatgpt.com/codex/tasks/task_e_685a335f27288328a64e4d4fd966cb65