### PR TITLE
Implement table member selection for team form

### DIFF
--- a/client/components/TeamForm.tsx
+++ b/client/components/TeamForm.tsx
@@ -1,12 +1,11 @@
 // @ts-nocheck
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
-import FormGroup from '@mui/material/FormGroup';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Checkbox from '@mui/material/Checkbox';
 import Autocomplete from '@mui/material/Autocomplete';
+import Paper from '@mui/material/Paper';
+import { DataGrid } from '@mui/x-data-grid';
 
 export default function TeamForm({ users = [], onSubmit, initial, submitText = 'Create' }) {
   const [name, setName] = useState(initial?.name || '');
@@ -18,10 +17,65 @@ export default function TeamForm({ users = [], onSubmit, initial, submitText = '
   });
   const [members, setMembers] = useState(initial?.members || []);
 
-  const toggleMember = id => {
-    setMembers(prev =>
-      prev.includes(id) ? prev.filter(m => m !== id) : [...prev, id]
+  const idNameMap = useMemo(() => {
+    const map = {} as Record<string, string>;
+    users.forEach(u => {
+      map[u.id] = u.name;
+    });
+    return map;
+  }, [users]);
+
+  const nameIdMap = useMemo(() => {
+    const map = {} as Record<string, string>;
+    users.forEach(u => {
+      map[u.name] = u.id;
+    });
+    return map;
+  }, [users]);
+
+  const selectionModel = useMemo(() => {
+    const ids = members.map(m => nameIdMap[m]).filter(Boolean);
+    if (lead?.id && !ids.includes(lead.id)) {
+      ids.unshift(lead.id);
+    }
+    return ids;
+  }, [members, lead, nameIdMap]);
+
+  const originalOrder = useMemo(() => {
+    const map = {} as Record<string, number>;
+    users.forEach((u, i) => {
+      map[u.id] = i;
+    });
+    return map;
+  }, [users]);
+
+  const rows = useMemo(() => {
+    const selected = new Set(
+      selectionModel.filter(id => id !== lead?.id)
     );
+    return [...users].sort((a, b) => {
+      if (lead?.id) {
+        if (a.id === lead.id) return -1;
+        if (b.id === lead.id) return 1;
+      }
+      const aSel = selected.has(a.id);
+      const bSel = selected.has(b.id);
+      if (aSel && !bSel) return -1;
+      if (!aSel && bSel) return 1;
+      return originalOrder[a.id] - originalOrder[b.id];
+    });
+  }, [users, selectionModel, lead, originalOrder]);
+
+  const handleSelectionChange = model => {
+    let ids = Array.isArray(model) ? model : [];
+    if (lead?.id && !ids.includes(lead.id)) {
+      ids = [lead.id, ...ids];
+    }
+    const names = ids
+      .filter(id => id !== lead?.id)
+      .map(id => idNameMap[id])
+      .filter(Boolean);
+    setMembers(names);
   };
 
   useEffect(() => {
@@ -46,6 +100,12 @@ export default function TeamForm({ users = [], onSubmit, initial, submitText = '
     }
   };
 
+  const columns = [
+    { field: 'name', headerName: 'Name', flex: 1 },
+    { field: 'email', headerName: 'Email', flex: 1 },
+    { field: 'position', headerName: 'Position', flex: 1 },
+  ];
+
   return (
     <Box
       component="form"
@@ -64,15 +124,18 @@ export default function TeamForm({ users = [], onSubmit, initial, submitText = '
         onChange={(_, v) => setLead(v)}
         renderInput={params => <TextField {...params} label="Team Lead" />}
       />
-      <FormGroup sx={{ gridColumn: 'span 2' }}>
-        {users.map(u => (
-          <FormControlLabel
-            key={u.id}
-            control={<Checkbox checked={members.includes(u.name)} onChange={() => toggleMember(u.name)} />}
-            label={u.name}
-          />
-        ))}
-      </FormGroup>
+      <Paper sx={{ gridColumn: 'span 2', height: 300 }}>
+        <DataGrid
+          rows={rows}
+          columns={columns}
+          checkboxSelection
+          disableRowSelectionOnClick
+          isRowSelectable={params => params.id !== lead?.id}
+          rowSelectionModel={selectionModel}
+          onRowSelectionModelChange={handleSelectionChange}
+          getRowId={row => row.id}
+        />
+      </Paper>
       <Button variant="contained" type="submit" sx={{ gridColumn: 'span 2' }}>
         {submitText}
       </Button>


### PR DESCRIPTION
## Summary
- switch TeamForm members UI to DataGrid table selection
- keep selected members and team lead at the top of the table
- prevent unselecting the lead row

## Testing
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_685a358d3b2083289f381b831363fee9