### PR TITLE
Set resources table defaults

### DIFF
--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -185,8 +185,13 @@ function TeamSetting() {
             columns={columns}
             getRowId={row => row.id}
             autoHeight
-            pageSize={25}
-            rowsPerPageOptions={[25]}
+            pageSize={10}
+            rowsPerPageOptions={[10]}
+            initialState={{
+              sorting: {
+                sortModel: [{ field: 'startDate', sort: 'asc' }],
+              },
+            }}
           />
         </Paper>
         <Popup open={open} onClose={() => setOpen(false)} title="Add Resource">

--- a/service/src/resources/data/resources.repository.ts
+++ b/service/src/resources/data/resources.repository.ts
@@ -22,7 +22,7 @@ export class ResourcesRepository {
   constructor(@InjectModel(Resource.name) private resourceModel: Model<Resource>) {}
 
   findAll(): Promise<Resource[]> {
-    return this.resourceModel.find().sort({ name: 1 }).exec();
+    return this.resourceModel.find().sort({ startDate: 1 }).exec();
   }
 
   create(data: CreateResourceInput): Promise<Resource> {


### PR DESCRIPTION
## Summary
- default the Resources list to ascending start date
- show 10 items per page on the Resources table

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685a4416069c8328a583cb27677cfc3f