### PR TITLE
Remove fixed 90% width

### DIFF
--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -16,7 +16,7 @@ export default function Layout({ children }) {
     <Box sx={{ display: 'flex' }}>
       <Topbar onMenuClick={handleToggleSidebar} />
       <Sidebar open={sidebarOpen} onClose={() => setOpen(false)} />
-      <Box component="main" sx={{ flexGrow: 1, p: 3, width: '90%', mx: 'auto' }}>
+      <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
         <Toolbar />
         {children}
       </Box>

--- a/client/pages/budget-management/index.tsx
+++ b/client/pages/budget-management/index.tsx
@@ -68,7 +68,7 @@ function BudgetManagement() {
 
   return (
     <Layout>
-      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
+      <Container maxWidth={false} sx={{ mt: 4 }}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
           <Typography variant="h5">Budget Management</Typography>
         </Box>

--- a/client/pages/budget-management/role-setting.tsx
+++ b/client/pages/budget-management/role-setting.tsx
@@ -70,7 +70,7 @@ function RoleSetting() {
 
   return (
     <Layout>
-      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
+      <Container maxWidth={false} sx={{ mt: 4 }}>
         <Typography variant="h5" gutterBottom>
           Role Setting
         </Typography>

--- a/client/pages/plan-management/index.tsx
+++ b/client/pages/plan-management/index.tsx
@@ -26,7 +26,7 @@ function PlanManagementOverview() {
 
   return (
     <Layout>
-      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
+      <Container maxWidth={false} sx={{ mt: 4 }}>
         <Paper sx={{ p: 2 }} elevation={3}>
           <Box
             sx={{

--- a/client/pages/plan-management/planing-setting.tsx
+++ b/client/pages/plan-management/planing-setting.tsx
@@ -7,7 +7,7 @@ import { withAuth } from '../../context/AuthContext';
 function PlanManagementSetting() {
   return (
     <Layout>
-      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
+      <Container maxWidth={false} sx={{ mt: 4 }}>
         <Typography variant="h5" gutterBottom>
           Planing Setting
         </Typography>

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -119,7 +119,7 @@ function ProjectManagement() {
 
   return (
     <Layout>
-      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
+      <Container maxWidth={false} sx={{ mt: 4 }}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
           <Typography variant="h5">Project Management</Typography>
           <Button variant="contained" onClick={() => setOpen(true)}>

--- a/client/pages/project/[id].tsx
+++ b/client/pages/project/[id].tsx
@@ -87,7 +87,7 @@ function ProjectDetail() {
   if (!project) {
     return (
       <Layout>
-        <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
+        <Container maxWidth={false} sx={{ mt: 4 }}>
           <Typography>Loading...</Typography>
         </Container>
       </Layout>
@@ -96,7 +96,7 @@ function ProjectDetail() {
 
   return (
     <Layout>
-      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
+      <Container maxWidth={false} sx={{ mt: 4 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
           <IconButton size="small" onClick={() => router.back()} sx={{ mr: 1 }}>
             <ArrowBackIosNew fontSize="small" />

--- a/client/pages/summary/detail.tsx
+++ b/client/pages/summary/detail.tsx
@@ -28,7 +28,7 @@ function SummaryDetail() {
 
   return (
     <Layout>
-      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
+      <Container maxWidth={false} sx={{ mt: 4 }}>
         <Typography variant="h5" gutterBottom>
           Summary Detail
         </Typography>

--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -167,7 +167,7 @@ function TeamSetting() {
   ];
   return (
     <Layout>
-      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
+      <Container maxWidth={false} sx={{ mt: 4 }}>
         <Typography variant="h5" gutterBottom>
           Team Setting
         </Typography>

--- a/client/pages/team-setting/team.tsx
+++ b/client/pages/team-setting/team.tsx
@@ -126,7 +126,7 @@ function TeamPage() {
 
   return (
     <Layout>
-      <Container maxWidth={false} sx={{ mt: 4, width: '90%' }}>
+      <Container maxWidth={false} sx={{ mt: 4 }}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
           <Typography variant="h5">Teams</Typography>
           <Button variant="contained" onClick={() => setOpen(true)}>


### PR DESCRIPTION
## Summary
- remove 90% width from main Layout component
- use full width for content containers

## Testing
- `npm test --silent` in `client`
- `npm test --silent` in `service`


------
https://chatgpt.com/codex/tasks/task_e_685a47a117e88328bea4a3a4768c69e2