### PR TITLE
Fix team member count

### DIFF
--- a/client/pages/team-setting/team.tsx
+++ b/client/pages/team-setting/team.tsx
@@ -87,7 +87,8 @@ function TeamPage() {
       width: 120,
       valueGetter: (_value, row) => {
         if (Array.isArray(row?.members)) {
-          return row.members.length;
+          const count = row.members.length + (row.lead ? 1 : 0);
+          return count;
         }
         return '';
       },


### PR DESCRIPTION
## Summary
- count team lead when computing `Total Member` on team list

## Testing
- `npm test --silent` in `service`
- `npm test --silent` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685a4c1ca9708328a4094b667f8a0127