### PR TITLE
Add dashboard overview

### DIFF
--- a/client/components/BudgetTable.tsx
+++ b/client/components/BudgetTable.tsx
@@ -34,16 +34,18 @@ export default function BudgetTable({ data, onEdit, onDelete }) {
       valueFormatter: ({ value }) =>
         typeof value === 'number' ? currencyFormatter.format(value) : value,
     },
-    {
+    (onEdit || onDelete) && {
       field: 'actions',
       headerName: 'Action',
       width: 120,
       sortable: false,
       renderCell: params => (
         <Box>
-          <IconButton size="small" onClick={() => onEdit(params.row)}>
-            <EditIcon fontSize="small" />
-          </IconButton>
+          {onEdit && (
+            <IconButton size="small" onClick={() => onEdit(params.row)}>
+              <EditIcon fontSize="small" />
+            </IconButton>
+          )}
           {onDelete && (
             <IconButton size="small" onClick={() => onDelete(params.row)}>
               <DeleteIcon fontSize="small" />
@@ -52,7 +54,7 @@ export default function BudgetTable({ data, onEdit, onDelete }) {
         </Box>
       ),
     },
-  ];
+  ].filter(Boolean);
 
   return (
     <Paper>

--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -69,6 +69,19 @@ export default function Sidebar({ open, onClose }) {
             <List component="div" disablePadding>
               <ListItemButton
                 sx={{ pl: 4 }}
+                selected={router.pathname === '/summary/overview'}
+                onClick={() => {
+                  router.push('/summary/overview');
+                  onClose();
+                }}
+              >
+                <ListItemIcon>
+                  <DashboardIcon fontSize="small" />
+                </ListItemIcon>
+                <ListItemText primary="Overview" />
+              </ListItemButton>
+              <ListItemButton
+                sx={{ pl: 4 }}
                 selected={router.pathname === '/summary/detail'}
                 onClick={() => {
                   router.push('/summary/detail');

--- a/client/pages/summary/overview.tsx
+++ b/client/pages/summary/overview.tsx
@@ -1,0 +1,88 @@
+// @ts-nocheck
+import { useEffect, useState } from 'react';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import { PieChart, LineChart } from '@mui/x-charts';
+import { Layout } from '../../components';
+import { withAuth } from '../../context/AuthContext';
+import { fetchBudgetOverview } from '../../models/budgetModel';
+import api from '../../api';
+
+function DashboardOverview() {
+  const [overview, setOverview] = useState([]);
+  const [unassigned, setUnassigned] = useState(0);
+
+  async function loadData() {
+    const [ov, res, pro] = await Promise.all([
+      fetchBudgetOverview(),
+      api.get('/api/v1/resources'),
+      api.get('/api/v1/projects'),
+    ]);
+    setOverview(ov);
+
+    const assigned = new Set();
+    pro.data.forEach(p => {
+      if (p.lead?._id) assigned.add(p.lead._id);
+      if (Array.isArray(p.members)) p.members.forEach(id => assigned.add(id));
+    });
+    setUnassigned(res.data.filter(r => !assigned.has(r.id)).length);
+  }
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  const totalCost = overview.reduce((sum, o) => sum + o.count * o.rate, 0);
+  const costData = Array.from({ length: 6 }, (_, i) => ({
+    month: `M${i + 1}`,
+    cost: Math.round(totalCost * Math.pow(0.9, i)),
+  }));
+
+  const pieData = overview
+    .filter(o => o.count > 0)
+    .map(o => ({ id: o.id, value: o.count, label: `${o.role} - ${o.level}` }));
+
+  return (
+    <Layout>
+      <Container maxWidth={false} sx={{ mt: 4 }}>
+        <Typography variant="h5" gutterBottom>
+          Dashboard Overview
+        </Typography>
+        <Grid container spacing={2}>
+          <Grid item xs={12} md={4}>
+            <Paper sx={{ p: 2, textAlign: 'center' }}>
+              <Typography variant="h6">Unassigned Resources</Typography>
+              <Typography variant="h4">{unassigned}</Typography>
+            </Paper>
+          </Grid>
+          <Grid item xs={12} md={8}>
+            <Paper sx={{ p: 2 }}>
+              <Typography variant="h6" gutterBottom>
+                Resource Distribution
+              </Typography>
+              <PieChart height={200} series={[{ data: pieData }]} />
+            </Paper>
+          </Grid>
+          <Grid item xs={12}>
+            <Paper sx={{ p: 2 }}>
+              <Typography variant="h6" gutterBottom>
+                Monthly Cost Target (10% Reduction)
+              </Typography>
+              <LineChart
+                height={300}
+                dataset={costData}
+                xAxis={[{ dataKey: 'month', scaleType: 'band' }]}
+                series={[{ dataKey: 'cost', label: 'Cost' }]}
+              />
+            </Paper>
+          </Grid>
+        </Grid>
+      </Container>
+    </Layout>
+  );
+}
+
+export default withAuth(DashboardOverview);


### PR DESCRIPTION
## Summary
- add `/summary/overview` page showing charts for resource distribution and cost trend
- allow optional action buttons in `BudgetTable`
- extend sidebar with Dashboard Overview link

## Testing
- `npm run check` in client
- `npm test` in client
- `npm run check` in service
- `npm test` in service

------
https://chatgpt.com/codex/tasks/task_e_685a4bcf2d948328bde79de5cda7889a