### PR TITLE
Add Excel export for resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ endpoint for creating projects with a structured body containing the project
 name, resources, start and end dates, manday estimate and priority.
 For convenience the service also offers `GET /api/v1/users` which lists all
 registered users so the client can populate team selection menus.
+It additionally supports `GET /api/v1/resources/export` to download all
+resources as an Excel file.
 
 An admin user is created automatically with username `admin` and password taken
 from the `ADMIN_PASSWORD` environment variable (default `admin`).

--- a/client/models/resourceModel.ts
+++ b/client/models/resourceModel.ts
@@ -19,3 +19,10 @@ export async function deleteResource(id) {
   const { data } = await api.delete(`/api/v1/resources/${id}`);
   return data;
 }
+
+export async function exportResources() {
+  const { data } = await api.get('/api/v1/resources/export', {
+    responseType: 'blob',
+  });
+  return data;
+}

--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -10,6 +10,7 @@ import Stack from '@mui/material/Stack';
 import IconButton from '@mui/material/IconButton';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
+import DownloadIcon from '@mui/icons-material/Download';
 import {
   format,
   differenceInYears,
@@ -25,6 +26,7 @@ import {
   createResource,
   updateResource,
   deleteResource,
+  exportResources,
 } from '../../models/resourceModel';
 import api from '../../api';
 
@@ -111,6 +113,21 @@ function TeamSetting() {
       }
     }
   };
+
+  const handleExport = async () => {
+    try {
+      const blob = await exportResources();
+      const url = window.URL.createObjectURL(new Blob([blob]));
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', 'resources.xlsx');
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } catch (e) {
+      showToast('Error exporting resources', { severity: 'error' });
+    }
+  };
   const columns = [
     {
       field: 'no',
@@ -191,13 +208,21 @@ function TeamSetting() {
   return (
     <Layout>
       <Container maxWidth={false} sx={{ mt: 4 }}>
-        <Box
-          sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}
-        >
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
           <Typography variant="h5">Resources</Typography>
-          <Button variant="contained" onClick={() => setOpen(true)}>
-            New Resource
-          </Button>
+          <Box>
+            <Button
+              variant="outlined"
+              startIcon={<DownloadIcon />}
+              onClick={handleExport}
+              sx={{ mr: 1 }}
+            >
+              Export
+            </Button>
+            <Button variant="contained" onClick={() => setOpen(true)}>
+              New Resource
+            </Button>
+          </Box>
         </Box>
         <Paper>
           <DataGrid

--- a/service/__tests__/resources.export.test.ts
+++ b/service/__tests__/resources.export.test.ts
@@ -1,0 +1,23 @@
+import { ResourcesService } from '../src/resources/resources.service';
+
+class MockRepo {
+  findAll() {
+    return Promise.resolve([
+      {
+        name: 'Test',
+        email: 'test@example.com',
+        position: 'dev',
+        startDate: new Date('2020-01-01'),
+      },
+    ]);
+  }
+}
+
+describe('ResourcesService exportExcel', () => {
+  it('should return a buffer', async () => {
+    const service = new ResourcesService(new MockRepo() as any);
+    const buf = await service.exportExcel();
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect(buf.byteLength).toBeGreaterThan(0);
+  });
+});

--- a/service/package.json
+++ b/service/package.json
@@ -23,7 +23,8 @@
     "rxjs": "^7.0.0",
     "dotenv": "^16.0.0",
     "@nestjs/swagger": "^6.3.0",
-    "swagger-ui-express": "^5.0.1"
+    "swagger-ui-express": "^5.0.1",
+    "exceljs": "^4.3.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",

--- a/service/src/resources/resources.controller.ts
+++ b/service/src/resources/resources.controller.ts
@@ -6,7 +6,9 @@ import {
   Patch,
   Delete,
   Param,
+  Res,
 } from '@nestjs/common';
+import { Response } from 'express';
 import { ResourcesService } from './resources.service';
 import {
   CreateResourceInput,
@@ -20,6 +22,17 @@ export class ResourcesController {
   @Get()
   getResources() {
     return this.service.getResources();
+  }
+
+  @Get('export')
+  async exportResources(@Res() res: Response) {
+    const buffer = await this.service.exportExcel();
+    res.set({
+      'Content-Type':
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'Content-Disposition': 'attachment; filename=resources.xlsx',
+    });
+    res.send(buffer);
   }
 
   @Post()

--- a/service/src/resources/resources.service.ts
+++ b/service/src/resources/resources.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import ExcelJS from 'exceljs';
 import {
   ResourcesRepository,
   CreateResourceInput,
@@ -31,5 +32,28 @@ export class ResourcesService {
 
   remove(id: string) {
     return this.repo.remove(id);
+  }
+
+  async exportExcel() {
+    const resources = await this.repo.findAll();
+    const wb = new ExcelJS.Workbook();
+    const ws = wb.addWorksheet('Resources');
+    ws.columns = [
+      { header: 'Name', key: 'name', width: 20 },
+      { header: 'Email', key: 'email', width: 30 },
+      { header: 'Position', key: 'position', width: 20 },
+      { header: 'Start Date', key: 'startDate', width: 15 },
+    ];
+    resources.forEach(r => {
+      ws.addRow({
+        name: r.name,
+        email: r.email,
+        position: r.position,
+        startDate: r.startDate
+          ? new Date(r.startDate).toISOString().split('T')[0]
+          : '',
+      });
+    });
+    return wb.xlsx.writeBuffer();
   }
 }


### PR DESCRIPTION
## Summary
- support Excel download on the service
- expose `GET /api/v1/resources/export`
- add client helper and UI button for export
- document new endpoint
- test exporting behaviour

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685a53755b8c8328a377b329755a134b