### PR TITLE
Improve resource export with full headers

### DIFF
--- a/service/__tests__/resources.export.test.ts
+++ b/service/__tests__/resources.export.test.ts
@@ -13,9 +13,18 @@ class MockRepo {
   }
 }
 
+class MockPositionsService {
+  getPositions() {
+    return Promise.resolve([{ value: 'dev_junior', label: 'Dev - junior' }]);
+  }
+}
+
 describe('ResourcesService exportExcel', () => {
   it('should return a buffer', async () => {
-    const service = new ResourcesService(new MockRepo() as any);
+    const service = new ResourcesService(
+      new MockRepo() as any,
+      new MockPositionsService() as any,
+    );
     const buf = await service.exportExcel();
     expect(Buffer.isBuffer(buf)).toBe(true);
     expect(buf.byteLength).toBeGreaterThan(0);

--- a/service/package.json
+++ b/service/package.json
@@ -24,7 +24,8 @@
     "dotenv": "^16.0.0",
     "@nestjs/swagger": "^6.3.0",
     "swagger-ui-express": "^5.0.1",
-    "exceljs": "^4.3.0"
+    "exceljs": "^4.3.0",
+    "date-fns": "^4.1.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",

--- a/service/src/resources/resources.module.ts
+++ b/service/src/resources/resources.module.ts
@@ -4,9 +4,13 @@ import { ResourcesController } from './resources.controller';
 import { ResourcesService } from './resources.service';
 import { ResourcesRepository } from './data/resources.repository';
 import { Resource, ResourceSchema } from './data/resource.schema';
+import { PositionsModule } from '../positions/positions.module';
 
 @Module({
-  imports: [MongooseModule.forFeature([{ name: Resource.name, schema: ResourceSchema }])],
+  imports: [
+    MongooseModule.forFeature([{ name: Resource.name, schema: ResourceSchema }]),
+    PositionsModule,
+  ],
   controllers: [ResourcesController],
   providers: [ResourcesService, ResourcesRepository],
   exports: [ResourcesService],

--- a/service/src/resources/resources.service.ts
+++ b/service/src/resources/resources.service.ts
@@ -1,14 +1,25 @@
 import { Injectable } from '@nestjs/common';
 import ExcelJS from 'exceljs';
 import {
+  differenceInYears,
+  differenceInMonths,
+  differenceInDays,
+  addYears,
+  addMonths,
+} from 'date-fns';
+import {
   ResourcesRepository,
   CreateResourceInput,
   UpdateResourceInput,
 } from './data/resources.repository';
+import { PositionsService } from '../positions/positions.service';
 
 @Injectable()
 export class ResourcesService {
-  constructor(private readonly repo: ResourcesRepository) {}
+  constructor(
+    private readonly repo: ResourcesRepository,
+    private readonly positionsService: PositionsService,
+  ) {}
 
   getResources() {
     return this.repo.findAll().then(resources =>
@@ -35,23 +46,61 @@ export class ResourcesService {
   }
 
   async exportExcel() {
-    const resources = await this.repo.findAll();
+    const [resources, positions] = await Promise.all([
+      this.repo.findAll(),
+      this.positionsService.getPositions(),
+    ]);
+
+    const posMap: Record<string, { role: string; level: string }> = {};
+    positions.forEach(p => {
+      const [role, level] = p.label.split(' - ');
+      posMap[p.value] = { role, level };
+    });
+
+    function getServiceDuration(date: Date) {
+      const start = new Date(date);
+      const now = new Date();
+      const years = differenceInYears(now, start);
+      const afterYears = addYears(start, years);
+      const months = differenceInMonths(now, afterYears);
+      const afterMonths = addMonths(afterYears, months);
+      const days = differenceInDays(now, afterMonths);
+      return `${years}y ${months}m ${days}d`;
+    }
+
+    function getServiceExp(date: Date) {
+      const years = differenceInYears(new Date(), new Date(date));
+      if (years <= 2) return 'junior';
+      if (years <= 4) return 'intermediate';
+      if (years <= 6) return 'senior';
+      return 'advance';
+    }
+
     const wb = new ExcelJS.Workbook();
     const ws = wb.addWorksheet('Resources');
     ws.columns = [
+      { header: 'No.', key: 'no', width: 5 },
       { header: 'Name', key: 'name', width: 20 },
       { header: 'Email', key: 'email', width: 30 },
-      { header: 'Position', key: 'position', width: 20 },
+      { header: 'Role', key: 'role', width: 20 },
+      { header: 'Level', key: 'level', width: 10 },
       { header: 'Start Date', key: 'startDate', width: 15 },
+      { header: 'Service Year', key: 'serviceYear', width: 15 },
+      { header: 'Service Exp', key: 'serviceExp', width: 15 },
     ];
-    resources.forEach(r => {
+
+    resources.forEach((r, idx) => {
+      const map = posMap[r.position] || { role: '', level: '' };
+      const start = r.startDate ? new Date(r.startDate) : null;
       ws.addRow({
+        no: idx + 1,
         name: r.name,
         email: r.email,
-        position: r.position,
-        startDate: r.startDate
-          ? new Date(r.startDate).toISOString().split('T')[0]
-          : '',
+        role: map.role,
+        level: map.level,
+        startDate: start ? start.toISOString().split('T')[0] : '',
+        serviceYear: start ? getServiceDuration(start) : '',
+        serviceExp: start ? getServiceExp(start) : '',
       });
     });
     return wb.xlsx.writeBuffer();


### PR DESCRIPTION
## Summary
- include Position module in resources
- compute role, level and service durations when exporting resources
- expose new `date-fns` dependency for the service
- adjust export test for new constructor

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685a57312bf88328960c0e7181c7dac9