### PR TITLE
Implement multi-step project creation

### DIFF
--- a/client/components/ProjectForm.tsx
+++ b/client/components/ProjectForm.tsx
@@ -1,21 +1,54 @@
 // @ts-nocheck
-import { useState } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Autocomplete from '@mui/material/Autocomplete';
+import Stepper from '@mui/material/Stepper';
+import Step from '@mui/material/Step';
+import StepLabel from '@mui/material/StepLabel';
+import Typography from '@mui/material/Typography';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import TableCell from '@mui/material/TableCell';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 
-export default function ProjectForm({ users = [], onSubmit }) {
-  const [name, setName] = useState('');
-  const [description, setDescription] = useState('');
-  const [start, setStart] = useState(null);
-  const [lead, setLead] = useState(null);
-  const [members, setMembers] = useState([]);
-  const [manday, setManday] = useState('');
+export default function ProjectForm({
+  users = [],
+  teams = [],
+  budgets = [],
+  onSubmit,
+  initial,
+  submitText = 'Create',
+}) {
+  const [active, setActive] = useState(0);
+  const [team, setTeam] = useState(null);
+  const [name, setName] = useState(initial?.name || '');
+  const [description, setDescription] = useState(initial?.description || '');
+  const [start, setStart] = useState(initial?.start || null);
+  const [lead, setLead] = useState(initial?.lead || null);
+  const [members, setMembers] = useState(initial?.members || []);
+  const [manday, setManday] = useState(
+    initial?.manday != null ? String(initial.manday) : ''
+  );
+
+  useEffect(() => {
+    setName(initial?.name || '');
+    setDescription(initial?.description || '');
+    setStart(initial?.start || null);
+    setLead(initial?.lead || null);
+    setMembers(initial?.members || []);
+    setManday(initial?.manday != null ? String(initial.manday) : '');
+  }, [initial]);
 
   const handleSubmit = e => {
     e.preventDefault();
+    if (active < 2) {
+      setActive(a => a + 1);
+      return;
+    }
     if (onSubmit) {
       onSubmit({
         name,
@@ -34,7 +67,52 @@ export default function ProjectForm({ users = [], onSubmit }) {
     setLead(null);
     setMembers([]);
     setManday('');
+    setActive(0);
+    setTeam(null);
   };
+
+  const handleTeamChange = (_: any, v: any) => {
+    setTeam(v);
+    if (v) {
+      const leadObj = users.find(u => u.name === v.lead) || null;
+      const memObjs = Array.isArray(v.members)
+        ? v.members
+            .map((n: string) => users.find(u => u.name === n) || null)
+            .filter(Boolean)
+        : [];
+      setLead(leadObj);
+      setMembers(memObjs);
+    }
+  };
+
+  const rateMap = useMemo(() => {
+    const map = {} as Record<string, number>;
+    budgets.forEach(b => {
+      map[b.id] = b.rate;
+    });
+    return map;
+  }, [budgets]);
+
+  const summary = useMemo(() => {
+    const counts: Record<string, number> = {};
+    const list = [lead, ...members].filter(Boolean);
+    list.forEach(r => {
+      counts[r.position] = (counts[r.position] || 0) + 1;
+    });
+    const rows = Object.entries(counts).map(([pos, count]) => ({
+      pos,
+      count,
+      rate: rateMap[pos] || 0,
+      cost: count * (rateMap[pos] || 0),
+    }));
+    const total = rows.reduce((s, r) => s + r.cost, 0);
+    return { rows, total };
+  }, [lead, members, rateMap]);
+
+  const currencyFormatter = useMemo(
+    () => new Intl.NumberFormat('th-TH', { style: 'currency', currency: 'THB' }),
+    [],
+  );
 
   return (
     <Box
@@ -46,45 +124,145 @@ export default function ProjectForm({ users = [], onSubmit }) {
         gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
       }}
     >
-      <TextField label="Name" value={name} onChange={e => setName(e.target.value)} required />
-      <TextField
-        label="Description"
-        value={description}
-        onChange={e => setDescription(e.target.value)}
-        multiline
-        sx={{ gridColumn: 'span 2' }}
-      />
-      <DatePicker
-        label="Start Date"
-        value={start}
-        onChange={setStart}
-        slotProps={{ textField: { required: true } }}
-      />
-      <Autocomplete
-        options={users}
-        getOptionLabel={o => o.name}
-        value={lead}
-        onChange={(_, v) => setLead(v)}
-        renderInput={params => <TextField {...params} label="Team Lead" required />}
-      />
-      <Autocomplete
-        multiple
-        options={users}
-        getOptionLabel={o => o.name}
-        value={members}
-        onChange={(_, v) => setMembers(v)}
-        renderInput={params => <TextField {...params} label="Members" />}
-        sx={{ gridColumn: 'span 2' }}
-      />
-      <TextField
-        label="Manday"
-        type="number"
-        value={manday}
-        onChange={e => setManday(e.target.value)}
-      />
-      <Button type="submit" variant="contained" sx={{ gridColumn: 'span 2' }}>
-        Create
-      </Button>
+      <Stepper activeStep={active} sx={{ gridColumn: 'span 2' }}>
+        {['General', 'Members', 'Review'].map(label => (
+          <Step key={label}>
+            <StepLabel>{label}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
+
+      {active === 0 && (
+        <>
+          <TextField
+            label="Name"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            required
+          />
+          <TextField
+            label="Description"
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            multiline
+            sx={{ gridColumn: 'span 2' }}
+          />
+          <DatePicker
+            label="Start Date"
+            value={start}
+            onChange={setStart}
+            slotProps={{ textField: { required: true } }}
+          />
+          <TextField
+            label="Manday"
+            type="number"
+            value={manday}
+            onChange={e => setManday(e.target.value)}
+          />
+        </>
+      )}
+
+      {active === 1 && (
+        <>
+          <Autocomplete
+            options={teams}
+            getOptionLabel={o => o.name}
+            value={team}
+            onChange={handleTeamChange}
+            renderInput={params => <TextField {...params} label="Team" />}
+            sx={{ gridColumn: 'span 2' }}
+          />
+          <Autocomplete
+            options={users}
+            getOptionLabel={o => o.name}
+            value={lead}
+            onChange={(_, v) => setLead(v)}
+            renderInput={params => <TextField {...params} label="Team Lead" required />}
+          />
+          <Autocomplete
+            multiple
+            options={users}
+            getOptionLabel={o => o.name}
+            value={members}
+            onChange={(_, v) => setMembers(v)}
+            renderInput={params => <TextField {...params} label="Members" />}
+            sx={{ gridColumn: 'span 2' }}
+          />
+        </>
+      )}
+
+      {active === 2 && (
+        <>
+          <Typography sx={{ gridColumn: 'span 2' }} variant="h6">
+            Review
+          </Typography>
+          <Box sx={{ gridColumn: 'span 2', display: 'grid', rowGap: 1 }}>
+            <Typography>
+              <strong>Name:</strong> {name}
+            </Typography>
+            <Typography>
+              <strong>Description:</strong> {description}
+            </Typography>
+            <Typography>
+              <strong>Start:</strong>{' '}
+              {start ? new Date(start).toLocaleDateString() : ''}
+            </Typography>
+            <Typography>
+              <strong>Manday:</strong> {manday}
+            </Typography>
+            <Typography>
+              <strong>Lead:</strong> {lead?.name || ''}
+            </Typography>
+            <Typography>
+              <strong>Members:</strong>{' '}
+              {members.map(m => m.name).join(', ')}
+            </Typography>
+          </Box>
+          {summary.rows.length > 0 && (
+            <Table size="small" sx={{ gridColumn: 'span 2' }}>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Position</TableCell>
+                  <TableCell>Count</TableCell>
+                  <TableCell>Rate/MD</TableCell>
+                  <TableCell>Cost/Day</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {summary.rows.map(r => (
+                  <TableRow key={r.pos}>
+                    <TableCell>{r.pos.replace('_', ' ')}</TableCell>
+                    <TableCell>{r.count}</TableCell>
+                    <TableCell>{currencyFormatter.format(r.rate)}</TableCell>
+                    <TableCell>{currencyFormatter.format(r.cost)}</TableCell>
+                  </TableRow>
+                ))}
+                <TableRow>
+                  <TableCell colSpan={3}>Total / Day</TableCell>
+                  <TableCell>{currencyFormatter.format(summary.total)}</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          )}
+        </>
+      )}
+
+      <Box sx={{ gridColumn: 'span 2', display: 'flex', justifyContent: 'space-between' }}>
+        {active > 0 && (
+          <Button type="button" onClick={() => setActive(a => a - 1)}>
+            Back
+          </Button>
+        )}
+        {active < 2 ? (
+          <Button type="button" variant="contained" onClick={() => setActive(a => a + 1)}>
+            Next
+          </Button>
+        ) : (
+          <Button type="submit" variant="contained">
+            {submitText}
+          </Button>
+        )}
+      </Box>
     </Box>
   );
 }

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -24,12 +24,20 @@ function ProjectManagement() {
   const [projects, setProjects] = useState([]);
   const [users, setUsers] = useState([]);
   const [open, setOpen] = useState(false);
+  const [teams, setTeams] = useState([]);
+  const [budgets, setBudgets] = useState([]);
 
   async function loadData() {
-    const pro = await api.get('/api/v1/projects');
+    const [pro, usr, tm, bg] = await Promise.all([
+      api.get('/api/v1/projects'),
+      api.get('/api/v1/resources'),
+      api.get('/api/v1/teams'),
+      api.get('/api/v1/budgets/overview'),
+    ]);
     setProjects(pro.data);
-    const usr = await api.get('/api/v1/resources');
     setUsers(usr.data);
+    setTeams(tm.data);
+    setBudgets(bg.data);
   }
 
   useEffect(() => {
@@ -137,7 +145,12 @@ function ProjectManagement() {
           />
         </Paper>
         <Popup open={open} onClose={() => setOpen(false)} title="Add Project">
-          <ProjectForm users={users} onSubmit={handleCreate} />
+          <ProjectForm
+            users={users}
+            teams={teams}
+            budgets={budgets}
+            onSubmit={handleCreate}
+          />
         </Popup>
       </Container>
     </Layout>

--- a/client/pages/project/[id].tsx
+++ b/client/pages/project/[id].tsx
@@ -23,6 +23,8 @@ function ProjectDetail() {
   const { showToast } = useToast();
   const [project, setProject] = useState(null);
   const [users, setUsers] = useState([]);
+  const [teams, setTeams] = useState([]);
+  const [budgets, setBudgets] = useState([]);
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
@@ -30,9 +32,13 @@ function ProjectDetail() {
       Promise.all([
         api.get(`/api/v1/projects/${id}`),
         api.get('/api/v1/resources'),
-      ]).then(([p, u]) => {
+        api.get('/api/v1/teams'),
+        api.get('/api/v1/budgets/overview'),
+      ]).then(([p, u, t, b]) => {
         setProject(p.data);
         setUsers(u.data);
+        setTeams(t.data);
+        setBudgets(b.data);
       });
     }
   }, [id]);
@@ -188,6 +194,8 @@ function ProjectDetail() {
           {project && (
             <ProjectForm
               users={users}
+              teams={teams}
+              budgets={budgets}
               onSubmit={handleSave}
               initial={{
                 name: project.name,


### PR DESCRIPTION
## Summary
- enhance `ProjectForm` with a stepper UI
- fetch teams and budget rates when creating/editing a project
- show project summary with daily cost per position

## Testing
- `npm test --prefix client`
- `npm test --prefix service`


------
https://chatgpt.com/codex/tasks/task_e_685a5902909083288e8d5020491cbde3