### PR TITLE
Add project status options and update table headers

### DIFF
--- a/client/components/ProjectForm.tsx
+++ b/client/components/ProjectForm.tsx
@@ -28,6 +28,7 @@ export default function ProjectForm({
   const [name, setName] = useState(initial?.name || '');
   const [description, setDescription] = useState(initial?.description || '');
   const [start, setStart] = useState(initial?.start || null);
+  const [status, setStatus] = useState(initial?.status || 'planing');
   const [lead, setLead] = useState(initial?.lead || null);
   const [members, setMembers] = useState(initial?.members || []);
   const [manday, setManday] = useState(
@@ -41,6 +42,7 @@ export default function ProjectForm({
     setLead(initial?.lead || null);
     setMembers(initial?.members || []);
     setManday(initial?.manday != null ? String(initial.manday) : '');
+    setStatus(initial?.status || 'planing');
   }, [initial]);
 
   const handleSubmit = e => {
@@ -55,6 +57,7 @@ export default function ProjectForm({
         description,
         start,
         end: start,
+        status,
         ...(manday ? { manday: Number(manday) } : {}),
         priority: 1,
         lead: lead?.id,
@@ -67,6 +70,7 @@ export default function ProjectForm({
     setLead(null);
     setMembers([]);
     setManday('');
+    setStatus('planing');
     setActive(0);
     setTeam(null);
   };
@@ -125,7 +129,7 @@ export default function ProjectForm({
       }}
     >
       <Stepper activeStep={active} sx={{ gridColumn: 'span 2' }}>
-        {['General', 'Members', 'Review'].map(label => (
+        {['General', 'Members', 'Preview'].map(label => (
           <Step key={label}>
             <StepLabel>{label}</StepLabel>
           </Step>
@@ -152,6 +156,20 @@ export default function ProjectForm({
             value={start}
             onChange={setStart}
             slotProps={{ textField: { required: true } }}
+          />
+          <Autocomplete
+            options={[
+              'planing',
+              'in progress',
+              'production',
+              'waiting payment',
+              'paid',
+            ]}
+            value={status}
+            onChange={(_, v) => setStatus(v)}
+            renderInput={params => (
+              <TextField {...params} label="Status" required />
+            )}
           />
           <TextField
             label="Manday"
@@ -194,7 +212,7 @@ export default function ProjectForm({
       {active === 2 && (
         <>
           <Typography sx={{ gridColumn: 'span 2' }} variant="h6">
-            Review
+            Preview
           </Typography>
           <Box sx={{ gridColumn: 'span 2', display: 'grid', rowGap: 1 }}>
             <Typography>
@@ -203,16 +221,19 @@ export default function ProjectForm({
             <Typography>
               <strong>Description:</strong> {description}
             </Typography>
-            <Typography>
-              <strong>Start:</strong>{' '}
-              {start ? new Date(start).toLocaleDateString() : ''}
-            </Typography>
-            <Typography>
-              <strong>Manday:</strong> {manday}
-            </Typography>
-            <Typography>
-              <strong>Lead:</strong> {lead?.name || ''}
-            </Typography>
+          <Typography>
+            <strong>Start:</strong>{' '}
+            {start ? new Date(start).toLocaleDateString() : ''}
+          </Typography>
+          <Typography>
+            <strong>Manday:</strong> {manday}
+          </Typography>
+          <Typography>
+            <strong>Status:</strong> {status}
+          </Typography>
+          <Typography>
+            <strong>Lead:</strong> {lead?.name || ''}
+          </Typography>
             <Typography>
               <strong>Members:</strong>{' '}
               {members.map(m => m.name).join(', ')}

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -80,20 +80,24 @@ function ProjectManagement() {
     },
     { field: 'status', headerName: 'Status', flex: 1 },
     {
-      field: 'totalDay',
-      headerName: 'Total Day',
-      width: 100,
-      valueGetter: (_value, row) =>
-        row.start ? differenceInDays(new Date(), new Date(row.start)) : '',
+      field: 'totalMember',
+      headerName: 'Total Member',
+      width: 120,
+      valueGetter: (_value, row) => row.resources ?? row.members?.length ?? 0,
     },
     {
-      field: 'remainManday',
-      headerName: 'Remain Manday',
-      width: 150,
+      field: 'actualManday',
+      headerName: 'Total Actual Manday',
+      width: 160,
       valueGetter: (_value, row) =>
-        row.start && typeof row.manday === 'number'
-          ? row.manday - differenceInDays(new Date(), new Date(row.start))
+        row.start && row.resources
+          ? differenceInDays(new Date(), new Date(row.start)) * row.resources
           : '',
+    },
+    {
+      field: 'manday',
+      headerName: 'Estimate Manday',
+      width: 150,
     },
     {
       field: 'start',
@@ -101,6 +105,12 @@ function ProjectManagement() {
       width: 120,
       valueGetter: (_value, row) =>
         row.start ? format(new Date(row.start), 'yyyy-MM-dd') : '',
+    },
+    {
+      field: 'projectService',
+      headerName: 'Project Service',
+      width: 130,
+      valueGetter: (_value, row) => row.priority ?? '',
     },
     {
       field: 'actions',

--- a/client/pages/project/[id].tsx
+++ b/client/pages/project/[id].tsx
@@ -201,6 +201,7 @@ function ProjectDetail() {
                 name: project.name,
                 description: project.description,
                 start: project.start ? new Date(project.start) : null,
+                status: project.status || 'planing',
                 lead: leadResource || null,
                 members,
                 manday: project.manday ?? ''


### PR DESCRIPTION
## Summary
- allow selecting project status when creating or editing a project
- show preview step instead of review for new project flow
- display status in preview summary
- update project table headers and columns

## Testing
- `npm test` *(fails: jest not found)*
- `npm run check` in client *(fails: next not found)*
- `npm test` in service *(fails: jest not found)*
- `npm run check` in service *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6012b26c832881598a40553e30e6