### PR TITLE
Fix project form preview flow

### DIFF
--- a/client/components/ProjectForm.tsx
+++ b/client/components/ProjectForm.tsx
@@ -45,12 +45,12 @@ export default function ProjectForm({
     setStatus(initial?.status || 'planing');
   }, [initial]);
 
+  const handleNext = () => setActive(a => Math.min(a + 1, 2));
+  const handleBack = () => setActive(a => Math.max(a - 1, 0));
+
   const handleSubmit = e => {
     e.preventDefault();
-    if (active < 2) {
-      setActive(a => a + 1);
-      return;
-    }
+    if (active < 2) return handleNext();
     if (onSubmit) {
       onSubmit({
         name,
@@ -270,12 +270,12 @@ export default function ProjectForm({
 
       <Box sx={{ gridColumn: 'span 2', display: 'flex', justifyContent: 'space-between' }}>
         {active > 0 && (
-          <Button type="button" onClick={() => setActive(a => a - 1)}>
+          <Button type="button" onClick={handleBack}>
             Back
           </Button>
         )}
         {active < 2 ? (
-          <Button type="button" variant="contained" onClick={() => setActive(a => a + 1)}>
+          <Button type="button" variant="contained" onClick={handleNext}>
             Next
           </Button>
         ) : (


### PR DESCRIPTION
## Summary
- keep state on preview step before creation
- add helper handlers for next/back navigation

## Testing
- `npm run build` in `client`
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_685a65508a088328a2d197f7367d246e