### PR TITLE
Implement workday settings

### DIFF
--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -241,11 +241,24 @@ export default function Sidebar({ open, onClose }) {
                 <ListItemIcon>
                   <GroupIcon fontSize="small" />
                 </ListItemIcon>
-                <ListItemText primary="Team" />
-              </ListItemButton>
-            </List>
-          </Collapse>
-        )}
+              <ListItemText primary="Team" />
+            </ListItemButton>
+            <ListItemButton
+              sx={{ pl: 4 }}
+              selected={router.pathname === '/team-setting/workday'}
+              onClick={() => {
+                router.push('/team-setting/workday');
+                onClose();
+              }}
+            >
+              <ListItemIcon>
+                <CalendarMonthIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText primary="Workday" />
+            </ListItemButton>
+          </List>
+        </Collapse>
+      )}
       </List>
     </Drawer>
   );

--- a/client/components/WorkdayForm.tsx
+++ b/client/components/WorkdayForm.tsx
@@ -1,0 +1,33 @@
+// @ts-nocheck
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { useState, useEffect } from 'react';
+import { Input } from '.';
+
+export default function WorkdayForm({ onSubmit, initial, submitText = 'Create' }) {
+  const [name, setName] = useState(initial?.name || '');
+  const [date, setDate] = useState(initial?.date ? new Date(initial.date) : null);
+
+  useEffect(() => {
+    setName(initial?.name || '');
+    setDate(initial?.date ? new Date(initial.date) : null);
+  }, [initial]);
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    if (onSubmit && date) {
+      onSubmit({ name, date });
+    }
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} sx={{ display: 'grid', gap: 2 }}>
+      <Input label="Name" value={name} onChange={e => setName(e.target.value)} required />
+      <DatePicker label="Date" value={date} onChange={setDate} slotProps={{ textField: { required: true } }} />
+      <Button variant="contained" type="submit">
+        {submitText}
+      </Button>
+    </Box>
+  );
+}

--- a/client/components/index.tsx
+++ b/client/components/index.tsx
@@ -14,3 +14,4 @@ export { default as ProjectForm } from './ProjectForm';
 export { default as BudgetForm } from './BudgetForm';
 export { default as BudgetTable } from './BudgetTable';
 export { ToastProvider, useToast } from '../context/ToastContext';
+export { default as WorkdayForm } from './WorkdayForm';

--- a/client/models/workdayModel.ts
+++ b/client/models/workdayModel.ts
@@ -1,0 +1,21 @@
+import api from '../api';
+
+export async function fetchWorkdays(year) {
+  const { data } = await api.get('/api/v1/workdays', { params: { year } });
+  return data;
+}
+
+export async function createWorkday(workday) {
+  const { data } = await api.post('/api/v1/workdays', workday);
+  return data;
+}
+
+export async function updateWorkday(id, workday) {
+  const { data } = await api.patch(`/api/v1/workdays/${id}`, workday);
+  return data;
+}
+
+export async function deleteWorkday(id) {
+  const { data } = await api.delete(`/api/v1/workdays/${id}`);
+  return data;
+}

--- a/client/pages/team-setting/workday.tsx
+++ b/client/pages/team-setting/workday.tsx
@@ -1,0 +1,175 @@
+// @ts-nocheck
+import { useEffect, useState } from 'react';
+import Container from '@mui/material/Container';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import MenuItem from '@mui/material/MenuItem';
+import TextField from '@mui/material/TextField';
+import Stack from '@mui/material/Stack';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { DataGrid } from '@mui/x-data-grid';
+import { format } from 'date-fns';
+import { Layout, Popup, WorkdayForm, useToast } from '../../components';
+import { withAuth, useAuth } from '../../context/AuthContext';
+import {
+  fetchWorkdays,
+  createWorkday,
+  updateWorkday,
+  deleteWorkday,
+} from '../../models/workdayModel';
+
+function WorkdayPage() {
+  const { token } = useAuth();
+  const { showToast } = useToast();
+  const currentYear = new Date().getFullYear();
+  const [year, setYear] = useState(currentYear);
+  const [rows, setRows] = useState([]);
+  const [open, setOpen] = useState(false);
+  const [editRow, setEditRow] = useState(null);
+
+  async function loadData() {
+    const data = await fetchWorkdays(year);
+    setRows(data);
+  }
+
+  useEffect(() => {
+    if (token) loadData();
+  }, [token, year]);
+
+  const handleCreate = async data => {
+    try {
+      await createWorkday(data);
+      showToast('Holiday created');
+      setOpen(false);
+      loadData();
+    } catch (e) {
+      showToast('Error creating holiday', { severity: 'error' });
+    }
+  };
+
+  const handleSave = async data => {
+    try {
+      if (editRow?.id) {
+        await updateWorkday(editRow.id, data);
+        showToast('Holiday updated');
+        setEditRow(null);
+        loadData();
+      }
+    } catch (e) {
+      showToast('Error updating holiday', { severity: 'error' });
+    }
+  };
+
+  const handleDelete = async row => {
+    if (row.readonly) return;
+    if (window.confirm('Delete this holiday?')) {
+      try {
+        await deleteWorkday(row.id);
+        showToast('Holiday deleted');
+        loadData();
+      } catch (e) {
+        showToast('Error deleting holiday', { severity: 'error' });
+      }
+    }
+  };
+
+  const years = [] as number[];
+  for (let i = currentYear - 2; i <= currentYear + 2; i++) years.push(i);
+
+  const columns = [
+    {
+      field: 'no',
+      headerName: 'No.',
+      width: 70,
+      sortable: false,
+      valueGetter: (_value, row, _col, api) => {
+        if (!api) return '';
+        const index = api.current.getRowIndexRelativeToVisibleRows(row.id);
+        return typeof index === 'number' ? index + 1 : '';
+      },
+    },
+    { field: 'name', headerName: 'Name', flex: 1 },
+    {
+      field: 'date',
+      headerName: 'Date',
+      width: 120,
+      valueGetter: (_value, row) => {
+        if (row?.date) {
+          try {
+            return format(new Date(row.date), 'yyyy-MM-dd');
+          } catch {
+            return '';
+          }
+        }
+        return '';
+      },
+    },
+    {
+      field: 'actions',
+      headerName: 'Action',
+      width: 120,
+      sortable: false,
+      renderCell: params =>
+        !params.row.readonly && (
+          <Stack direction="row" spacing={1}>
+            <IconButton size="small" onClick={() => setEditRow(params.row)}>
+              <EditIcon fontSize="small" />
+            </IconButton>
+            <IconButton size="small" onClick={() => handleDelete(params.row)}>
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </Stack>
+        ),
+    },
+  ];
+
+  return (
+    <Layout>
+      <Container maxWidth={false} sx={{ mt: 4 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
+          <Typography variant="h5">Workday Setting</Typography>
+          <Box>
+            <TextField
+              select
+              size="small"
+              value={year}
+              onChange={e => setYear(Number(e.target.value))}
+              sx={{ mr: 1 }}
+            >
+              {years.map(y => (
+                <MenuItem key={y} value={y}>
+                  {y}
+                </MenuItem>
+              ))}
+            </TextField>
+            <Button variant="contained" onClick={() => setOpen(true)}>
+              New Holiday
+            </Button>
+          </Box>
+        </Box>
+        <Paper>
+          <DataGrid
+            rows={rows}
+            columns={columns}
+            getRowId={row => row.id}
+            autoHeight
+            pageSize={25}
+            rowsPerPageOptions={[25]}
+          />
+        </Paper>
+        <Popup open={open} onClose={() => setOpen(false)} title="Add Holiday">
+          <WorkdayForm onSubmit={handleCreate} />
+        </Popup>
+        <Popup open={!!editRow} onClose={() => setEditRow(null)} title="Edit Holiday">
+          {editRow && <WorkdayForm onSubmit={handleSave} initial={editRow} submitText="Save" />}
+        </Popup>
+      </Container>
+    </Layout>
+  );
+}
+
+export default withAuth(WorkdayPage);

--- a/service/src/app.module.ts
+++ b/service/src/app.module.ts
@@ -11,6 +11,7 @@ import { TeamsModule } from './teams/teams.module';
 import { BudgetsModule } from './budgets/budgets.module';
 import { PositionsModule } from './positions/positions.module';
 import { RolesModule } from './roles/roles.module';
+import { WorkdaysModule } from './workdays/workdays.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { RolesModule } from './roles/roles.module';
     BudgetsModule,
     PositionsModule,
     RolesModule,
+    WorkdaysModule,
   ],
   providers: [LoggerService],
   exports: [LoggerService],

--- a/service/src/workdays/data/workday.schema.ts
+++ b/service/src/workdays/data/workday.schema.ts
@@ -1,0 +1,13 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class Workday extends Document {
+  @Prop({ required: true })
+  name: string;
+
+  @Prop({ required: true })
+  date: Date;
+}
+
+export const WorkdaySchema = SchemaFactory.createForClass(Workday);

--- a/service/src/workdays/data/workdays.repository.ts
+++ b/service/src/workdays/data/workdays.repository.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Workday } from './workday.schema';
+
+export interface CreateWorkdayInput {
+  name: string;
+  date: Date;
+}
+
+export interface UpdateWorkdayInput {
+  name?: string;
+  date?: Date;
+}
+
+@Injectable()
+export class WorkdaysRepository {
+  constructor(@InjectModel(Workday.name) private model: Model<Workday>) {}
+
+  findByYear(year: number): Promise<Workday[]> {
+    const start = new Date(year, 0, 1);
+    const end = new Date(year + 1, 0, 1);
+    return this.model
+      .find({ date: { $gte: start, $lt: end } })
+      .sort({ date: 1 })
+      .exec();
+  }
+
+  create(data: CreateWorkdayInput): Promise<Workday> {
+    const w = new this.model(data);
+    return w.save();
+  }
+
+  update(id: string, data: UpdateWorkdayInput): Promise<Workday | null> {
+    return this.model.findByIdAndUpdate(id, data, { new: true }).exec();
+  }
+
+  remove(id: string): Promise<Workday | null> {
+    return this.model.findByIdAndDelete(id).exec();
+  }
+}

--- a/service/src/workdays/workdays.controller.ts
+++ b/service/src/workdays/workdays.controller.ts
@@ -1,0 +1,29 @@
+import { Body, Controller, Get, Post, Patch, Delete, Param, Query } from '@nestjs/common';
+import { WorkdaysService } from './workdays.service';
+import { CreateWorkdayInput, UpdateWorkdayInput } from './data/workdays.repository';
+
+@Controller('workdays')
+export class WorkdaysController {
+  constructor(private readonly service: WorkdaysService) {}
+
+  @Get()
+  getWorkdays(@Query('year') year?: string) {
+    const y = Number(year) || new Date().getFullYear();
+    return this.service.getWorkdays(y);
+  }
+
+  @Post()
+  create(@Body() body: CreateWorkdayInput) {
+    return this.service.create(body);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() body: UpdateWorkdayInput) {
+    return this.service.update(id, body);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/service/src/workdays/workdays.module.ts
+++ b/service/src/workdays/workdays.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { WorkdaysController } from './workdays.controller';
+import { WorkdaysService } from './workdays.service';
+import { WorkdaysRepository } from './data/workdays.repository';
+import { Workday, WorkdaySchema } from './data/workday.schema';
+
+@Module({
+  imports: [MongooseModule.forFeature([{ name: Workday.name, schema: WorkdaySchema }])],
+  controllers: [WorkdaysController],
+  providers: [WorkdaysService, WorkdaysRepository],
+})
+export class WorkdaysModule {}

--- a/service/src/workdays/workdays.service.ts
+++ b/service/src/workdays/workdays.service.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@nestjs/common';
+import {
+  WorkdaysRepository,
+  CreateWorkdayInput,
+  UpdateWorkdayInput,
+} from './data/workdays.repository';
+
+interface WorkdayDto {
+  id: string;
+  name: string;
+  date: Date;
+  readonly: boolean;
+}
+
+@Injectable()
+export class WorkdaysService {
+  constructor(private readonly repo: WorkdaysRepository) {}
+
+  async getWorkdays(year: number): Promise<WorkdayDto[]> {
+    const custom = await this.repo.findByYear(year);
+    const weekend = getWeekendDays(year).map(d => ({
+      id: `weekend-${d.toISOString()}`,
+      name: 'Weekend',
+      date: d,
+      readonly: true,
+    }));
+    const thai = getThaiHolidays(year).map(h => ({
+      id: `thai-${h.date.toISOString()}`,
+      name: h.name,
+      date: h.date,
+      readonly: true,
+    }));
+    const user = custom.map(c => ({
+      id: c._id.toString(),
+      name: c.name,
+      date: c.date,
+      readonly: false,
+    }));
+    return [...weekend, ...thai, ...user].sort(
+      (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+    );
+  }
+
+  create(data: CreateWorkdayInput) {
+    return this.repo.create(data);
+  }
+
+  update(id: string, data: UpdateWorkdayInput) {
+    return this.repo.update(id, data);
+  }
+
+  remove(id: string) {
+    return this.repo.remove(id);
+  }
+}
+
+function getWeekendDays(year: number): Date[] {
+  const days: Date[] = [];
+  const d = new Date(year, 0, 1);
+  while (d.getFullYear() === year) {
+    if (d.getDay() === 0 || d.getDay() === 6) {
+      days.push(new Date(d));
+    }
+    d.setDate(d.getDate() + 1);
+  }
+  return days;
+}
+
+function getThaiHolidays(year: number): { name: string; date: Date }[] {
+  const toDate = (m: number, d: number) => new Date(year, m - 1, d);
+  return [
+    { name: "New Year's Day", date: toDate(1, 1) },
+    { name: 'Chakri Memorial Day', date: toDate(4, 6) },
+    { name: 'Songkran', date: toDate(4, 13) },
+    { name: 'Songkran', date: toDate(4, 14) },
+    { name: 'Songkran', date: toDate(4, 15) },
+    { name: 'Labour Day', date: toDate(5, 1) },
+    { name: 'Coronation Day', date: toDate(5, 4) },
+    { name: "HM Queen's Birthday", date: toDate(6, 3) },
+    { name: "HM King's Birthday", date: toDate(7, 28) },
+    { name: 'HM Queen Mother Birthday', date: toDate(8, 12) },
+    { name: 'King Bhumibol Memorial Day', date: toDate(10, 13) },
+    { name: 'Chulalongkorn Day', date: toDate(10, 23) },
+    { name: "Father's Day", date: toDate(12, 5) },
+    { name: 'Constitution Day', date: toDate(12, 10) },
+    { name: "New Year's Eve", date: toDate(12, 31) },
+  ];
+}


### PR DESCRIPTION
## Summary
- add Workday CRUD service
- load Thai and weekend holidays by year
- wire WorkdaysModule into app
- expose client UI for workday management with year dropdown
- update sidebar navigation

## Testing
- `npm test --prefix service`
- `npm test --prefix client`
- `npm run check --prefix service`
- `npm run check --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_685a6f8cd7088328a5754532cd0a4050