### PR TITLE
Fix screen reader focus with Popup

### DIFF
--- a/client/components/Popup.tsx
+++ b/client/components/Popup.tsx
@@ -2,8 +2,21 @@
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
+import { useEffect } from 'react';
 
 export default function Popup({ open, onClose, title, children }) {
+  useEffect(() => {
+    const root = document.getElementById('__next');
+    if (!root) return;
+    if (open) {
+      root.setAttribute('inert', '');
+    } else {
+      root.removeAttribute('inert');
+    }
+    return () => {
+      root.removeAttribute('inert');
+    };
+  }, [open]);
   return (
     <Dialog
       open={open}


### PR DESCRIPTION
## Summary
- fix accessibility warning by toggling `inert` on the main app container when `Popup` opens

## Testing
- `npm --prefix client run test`

------
https://chatgpt.com/codex/tasks/task_e_685a70b382fc8328bd2160e167fc52ca