### PR TITLE
Adjust DataGrid widths

### DIFF
--- a/client/components/BudgetTable.tsx
+++ b/client/components/BudgetTable.tsx
@@ -65,6 +65,7 @@ export default function BudgetTable({ data, onEdit, onDelete }) {
         autoHeight
         pageSize={25}
         rowsPerPageOptions={[25]}
+        sx={{ width: '100%' }}
       />
     </Paper>
   );

--- a/client/components/TeamForm.tsx
+++ b/client/components/TeamForm.tsx
@@ -124,18 +124,19 @@ export default function TeamForm({ users = [], onSubmit, initial, submitText = '
         onChange={(_, v) => setLead(v)}
         renderInput={params => <TextField {...params} label="Team Lead" />}
       />
-      <Paper sx={{ gridColumn: 'span 2', height: 300 }}>
-        <DataGrid
-          rows={rows}
-          columns={columns}
-          checkboxSelection
-          disableRowSelectionOnClick
-          isRowSelectable={params => params.id !== lead?.id}
-          rowSelectionModel={selectionModel}
-          onRowSelectionModelChange={handleSelectionChange}
-          getRowId={row => row.id}
-        />
-      </Paper>
+        <Paper sx={{ gridColumn: 'span 2', height: 300 }}>
+          <DataGrid
+            rows={rows}
+            columns={columns}
+            checkboxSelection
+            disableRowSelectionOnClick
+            isRowSelectable={params => params.id !== lead?.id}
+            rowSelectionModel={selectionModel}
+            onRowSelectionModelChange={handleSelectionChange}
+            getRowId={row => row.id}
+            sx={{ width: '100%' }}
+          />
+        </Paper>
       <Button variant="contained" type="submit" sx={{ gridColumn: 'span 2' }}>
         {submitText}
       </Button>

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -234,6 +234,7 @@ function ProjectManagement() {
             pageSize={25}
             rowsPerPageOptions={[25]}
             autoHeight
+            sx={{ width: '100%' }}
           />
         </Paper>
         <Popup open={open} onClose={() => setOpen(false)} title="Add Project">

--- a/client/pages/project/[id].tsx
+++ b/client/pages/project/[id].tsx
@@ -184,14 +184,15 @@ function ProjectDetail() {
             <Typography variant="h6" sx={{ p: 2 }}>
               Members
             </Typography>
-            <DataGrid
-              rows={uniqueMembers}
-              columns={memberColumns}
-              autoHeight
-              pageSize={25}
-              rowsPerPageOptions={[25]}
-              getRowId={row => row.id}
-            />
+          <DataGrid
+            rows={uniqueMembers}
+            columns={memberColumns}
+            autoHeight
+            pageSize={25}
+            rowsPerPageOptions={[25]}
+            getRowId={row => row.id}
+            sx={{ width: '100%' }}
+          />
           </Paper>
         )}
         <Popup open={open} onClose={() => setOpen(false)} title="Edit Project">

--- a/client/pages/summary/detail.tsx
+++ b/client/pages/summary/detail.tsx
@@ -40,6 +40,7 @@ function SummaryDetail() {
             autoHeight
             pageSize={25}
             rowsPerPageOptions={[25]}
+            sx={{ width: '100%' }}
           />
         </Paper>
       </Container>

--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -237,6 +237,7 @@ function TeamSetting() {
                 sortModel: [{ field: 'startDate', sort: 'asc' }],
               },
             }}
+            sx={{ width: '100%' }}
           />
         </Paper>
         <Popup open={open} onClose={() => setOpen(false)} title="Add Resource">

--- a/client/pages/team-setting/team.tsx
+++ b/client/pages/team-setting/team.tsx
@@ -142,6 +142,7 @@ function TeamPage() {
             autoHeight
             pageSize={25}
             rowsPerPageOptions={[25]}
+            sx={{ width: '100%' }}
           />
         </Paper>
         <Popup open={open} onClose={() => setOpen(false)} title="Add Team">

--- a/client/pages/team-setting/workday.tsx
+++ b/client/pages/team-setting/workday.tsx
@@ -159,6 +159,7 @@ function WorkdayPage() {
             autoHeight
             pageSize={25}
             rowsPerPageOptions={[25]}
+            sx={{ width: '100%' }}
           />
         </Paper>
         <Popup open={open} onClose={() => setOpen(false)} title="Add Holiday">


### PR DESCRIPTION
## Summary
- widen all tables by setting `sx={{ width: '100%' }}` on every DataGrid

## Testing
- `npm test` in `client`
- `npm test` in `service`


------
https://chatgpt.com/codex/tasks/task_e_685a753897c48328984826190703acff