### PR TITLE
Hide weekend rows in workday table

### DIFF
--- a/client/pages/team-setting/workday.tsx
+++ b/client/pages/team-setting/workday.tsx
@@ -33,7 +33,8 @@ function WorkdayPage() {
 
   async function loadData() {
     const data = await fetchWorkdays(year);
-    setRows(data);
+    const filtered = data.filter(row => !String(row?.id).startsWith('weekend-'));
+    setRows(filtered);
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- filter out weekend entries when loading workday list

## Testing
- `npm test` in `service`
- `npm run check` in `service`
- `npm test` in `client`
- `npm run check` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685a7590491c832897a9c704c9c041f5