### PR TITLE
Align numeric cells in tables

### DIFF
--- a/client/components/BudgetTable.tsx
+++ b/client/components/BudgetTable.tsx
@@ -18,6 +18,9 @@ export default function BudgetTable({ data, onEdit, onDelete }) {
       headerName: 'No.',
       width: 70,
       sortable: false,
+      type: 'number',
+      headerAlign: 'right',
+      align: 'right',
       valueGetter: (_value, row, _col, api) => {
         if (!api) return '';
         const index = api.current.getRowIndexRelativeToVisibleRows(row.id);
@@ -26,11 +29,21 @@ export default function BudgetTable({ data, onEdit, onDelete }) {
     },
     { field: 'role', headerName: 'Role', flex: 1 },
     { field: 'level', headerName: 'Level', width: 130 },
-    { field: 'count', headerName: 'Count', width: 100 },
+    {
+      field: 'count',
+      headerName: 'Count',
+      width: 100,
+      type: 'number',
+      headerAlign: 'right',
+      align: 'right',
+    },
     {
       field: 'rate',
       headerName: 'Baht/MD',
       width: 120,
+      type: 'number',
+      headerAlign: 'right',
+      align: 'right',
       valueFormatter: ({ value }) =>
         typeof value === 'number' ? currencyFormatter.format(value) : value,
     },

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -176,12 +176,18 @@ function ProjectManagement() {
       field: 'totalMember',
       headerName: 'Team Size',
       width: 120,
+      type: 'number',
+      headerAlign: 'right',
+      align: 'right',
       valueGetter: (_value, row) => row.resources ?? row.members?.length ?? 0,
     },
     {
       field: 'actualManday',
       headerName: 'Actual Mandays',
       width: 160,
+      type: 'number',
+      headerAlign: 'right',
+      align: 'right',
       valueGetter: (_value, row) =>
         row.start && row.resources
           ? differenceInDays(new Date(), new Date(row.start)) * row.resources
@@ -191,6 +197,9 @@ function ProjectManagement() {
       field: 'manday',
       headerName: 'Estimated Mandays',
       width: 150,
+      type: 'number',
+      headerAlign: 'right',
+      align: 'right',
     },
     {
       field: 'start',

--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -134,6 +134,9 @@ function TeamSetting() {
       headerName: 'No.',
       width: 70,
       sortable: false,
+      type: 'number',
+      headerAlign: 'right',
+      align: 'right',
       valueGetter: (_value, row, _col, api) => {
         if (!api) return '';
         const index = api.current.getRowIndexRelativeToVisibleRows(row.id);

--- a/client/pages/team-setting/team.tsx
+++ b/client/pages/team-setting/team.tsx
@@ -85,6 +85,9 @@ function TeamPage() {
       field: 'totalMember',
       headerName: 'Total Member',
       width: 120,
+      type: 'number',
+      headerAlign: 'right',
+      align: 'right',
       valueGetter: (_value, row) => {
         if (Array.isArray(row?.members)) {
           const count = row.members.length + (row.lead ? 1 : 0);

--- a/client/pages/team-setting/workday.tsx
+++ b/client/pages/team-setting/workday.tsx
@@ -87,6 +87,9 @@ function WorkdayPage() {
       headerName: 'No.',
       width: 70,
       sortable: false,
+      type: 'number',
+      headerAlign: 'right',
+      align: 'right',
       valueGetter: (_value, row, _col, api) => {
         if (!api) return '';
         const index = api.current.getRowIndexRelativeToVisibleRows(row.id);


### PR DESCRIPTION
## Summary
- align numeric columns to the right in budget table and various grids

## Testing
- `npm test --silent` in `client`
- `npm test --silent` in `service`


------
https://chatgpt.com/codex/tasks/task_e_685b9f1c75e083288a05b1297cb9634d