### PR TITLE
Implement soft delete expiry and restore fix

### DIFF
--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -179,6 +179,16 @@ function ProjectManagement() {
       headerName: 'Project Name',
       flex: 1,
       minWidth: 80,
+      renderCell: params => (
+        <Box>
+          <Typography>{params.value}</Typography>
+          {params.row.deleted && params.row.deletedAt && (
+            <Typography variant="caption" color="error">
+              {`will be deleted on ${format(new Date(params.row.deletedAt), 'yyyy-MM-dd')}`}
+            </Typography>
+          )}
+        </Box>
+      ),
     },
     {
       field: 'lead',

--- a/client/pages/project/[id].tsx
+++ b/client/pages/project/[id].tsx
@@ -111,9 +111,16 @@ function ProjectDetail() {
           <IconButton size="small" onClick={() => router.back()} sx={{ mr: 1 }}>
             <ArrowBackIosNew fontSize="small" />
           </IconButton>
-          <Typography variant="h5" gutterBottom>
-            {project.name}
-          </Typography>
+          <Box>
+            <Typography variant="h5" gutterBottom>
+              {project.name}
+            </Typography>
+            {project.deleted && project.deletedAt && (
+              <Typography variant="body2" color="error" sx={{ ml: 0.5 }}>
+                {`This project will be deleted on ${new Date(project.deletedAt).toLocaleDateString()}`}
+              </Typography>
+            )}
+          </Box>
           <Box sx={{ flexGrow: 1 }} />
           <Button variant="outlined" onClick={() => setOpen(true)}>
             Edit

--- a/client/styles/globals.scss
+++ b/client/styles/globals.scss
@@ -8,5 +8,4 @@ body {
 
 .project-disabled {
   opacity: 0.5;
-  pointer-events: none;
 }

--- a/service/src/projects/data/project.schema.ts
+++ b/service/src/projects/data/project.schema.ts
@@ -35,6 +35,10 @@ export class Project extends Document {
 
   @Prop({ default: false })
   deleted: boolean;
+
+  @Prop()
+  deletedAt?: Date;
 }
 
 export const ProjectSchema = SchemaFactory.createForClass(Project);
+ProjectSchema.index({ deletedAt: 1 }, { expireAfterSeconds: 0 });

--- a/service/src/projects/data/projects.repository.ts
+++ b/service/src/projects/data/projects.repository.ts
@@ -15,6 +15,7 @@ export interface CreateProjectInput {
   status?: string;
   members?: string[];
   deleted?: boolean;
+  deletedAt?: Date;
 }
 
 export interface UpdateProjectInput {
@@ -29,6 +30,7 @@ export interface UpdateProjectInput {
   status?: string;
   members?: string[];
   deleted?: boolean;
+  deletedAt?: Date;
 }
 
 @Injectable()
@@ -60,13 +62,17 @@ export class ProjectsRepository {
 
   remove(id: string): Promise<Project | null> {
     return this.projectModel
-      .findByIdAndUpdate(id, { deleted: true }, { new: true })
+      .findByIdAndUpdate(
+        id,
+        { deleted: true, deletedAt: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000) },
+        { new: true },
+      )
       .exec();
   }
 
   restore(id: string): Promise<Project | null> {
     return this.projectModel
-      .findByIdAndUpdate(id, { deleted: false }, { new: true })
+      .findByIdAndUpdate(id, { deleted: false, deletedAt: null }, { new: true })
       .exec();
   }
 }


### PR DESCRIPTION
## Summary
- mark projects for hard deletion via TTL
- allow restoring deleted projects
- show expiry notes on project listings and details

## Testing
- `npm test --prefix service`
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_685ba6f3c16c8328b230d10ea025f96f