### PR TITLE
Implement activity logs

### DIFF
--- a/client/components/Topbar.tsx
+++ b/client/components/Topbar.tsx
@@ -10,12 +10,14 @@ import Drawer from '@mui/material/Drawer';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { useState } from 'react';
+import { useRouter } from 'next/router';
 import { useAuth } from '../context/AuthContext';
 
 export default function Topbar({ onMenuClick }) {
   const { logout } = useAuth();
   const [anchorEl, setAnchorEl] = useState(null);
   const [openProfile, setOpenProfile] = useState(false);
+  const router = useRouter();
 
   const handleMenu = (event) => {
     setAnchorEl(event.currentTarget);
@@ -52,6 +54,14 @@ export default function Topbar({ onMenuClick }) {
             }}
           >
             My Profile
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              handleClose();
+              router.push('/activity');
+            }}
+          >
+            Activity
           </MenuItem>
           <MenuItem
             onClick={() => {

--- a/client/models/activityLogModel.ts
+++ b/client/models/activityLogModel.ts
@@ -1,0 +1,6 @@
+import api from '../api';
+
+export async function fetchActivityLogs() {
+  const { data } = await api.get('/api/v1/activity-logs');
+  return data;
+}

--- a/client/pages/activity.tsx
+++ b/client/pages/activity.tsx
@@ -1,0 +1,53 @@
+// @ts-nocheck
+import { useEffect, useState } from 'react';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+import { DataGrid } from '@mui/x-data-grid';
+import { Layout } from '../components';
+import { withAuth } from '../context/AuthContext';
+import { fetchActivityLogs } from '../models/activityLogModel';
+
+function ActivityPage() {
+  const [logs, setLogs] = useState([]);
+
+  useEffect(() => {
+    fetchActivityLogs().then(setLogs).catch(console.error);
+  }, []);
+
+  const columns = [
+    { field: 'method', headerName: 'Method', width: 100 },
+    { field: 'url', headerName: 'URL', flex: 1 },
+    { field: 'statusCode', headerName: 'Status', width: 100 },
+    {
+      field: 'timestamp',
+      headerName: 'Time',
+      width: 180,
+      valueGetter: (_v, row) =>
+        row?.timestamp ? new Date(row.timestamp).toLocaleString() : '',
+    },
+  ];
+
+  return (
+    <Layout>
+      <Container maxWidth={false} sx={{ mt: 4 }}>
+        <Typography variant="h5" gutterBottom>
+          Activity Logs
+        </Typography>
+        <Paper>
+          <DataGrid
+            rows={logs}
+            columns={columns}
+            getRowId={row => row._id}
+            autoHeight
+            pageSize={25}
+            rowsPerPageOptions={[25]}
+            sx={{ width: '100%' }}
+          />
+        </Paper>
+      </Container>
+    </Layout>
+  );
+}
+
+export default withAuth(ActivityPage);

--- a/service/src/activity-logs/activity-logs.controller.ts
+++ b/service/src/activity-logs/activity-logs.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { ActivityLogsService } from './activity-logs.service';
+
+@Controller('activity-logs')
+export class ActivityLogsController {
+  constructor(private readonly service: ActivityLogsService) {}
+
+  @Get()
+  getLogs() {
+    return this.service.getLogs();
+  }
+}

--- a/service/src/activity-logs/activity-logs.interceptor.ts
+++ b/service/src/activity-logs/activity-logs.interceptor.ts
@@ -1,0 +1,40 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap, catchError } from 'rxjs/operators';
+import { ActivityLogsService } from './activity-logs.service';
+
+@Injectable()
+export class ActivityLogsInterceptor implements NestInterceptor {
+  constructor(private readonly logsService: ActivityLogsService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const req = context.switchToHttp().getRequest();
+    const res = context.switchToHttp().getResponse();
+    const { method, originalUrl: url, body } = req;
+    if (method === 'GET') return next.handle();
+    const start = Date.now();
+    return next.handle().pipe(
+      tap(() => {
+        const processTime = Date.now() - start;
+        this.logsService.create({
+          method,
+          url,
+          body,
+          statusCode: res.statusCode,
+          processTime,
+        });
+      }),
+      catchError(err => {
+        const processTime = Date.now() - start;
+        this.logsService.create({
+          method,
+          url,
+          body,
+          statusCode: res.statusCode,
+          processTime,
+        });
+        throw err;
+      }),
+    );
+  }
+}

--- a/service/src/activity-logs/activity-logs.module.ts
+++ b/service/src/activity-logs/activity-logs.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { ActivityLogsController } from './activity-logs.controller';
+import { ActivityLogsService } from './activity-logs.service';
+import { ActivityLogsRepository } from './data/activity-logs.repository';
+import { ActivityLog, ActivityLogSchema } from './data/activity-log.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: ActivityLog.name, schema: ActivityLogSchema }]),
+  ],
+  controllers: [ActivityLogsController],
+  providers: [ActivityLogsService, ActivityLogsRepository],
+  exports: [ActivityLogsService],
+})
+export class ActivityLogsModule {}

--- a/service/src/activity-logs/activity-logs.service.ts
+++ b/service/src/activity-logs/activity-logs.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { ActivityLogsRepository } from './data/activity-logs.repository';
+
+@Injectable()
+export class ActivityLogsService {
+  constructor(private readonly repo: ActivityLogsRepository) {}
+
+  getLogs() {
+    return this.repo.findAll();
+  }
+
+  create(data: { method: string; url: string; body: any; statusCode: number; processTime: number }) {
+    return this.repo.create({ ...data, timestamp: new Date() });
+  }
+}

--- a/service/src/activity-logs/data/activity-log.schema.ts
+++ b/service/src/activity-logs/data/activity-log.schema.ts
@@ -1,0 +1,25 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema()
+export class ActivityLog extends Document {
+  @Prop({ required: true })
+  method: string;
+
+  @Prop({ required: true })
+  url: string;
+
+  @Prop({ type: Object })
+  body: any;
+
+  @Prop({ required: true })
+  statusCode: number;
+
+  @Prop({ required: true })
+  processTime: number;
+
+  @Prop({ default: Date.now })
+  timestamp: Date;
+}
+
+export const ActivityLogSchema = SchemaFactory.createForClass(ActivityLog);

--- a/service/src/activity-logs/data/activity-logs.repository.ts
+++ b/service/src/activity-logs/data/activity-logs.repository.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { ActivityLog } from './activity-log.schema';
+
+@Injectable()
+export class ActivityLogsRepository {
+  constructor(@InjectModel(ActivityLog.name) private readonly model: Model<ActivityLog>) {}
+
+  findAll(): Promise<ActivityLog[]> {
+    return this.model.find().sort({ timestamp: -1 }).exec();
+  }
+
+  create(data: Partial<ActivityLog>): Promise<ActivityLog> {
+    const log = new this.model(data);
+    return log.save();
+  }
+}

--- a/service/src/app.module.ts
+++ b/service/src/app.module.ts
@@ -12,6 +12,7 @@ import { BudgetsModule } from './budgets/budgets.module';
 import { PositionsModule } from './positions/positions.module';
 import { RolesModule } from './roles/roles.module';
 import { WorkdaysModule } from './workdays/workdays.module';
+import { ActivityLogsModule } from './activity-logs/activity-logs.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { WorkdaysModule } from './workdays/workdays.module';
     PositionsModule,
     RolesModule,
     WorkdaysModule,
+    ActivityLogsModule,
   ],
   providers: [LoggerService],
   exports: [LoggerService],

--- a/service/src/main.ts
+++ b/service/src/main.ts
@@ -3,6 +3,8 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { LoggingInterceptor } from './logger/logging.interceptor';
 import { LoggerService } from './logger/logger.service';
+import { ActivityLogsService } from './activity-logs/activity-logs.service';
+import { ActivityLogsInterceptor } from './activity-logs/activity-logs.interceptor';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 
 async function bootstrap() {
@@ -11,7 +13,11 @@ async function bootstrap() {
   app.enableCors();
   app.setGlobalPrefix('api/v1');
   const logger = app.get(LoggerService);
-  app.useGlobalInterceptors(new LoggingInterceptor(logger));
+  const activityLogs = app.get(ActivityLogsService);
+  app.useGlobalInterceptors(
+    new LoggingInterceptor(logger),
+    new ActivityLogsInterceptor(activityLogs),
+  );
   if (process.env.NODE_ENV !== 'production') {
     const swaggerConfig = new DocumentBuilder()
       .setTitle('Budget Management API')


### PR DESCRIPTION
## Summary
- add ActivityLogs module for server
- add interceptor to store logs for non-GET requests
- expose logs through new endpoint `/api/v1/activity-logs`
- show Activity page on client and link from profile menu

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685ba881a6908328be11cd63a7ca35cd