### PR TITLE
Fix restore button and toast position

### DIFF
--- a/client/context/ToastContext.tsx
+++ b/client/context/ToastContext.tsx
@@ -36,7 +36,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
         open={open}
         autoHideDuration={3000}
         onClose={handleClose}
-        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
       >
         <Alert onClose={handleClose} severity={severity} sx={{ width: '100%' }}>
           {message}

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -266,7 +266,11 @@ function ProjectManagement() {
             <DownloadIcon fontSize="small" />
           </IconButton>
           {params.row.deleted ? (
-            <IconButton size="small" onClick={() => handleRestore(params.row)}>
+            <IconButton
+              size="small"
+              onClick={() => handleRestore(params.row)}
+              className="restore-button"
+            >
               <RestoreIcon fontSize="small" />
             </IconButton>
           ) : (

--- a/client/styles/globals.scss
+++ b/client/styles/globals.scss
@@ -7,5 +7,10 @@ body {
 }
 
 .project-disabled {
-  opacity: 0.5;
+  background-color: #f0f0f0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.project-disabled .restore-button {
+  color: #1976d2;
 }


### PR DESCRIPTION
## Summary
- keep deleted rows gray but maintain bright Restore button
- show toast messages at bottom-right for clearer UI

## Testing
- `npm --prefix client run check`
- `npm --prefix client test`
- `npm --prefix service run check`
- `npm --prefix service test`


------
https://chatgpt.com/codex/tasks/task_e_685ba9b150d08328b0018aa6f38a3b89