### PR TITLE
Add human-readable activity names

### DIFF
--- a/client/pages/activity.tsx
+++ b/client/pages/activity.tsx
@@ -16,6 +16,8 @@ function ActivityPage() {
   }, []);
 
   const columns = [
+    { field: 'name', headerName: 'Activity', width: 180 },
+    { field: 'detail', headerName: 'Detail', flex: 1 },
     { field: 'method', headerName: 'Method', width: 100 },
     { field: 'url', headerName: 'URL', flex: 1 },
     { field: 'statusCode', headerName: 'Status', width: 100 },

--- a/service/src/activity-logs/activity-logs.interceptor.ts
+++ b/service/src/activity-logs/activity-logs.interceptor.ts
@@ -2,6 +2,7 @@ import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nes
 import { Observable } from 'rxjs';
 import { tap, catchError } from 'rxjs/operators';
 import { ActivityLogsService } from './activity-logs.service';
+import { getActivityDescription } from './activity.constants';
 
 @Injectable()
 export class ActivityLogsInterceptor implements NestInterceptor {
@@ -16,22 +17,28 @@ export class ActivityLogsInterceptor implements NestInterceptor {
     return next.handle().pipe(
       tap(() => {
         const processTime = Date.now() - start;
+        const { name, detail } = getActivityDescription(method, url);
         this.logsService.create({
           method,
           url,
           body,
           statusCode: res.statusCode,
           processTime,
+          name,
+          detail,
         });
       }),
       catchError(err => {
         const processTime = Date.now() - start;
+        const { name, detail } = getActivityDescription(method, url);
         this.logsService.create({
           method,
           url,
           body,
           statusCode: res.statusCode,
           processTime,
+          name,
+          detail,
         });
         throw err;
       }),

--- a/service/src/activity-logs/activity-logs.service.ts
+++ b/service/src/activity-logs/activity-logs.service.ts
@@ -9,7 +9,15 @@ export class ActivityLogsService {
     return this.repo.findAll();
   }
 
-  create(data: { method: string; url: string; body: any; statusCode: number; processTime: number }) {
+  create(data: {
+    method: string;
+    url: string;
+    body: any;
+    statusCode: number;
+    processTime: number;
+    name?: string;
+    detail?: string;
+  }) {
     return this.repo.create({ ...data, timestamp: new Date() });
   }
 }

--- a/service/src/activity-logs/activity.constants.ts
+++ b/service/src/activity-logs/activity.constants.ts
@@ -1,0 +1,42 @@
+export interface ActivityDescription {
+  pattern: RegExp;
+  name: string;
+  detail: string;
+}
+
+export const ACTIVITY_DESCRIPTIONS: ActivityDescription[] = [
+  {
+    pattern: /^POST \/api\/v1\/projects$/, 
+    name: 'Create project',
+    detail: 'Create a new project',
+  },
+  {
+    pattern: /^PATCH \/api\/v1\/projects\//, 
+    name: 'Update project',
+    detail: 'Modify an existing project',
+  },
+  {
+    pattern: /^DELETE \/api\/v1\/projects\//, 
+    name: 'Delete project',
+    detail: 'Remove a project',
+  },
+  {
+    pattern: /^POST \/api\/v1\/budgets$/, 
+    name: 'Create budget',
+    detail: 'Create a new budget record',
+  },
+  {
+    pattern: /^PATCH \/api\/v1\/budgets\//,
+    name: 'Update budget',
+    detail: 'Modify an existing budget',
+  },
+];
+
+export function getActivityDescription(
+  method: string,
+  url: string,
+): { name?: string; detail?: string } {
+  const key = `${method} ${url}`;
+  const entry = ACTIVITY_DESCRIPTIONS.find(d => d.pattern.test(key));
+  return entry ? { name: entry.name, detail: entry.detail } : {};
+}

--- a/service/src/activity-logs/data/activity-log.schema.ts
+++ b/service/src/activity-logs/data/activity-log.schema.ts
@@ -20,6 +20,12 @@ export class ActivityLog extends Document {
 
   @Prop({ default: Date.now })
   timestamp: Date;
+
+  @Prop()
+  name: string;
+
+  @Prop()
+  detail: string;
 }
 
 export const ActivityLogSchema = SchemaFactory.createForClass(ActivityLog);


### PR DESCRIPTION
## Summary
- enrich activity log schema with `name` and `detail`
- hardcode activity descriptions and look them up in the interceptor
- show `Activity` and `Detail` columns in the activity page

## Testing
- `npm run check` in `service`
- `npm test -- -i` in `service`
- `npm run check` in `client`
- `npm test -- -i` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685bac0a8e68832899059936a9fd1ea7