### PR TITLE
Add breadcrumbs to pages

### DIFF
--- a/client/components/PageBreadcrumbs.tsx
+++ b/client/components/PageBreadcrumbs.tsx
@@ -1,0 +1,34 @@
+import Breadcrumbs from '@mui/material/Breadcrumbs';
+import Link from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
+import { useRouter } from 'next/router';
+
+export interface Crumb {
+  label: string;
+  href?: string;
+}
+
+export default function PageBreadcrumbs({ items }: { items: Crumb[] }) {
+  const router = useRouter();
+  return (
+    <Breadcrumbs aria-label="breadcrumb" sx={{ mb: 2 }}>
+      {items.map((item, idx) =>
+        item.href ? (
+          <Link
+            key={idx}
+            underline="hover"
+            color="inherit"
+            onClick={() => router.push(item.href!)}
+            sx={{ cursor: 'pointer' }}
+          >
+            {item.label}
+          </Link>
+        ) : (
+          <Typography key={idx} color="text.primary">
+            {item.label}
+          </Typography>
+        ),
+      )}
+    </Breadcrumbs>
+  );
+}

--- a/client/components/index.tsx
+++ b/client/components/index.tsx
@@ -15,3 +15,4 @@ export { default as BudgetForm } from './BudgetForm';
 export { default as BudgetTable } from './BudgetTable';
 export { ToastProvider, useToast } from '../context/ToastContext';
 export { default as WorkdayForm } from './WorkdayForm';
+export { default as PageBreadcrumbs } from './PageBreadcrumbs';

--- a/client/pages/activity.tsx
+++ b/client/pages/activity.tsx
@@ -4,7 +4,7 @@ import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
 import { DataGrid } from '@mui/x-data-grid';
-import { Layout } from '../components';
+import { Layout, PageBreadcrumbs } from '../components';
 import { withAuth } from '../context/AuthContext';
 import { fetchActivityLogs } from '../models/activityLogModel';
 
@@ -36,6 +36,7 @@ function ActivityPage() {
         <Typography variant="h5" gutterBottom>
           Activity Logs
         </Typography>
+        <PageBreadcrumbs items={[{ label: 'Activity Logs' }]} />
         <Paper>
           <DataGrid
             rows={logs}

--- a/client/pages/budget-management/index.tsx
+++ b/client/pages/budget-management/index.tsx
@@ -9,6 +9,7 @@ import {
   BudgetForm,
   BudgetTable,
   useToast,
+  PageBreadcrumbs,
 } from '../../components';
 import { withAuth, useAuth } from '../../context/AuthContext';
 import {
@@ -72,6 +73,7 @@ function BudgetManagement() {
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
           <Typography variant="h5">Budget Management</Typography>
         </Box>
+        <PageBreadcrumbs items={[{ label: 'Budget Management' }]} />
         <BudgetTable data={rows} onEdit={handleEdit} onDelete={handleDelete} />
         <Popup open={!!editRow} onClose={() => setEditRow(null)} title="Edit Rate">
           {editRow && (

--- a/client/pages/budget-management/role-setting.tsx
+++ b/client/pages/budget-management/role-setting.tsx
@@ -8,7 +8,7 @@ import TextField from '@mui/material/TextField';
 import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import Paper from '@mui/material/Paper';
-import { Layout, useToast } from '../../components';
+import { Layout, useToast, PageBreadcrumbs } from '../../components';
 import { withAuth, useAuth } from '../../context/AuthContext';
 import {
   fetchRoles,
@@ -74,6 +74,7 @@ function RoleSetting() {
         <Typography variant="h5" gutterBottom>
           Role Setting
         </Typography>
+        <PageBreadcrumbs items={[{ label: 'Role Setting' }]} />
         <Typography variant="body2" sx={{ mb: 2 }}>
           Manage your roles and their levels. Press Enter or click Add to save. Click a level chip to remove it.
         </Typography>

--- a/client/pages/plan-management/index.tsx
+++ b/client/pages/plan-management/index.tsx
@@ -13,7 +13,7 @@ import TimelineSeparator from '@mui/lab/TimelineSeparator';
 import TimelineConnector from '@mui/lab/TimelineConnector';
 import TimelineContent from '@mui/lab/TimelineContent';
 import TimelineDot from '@mui/lab/TimelineDot';
-import { Layout, SimpleCalendar } from '../../components';
+import { Layout, SimpleCalendar, PageBreadcrumbs } from '../../components';
 import { withAuth } from '../../context/AuthContext';
 
 function PlanManagementOverview() {
@@ -37,6 +37,7 @@ function PlanManagementOverview() {
             }}
           >
             <Typography variant="h5">Plan Management Overview</Typography>
+            <PageBreadcrumbs items={[{ label: 'Plan Management' }]} />
             <ToggleButtonGroup
               value={view}
               exclusive

--- a/client/pages/plan-management/planing-setting.tsx
+++ b/client/pages/plan-management/planing-setting.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
-import { Layout } from '../../components';
+import { Layout, PageBreadcrumbs } from '../../components';
 import { withAuth } from '../../context/AuthContext';
 
 function PlanManagementSetting() {
@@ -11,6 +11,7 @@ function PlanManagementSetting() {
         <Typography variant="h5" gutterBottom>
           Planing Setting
         </Typography>
+        <PageBreadcrumbs items={[{ label: 'Plan Management', href: '/plan-management' }, { label: 'Planing Setting' }]} />
         <Typography variant="body2">Content coming soon.</Typography>
       </Container>
     </Layout>

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -25,7 +25,7 @@ import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import Chip from '@mui/material/Chip';
 import api from '../api';
-import { Layout, Popup, ProjectForm, useToast } from '../components';
+import { Layout, Popup, ProjectForm, useToast, PageBreadcrumbs } from '../components';
 import { withAuth, useAuth } from '../context/AuthContext';
 
 const statusOptions = [
@@ -292,6 +292,7 @@ function ProjectManagement() {
             New Project
           </Button>
         </Box>
+        <PageBreadcrumbs items={[{ label: 'Project Management' }]} />
         <Paper>
           <DataGrid
             rows={projects}

--- a/client/pages/project/[id].tsx
+++ b/client/pages/project/[id].tsx
@@ -5,8 +5,7 @@ import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
 import Box from '@mui/material/Box';
-import Breadcrumbs from '@mui/material/Breadcrumbs';
-import Link from '@mui/material/Link';
+import { PageBreadcrumbs } from '../../components';
 import IconButton from '@mui/material/IconButton';
 import Button from '@mui/material/Button';
 import ArrowBackIosNew from '@mui/icons-material/ArrowBackIosNew';
@@ -126,17 +125,12 @@ function ProjectDetail() {
             Edit
           </Button>
         </Box>
-        <Breadcrumbs aria-label="breadcrumb" sx={{ mb: 2 }}>
-          <Link
-            underline="hover"
-            color="inherit"
-            onClick={() => router.push('/project-management')}
-            sx={{ cursor: 'pointer' }}
-          >
-            Project Management
-          </Link>
-          <Typography color="text.primary">{project.name}</Typography>
-        </Breadcrumbs>
+        <PageBreadcrumbs
+          items={[
+            { label: 'Project Management', href: '/project-management' },
+            { label: project.name },
+          ]}
+        />
         <Paper sx={{ p: 2 }}>
           <Box sx={{ display: 'grid', rowGap: 1 }}>
             <Typography>

--- a/client/pages/summary/detail.tsx
+++ b/client/pages/summary/detail.tsx
@@ -4,7 +4,7 @@ import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
 import { DataGrid } from '@mui/x-data-grid';
-import { Layout } from '../../components';
+import { Layout, PageBreadcrumbs } from '../../components';
 import { withAuth } from '../../context/AuthContext';
 import { fetchEvents } from '../../models/eventsModel';
 
@@ -32,6 +32,7 @@ function SummaryDetail() {
         <Typography variant="h5" gutterBottom>
           Summary Detail
         </Typography>
+        <PageBreadcrumbs items={[{ label: 'Summary Detail' }]} />
         <Paper>
           <DataGrid
             rows={events}

--- a/client/pages/summary/overview.tsx
+++ b/client/pages/summary/overview.tsx
@@ -6,7 +6,7 @@ import Paper from '@mui/material/Paper';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import { PieChart, LineChart, BarChart } from '@mui/x-charts';
-import { Layout } from '../../components';
+import { Layout, PageBreadcrumbs } from '../../components';
 import { withAuth } from '../../context/AuthContext';
 import { fetchBudgetOverview } from '../../models/budgetModel';
 import api from '../../api';
@@ -91,6 +91,7 @@ function DashboardOverview() {
         <Typography variant="h5" gutterBottom>
           Dashboard Overview
         </Typography>
+        <PageBreadcrumbs items={[{ label: 'Dashboard Overview' }]} />
 
         <Paper sx={{ p: 2 }}>
           <Typography variant="h6" gutterBottom>

--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -19,7 +19,7 @@ import {
   addYears,
   addMonths,
 } from 'date-fns';
-import { Layout, ResourceForm, Popup, useToast } from '../../components';
+import { Layout, ResourceForm, Popup, useToast, PageBreadcrumbs } from '../../components';
 import { withAuth, useAuth } from '../../context/AuthContext';
 import {
   fetchResources,
@@ -227,6 +227,7 @@ function TeamSetting() {
             </Button>
           </Box>
         </Box>
+        <PageBreadcrumbs items={[{ label: 'Resources' }]} />
         <Paper>
           <DataGrid
             rows={resources}

--- a/client/pages/team-setting/team.tsx
+++ b/client/pages/team-setting/team.tsx
@@ -11,7 +11,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { DataGrid } from '@mui/x-data-grid';
 import api from '../../api';
-import { Layout, Popup, TeamForm, useToast } from '../../components';
+import { Layout, Popup, TeamForm, useToast, PageBreadcrumbs } from '../../components';
 import {
   fetchTeams,
   createTeam,
@@ -137,6 +137,7 @@ function TeamPage() {
             New Team
           </Button>
         </Box>
+        <PageBreadcrumbs items={[{ label: 'Teams' }]} />
         <Paper>
           <DataGrid
             rows={teams}

--- a/client/pages/team-setting/workday.tsx
+++ b/client/pages/team-setting/workday.tsx
@@ -13,7 +13,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { DataGrid } from '@mui/x-data-grid';
 import { format } from 'date-fns';
-import { Layout, Popup, WorkdayForm, useToast } from '../../components';
+import { Layout, Popup, WorkdayForm, useToast, PageBreadcrumbs } from '../../components';
 import { withAuth, useAuth } from '../../context/AuthContext';
 import {
   fetchWorkdays,
@@ -155,6 +155,7 @@ function WorkdayPage() {
             </Button>
           </Box>
         </Box>
+        <PageBreadcrumbs items={[{ label: 'Workday Setting' }]} />
         <Paper>
           <DataGrid
             rows={rows}


### PR DESCRIPTION
## Summary
- implement `PageBreadcrumbs` component
- export `PageBreadcrumbs`
- use breadcrumbs across client pages

## Testing
- `npm test --silent` in `client`
- `npm test --silent` in `service`


------
https://chatgpt.com/codex/tasks/task_e_685bb12ca9588328ba8a7248c4f9cfaa