### PR TITLE
Add confirm dialogs for deletions

### DIFF
--- a/client/components/ConfirmDialog.tsx
+++ b/client/components/ConfirmDialog.tsx
@@ -1,0 +1,21 @@
+// @ts-nocheck
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+
+export default function ConfirmDialog({ open, title, content, onClose, onConfirm }) {
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth>
+      {title && <DialogTitle>{title}</DialogTitle>}
+      {content && <DialogContent>{content}</DialogContent>}
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button variant="contained" color="error" onClick={onConfirm}>
+          Confirm
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/client/components/index.tsx
+++ b/client/components/index.tsx
@@ -15,3 +15,4 @@ export { default as BudgetForm } from './BudgetForm';
 export { default as BudgetTable } from './BudgetTable';
 export { ToastProvider, useToast } from '../context/ToastContext';
 export { default as WorkdayForm } from './WorkdayForm';
+export { default as ConfirmDialog } from './ConfirmDialog';

--- a/client/pages/budget-management/index.tsx
+++ b/client/pages/budget-management/index.tsx
@@ -6,6 +6,7 @@ import Box from '@mui/material/Box';
 import {
   Layout,
   Popup,
+  ConfirmDialog,
   BudgetForm,
   BudgetTable,
   useToast,
@@ -23,6 +24,7 @@ function BudgetManagement() {
   const { showToast } = useToast();
   const [rows, setRows] = useState([]);
   const [editRow, setEditRow] = useState(null);
+  const [deleteRow, setDeleteRow] = useState(null);
 
   async function loadData() {
     const data = await fetchBudgetOverview();
@@ -54,16 +56,19 @@ function BudgetManagement() {
     setEditRow(row);
   };
 
-  const handleDelete = async row => {
-    if (window.confirm('Delete this rate?')) {
-      try {
-        await deleteBudget(row.budgetId);
-        showToast('Rate deleted');
-        loadData();
-      } catch (e) {
-        showToast('Error deleting rate', { severity: 'error' });
-      }
+  const handleDelete = row => {
+    setDeleteRow(row);
+  };
+
+  const confirmDelete = async () => {
+    try {
+      await deleteBudget(deleteRow.budgetId);
+      showToast('Rate deleted');
+      loadData();
+    } catch (e) {
+      showToast('Error deleting rate', { severity: 'error' });
     }
+    setDeleteRow(null);
   };
 
   return (
@@ -86,6 +91,13 @@ function BudgetManagement() {
             />
           )}
         </Popup>
+        <ConfirmDialog
+          open={!!deleteRow}
+          title="Confirm Delete"
+          content="Delete this rate?"
+          onClose={() => setDeleteRow(null)}
+          onConfirm={confirmDelete}
+        />
       </Container>
     </Layout>
   );

--- a/client/pages/budget-management/role-setting.tsx
+++ b/client/pages/budget-management/role-setting.tsx
@@ -8,7 +8,7 @@ import TextField from '@mui/material/TextField';
 import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import Paper from '@mui/material/Paper';
-import { Layout, useToast } from '../../components';
+import { Layout, useToast, ConfirmDialog } from '../../components';
 import { withAuth, useAuth } from '../../context/AuthContext';
 import {
   fetchRoles,
@@ -23,6 +23,7 @@ function RoleSetting() {
   const [roles, setRoles] = useState([]);
   const [newRole, setNewRole] = useState('');
   const [levelInputs, setLevelInputs] = useState({});
+  const [removeData, setRemoveData] = useState(null);
 
   async function loadData() {
     const data = await fetchRoles();
@@ -57,15 +58,19 @@ function RoleSetting() {
     }
   };
 
-  const handleRemoveLevel = async (roleId, level) => {
-    if (!window.confirm('Remove this level?')) return;
+  const handleRemoveLevel = (roleId, level) => {
+    setRemoveData({ roleId, level });
+  };
+
+  const confirmRemove = async () => {
     try {
-      await removeLevel(roleId, level);
+      await removeLevel(removeData.roleId, removeData.level);
       showToast('Level removed');
       loadData();
     } catch (e) {
       showToast('Error removing level', { severity: 'error' });
     }
+    setRemoveData(null);
   };
 
   return (
@@ -129,6 +134,13 @@ function RoleSetting() {
             </Box>
           </Paper>
         ))}
+        <ConfirmDialog
+          open={!!removeData}
+          title="Confirm Delete"
+          content="Remove this level?"
+          onClose={() => setRemoveData(null)}
+          onConfirm={confirmRemove}
+        />
       </Container>
     </Layout>
   );

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -25,7 +25,7 @@ import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import Chip from '@mui/material/Chip';
 import api from '../api';
-import { Layout, Popup, ProjectForm, useToast } from '../components';
+import { Layout, Popup, ProjectForm, useToast, ConfirmDialog } from '../components';
 import { withAuth, useAuth } from '../context/AuthContext';
 
 const statusOptions = [
@@ -90,6 +90,7 @@ function ProjectManagement() {
   const [open, setOpen] = useState(false);
   const [teams, setTeams] = useState([]);
   const [budgets, setBudgets] = useState([]);
+  const [deleteRow, setDeleteRow] = useState(null);
 
   async function loadData() {
     const [pro, usr, tm, bg] = await Promise.all([
@@ -130,16 +131,19 @@ function ProjectManagement() {
     }
   };
 
-  const handleDelete = async row => {
-    if (window.confirm('Delete this project?')) {
-      try {
-        await api.delete(`/api/v1/projects/${row._id}`);
-        showToast('Project deleted');
-        loadData();
-      } catch (e) {
-        showToast('Error deleting project', { severity: 'error' });
-      }
+  const handleDelete = row => {
+    setDeleteRow(row);
+  };
+
+  const confirmDelete = async () => {
+    try {
+      await api.delete(`/api/v1/projects/${deleteRow._id}`);
+      showToast('Project deleted');
+      loadData();
+    } catch (e) {
+      showToast('Error deleting project', { severity: 'error' });
     }
+    setDeleteRow(null);
   };
 
   const handleRestore = async row => {
@@ -312,6 +316,13 @@ function ProjectManagement() {
             onSubmit={handleCreate}
           />
         </Popup>
+        <ConfirmDialog
+          open={!!deleteRow}
+          title="Confirm Delete"
+          content="Delete this project?"
+          onClose={() => setDeleteRow(null)}
+          onConfirm={confirmDelete}
+        />
       </Container>
     </Layout>
   );

--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -19,7 +19,7 @@ import {
   addYears,
   addMonths,
 } from 'date-fns';
-import { Layout, ResourceForm, Popup, useToast } from '../../components';
+import { Layout, ResourceForm, Popup, useToast, ConfirmDialog } from '../../components';
 import { withAuth, useAuth } from '../../context/AuthContext';
 import {
   fetchResources,
@@ -36,6 +36,7 @@ function TeamSetting() {
   const [resources, setResources] = useState([]);
   const [open, setOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
+  const [deleteRow, setDeleteRow] = useState(null);
 
   function getServiceDuration(date: string | Date) {
     const start = new Date(date);
@@ -102,16 +103,19 @@ function TeamSetting() {
     }
   };
 
-  const handleDelete = async row => {
-    if (window.confirm('Delete this resource?')) {
-      try {
-        await deleteResource(row.id);
-        showToast('Resource deleted');
-        loadData();
-      } catch (e) {
-        showToast('Error deleting resource', { severity: 'error' });
-      }
+  const handleDelete = row => {
+    setDeleteRow(row);
+  };
+
+  const confirmDelete = async () => {
+    try {
+      await deleteResource(deleteRow.id);
+      showToast('Resource deleted');
+      loadData();
+    } catch (e) {
+      showToast('Error deleting resource', { severity: 'error' });
     }
+    setDeleteRow(null);
   };
 
   const handleExport = async () => {
@@ -255,6 +259,13 @@ function TeamSetting() {
             />
           )}
         </Popup>
+        <ConfirmDialog
+          open={!!deleteRow}
+          title="Confirm Delete"
+          content="Delete this resource?"
+          onClose={() => setDeleteRow(null)}
+          onConfirm={confirmDelete}
+        />
       </Container>
     </Layout>
   );

--- a/client/pages/team-setting/team.tsx
+++ b/client/pages/team-setting/team.tsx
@@ -11,7 +11,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { DataGrid } from '@mui/x-data-grid';
 import api from '../../api';
-import { Layout, Popup, TeamForm, useToast } from '../../components';
+import { Layout, Popup, TeamForm, useToast, ConfirmDialog } from '../../components';
 import {
   fetchTeams,
   createTeam,
@@ -28,6 +28,7 @@ function TeamPage() {
   const [users, setUsers] = useState([]);
   const [open, setOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
+  const [deleteRow, setDeleteRow] = useState(null);
 
   async function loadData() {
     const [t, u] = await Promise.all([
@@ -66,16 +67,19 @@ function TeamPage() {
     }
   };
 
-  const handleDelete = async row => {
-    if (window.confirm('Delete this team?')) {
-      try {
-        await deleteTeam(row._id);
-        showToast('Team deleted');
-        loadData();
-      } catch (e) {
-        showToast('Error deleting team', { severity: 'error' });
-      }
+  const handleDelete = row => {
+    setDeleteRow(row);
+  };
+
+  const confirmDelete = async () => {
+    try {
+      await deleteTeam(deleteRow._id);
+      showToast('Team deleted');
+      loadData();
+    } catch (e) {
+      showToast('Error deleting team', { severity: 'error' });
     }
+    setDeleteRow(null);
   };
 
   const columns = [
@@ -161,6 +165,13 @@ function TeamPage() {
             />
           )}
         </Popup>
+        <ConfirmDialog
+          open={!!deleteRow}
+          title="Confirm Delete"
+          content="Delete this team?"
+          onClose={() => setDeleteRow(null)}
+          onConfirm={confirmDelete}
+        />
       </Container>
     </Layout>
   );

--- a/client/pages/team-setting/workday.tsx
+++ b/client/pages/team-setting/workday.tsx
@@ -13,7 +13,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { DataGrid } from '@mui/x-data-grid';
 import { format } from 'date-fns';
-import { Layout, Popup, WorkdayForm, useToast } from '../../components';
+import { Layout, Popup, WorkdayForm, useToast, ConfirmDialog } from '../../components';
 import { withAuth, useAuth } from '../../context/AuthContext';
 import {
   fetchWorkdays,
@@ -30,6 +30,7 @@ function WorkdayPage() {
   const [rows, setRows] = useState([]);
   const [open, setOpen] = useState(false);
   const [editRow, setEditRow] = useState(null);
+  const [deleteRow, setDeleteRow] = useState(null);
 
   async function loadData() {
     const data = await fetchWorkdays(year);
@@ -65,17 +66,20 @@ function WorkdayPage() {
     }
   };
 
-  const handleDelete = async row => {
+  const handleDelete = row => {
     if (row.readonly) return;
-    if (window.confirm('Delete this holiday?')) {
-      try {
-        await deleteWorkday(row.id);
-        showToast('Holiday deleted');
-        loadData();
-      } catch (e) {
-        showToast('Error deleting holiday', { severity: 'error' });
-      }
+    setDeleteRow(row);
+  };
+
+  const confirmDelete = async () => {
+    try {
+      await deleteWorkday(deleteRow.id);
+      showToast('Holiday deleted');
+      loadData();
+    } catch (e) {
+      showToast('Error deleting holiday', { severity: 'error' });
     }
+    setDeleteRow(null);
   };
 
   const years = [] as number[];
@@ -172,6 +176,13 @@ function WorkdayPage() {
         <Popup open={!!editRow} onClose={() => setEditRow(null)} title="Edit Holiday">
           {editRow && <WorkdayForm onSubmit={handleSave} initial={editRow} submitText="Save" />}
         </Popup>
+        <ConfirmDialog
+          open={!!deleteRow}
+          title="Confirm Delete"
+          content="Delete this holiday?"
+          onClose={() => setDeleteRow(null)}
+          onConfirm={confirmDelete}
+        />
       </Container>
     </Layout>
   );


### PR DESCRIPTION
## Summary
- create a `ConfirmDialog` component using MUI Dialog
- export the new component from the shared index
- replace `window.confirm` delete prompts with the modal in several pages

## Testing
- `npm test` in `client`
- `npm install` and `npm test` in `service`


------
https://chatgpt.com/codex/tasks/task_e_685bb139f5888328a833788e756883af