### PR TITLE
Fix vertical alignment of Project Name

### DIFF
--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -180,7 +180,14 @@ function ProjectManagement() {
       flex: 1,
       minWidth: 80,
       renderCell: params => (
-        <Box sx={{ display: 'flex', flexDirection: 'column', lineHeight: 1 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            lineHeight: 1,
+          }}
+        >
           <Typography variant="body2">{params.value}</Typography>
           {params.row.deleted && params.row.deletedAt && (
             <Typography variant="caption" color="error" sx={{ fontSize: '0.5em' }}>


### PR DESCRIPTION
## Summary
- center the Project Name column in Project Management page

## Testing
- `npm test --silent` in `service`
- `npm test --silent` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685bb1e65c688328998461e3754ff6f4