### PR TITLE
Hide single-level breadcrumbs

### DIFF
--- a/client/components/PageBreadcrumbs.tsx
+++ b/client/components/PageBreadcrumbs.tsx
@@ -10,6 +10,9 @@ export interface Crumb {
 
 export default function PageBreadcrumbs({ items }: { items: Crumb[] }) {
   const router = useRouter();
+  if (items.length <= 1) {
+    return null;
+  }
   return (
     <Breadcrumbs aria-label="breadcrumb" sx={{ mb: 2 }}>
       {items.map((item, idx) =>


### PR DESCRIPTION
## Summary
- avoid rendering breadcrumbs if there is only one item

## Testing
- `npm test` in `client`
- `npm test` in `service`


------
https://chatgpt.com/codex/tasks/task_e_685bb63318b48328ac8ffa5d4dc4abcf