### PR TITLE
Fix planning setting path

### DIFF
--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -128,16 +128,16 @@ export default function Sidebar({ open, onClose }) {
               </ListItemButton>
               <ListItemButton
                 sx={{ pl: 4 }}
-                selected={router.pathname === '/plan-management/planing-setting'}
+                selected={router.pathname === '/plan-management/planning-setting'}
                 onClick={() => {
-                  router.push('/plan-management/planing-setting');
+                  router.push('/plan-management/planning-setting');
                   onClose();
                 }}
               >
                 <ListItemIcon>
                   <CalendarMonthIcon fontSize="small" />
                 </ListItemIcon>
-                <ListItemText primary="Planing Setting" />
+                <ListItemText primary="Planning Setting" />
               </ListItemButton>
             </List>
           </Collapse>


### PR DESCRIPTION
## Summary
- fix the typo in Plan Management menu item

## Testing
- `npm test` in `client`
- `npm test` in `service`


------
https://chatgpt.com/codex/tasks/task_e_685bc0fc10a883288ab2d72ad2edad51