### PR TITLE
Add page loading component

### DIFF
--- a/client/components/PageLoading.tsx
+++ b/client/components/PageLoading.tsx
@@ -1,0 +1,10 @@
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+
+export default function PageLoading() {
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
+      <CircularProgress />
+    </Box>
+  );
+}

--- a/client/components/index.tsx
+++ b/client/components/index.tsx
@@ -1,5 +1,6 @@
 // @ts-nocheck
 export { default as Loading } from './Loading';
+export { default as PageLoading } from './PageLoading';
 export { default as lazyLoad } from './LazyLoad';
 export { default as Popup } from './Popup';
 export { default as Input } from './Input';

--- a/client/pages/activity.tsx
+++ b/client/pages/activity.tsx
@@ -10,7 +10,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
 import { DataGrid } from '@mui/x-data-grid';
-import { Layout, PageBreadcrumbs } from '../components';
+import { Layout, PageBreadcrumbs, PageLoading } from '../components';
 import { withAuth } from '../context/AuthContext';
 import { fetchActivityLogs } from '../models/activityLogModel';
 
@@ -18,9 +18,14 @@ function ActivityPage() {
   const [logs, setLogs] = useState([]);
   const [methodFilter, setMethodFilter] = useState('');
   const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetchActivityLogs().then(setLogs).catch(console.error);
+    setLoading(true);
+    fetchActivityLogs()
+      .then(setLogs)
+      .catch(console.error)
+      .finally(() => setLoading(false));
   }, []);
 
   const methods = useMemo(() => {
@@ -92,17 +97,21 @@ function ActivityPage() {
             onChange={e => setSearch(e.target.value)}
           />
         </Box>
-        <Paper>
-          <DataGrid
-            rows={filteredLogs}
-            columns={columns}
-            getRowId={row => row._id}
-            autoHeight
-            pageSize={25}
-            rowsPerPageOptions={[25]}
-            sx={{ width: '100%' }}
-          />
-        </Paper>
+        {loading ? (
+          <PageLoading />
+        ) : (
+          <Paper>
+            <DataGrid
+              rows={filteredLogs}
+              columns={columns}
+              getRowId={row => row._id}
+              autoHeight
+              pageSize={25}
+              rowsPerPageOptions={[25]}
+              sx={{ width: '100%' }}
+            />
+          </Paper>
+        )}
       </Container>
     </Layout>
   );

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -25,7 +25,7 @@ import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import Chip from '@mui/material/Chip';
 import api from '../api';
-import { Layout, Popup, ProjectForm, useToast, ConfirmDialog, PageBreadcrumbs } from '../components';
+import { Layout, Popup, ProjectForm, useToast, ConfirmDialog, PageBreadcrumbs, PageLoading } from '../components';
 import { withAuth, useAuth } from '../context/AuthContext';
 
 const statusOptions = [
@@ -91,25 +91,31 @@ function ProjectManagement() {
   const [teams, setTeams] = useState([]);
   const [budgets, setBudgets] = useState([]);
   const [deleteRow, setDeleteRow] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   async function loadData() {
-    const [pro, usr, tm, bg] = await Promise.all([
-      api.get('/api/v1/projects'),
-      api.get('/api/v1/resources'),
-      api.get('/api/v1/teams'),
-      api.get('/api/v1/budgets/overview'),
-    ]);
-    const cleaned = pro.data.map((p: any) => {
-      if (typeof p.onClick !== 'undefined') {
-        const { onClick, ...rest } = p;
-        return rest;
-      }
-      return p;
-    });
-    setProjects(cleaned);
-    setUsers(usr.data);
-    setTeams(tm.data);
-    setBudgets(bg.data);
+    try {
+      setLoading(true);
+      const [pro, usr, tm, bg] = await Promise.all([
+        api.get('/api/v1/projects'),
+        api.get('/api/v1/resources'),
+        api.get('/api/v1/teams'),
+        api.get('/api/v1/budgets/overview'),
+      ]);
+      const cleaned = pro.data.map((p: any) => {
+        if (typeof p.onClick !== 'undefined') {
+          const { onClick, ...rest } = p;
+          return rest;
+        }
+        return p;
+      });
+      setProjects(cleaned);
+      setUsers(usr.data);
+      setTeams(tm.data);
+      setBudgets(bg.data);
+    } finally {
+      setLoading(false);
+    }
   }
 
   useEffect(() => {
@@ -304,18 +310,24 @@ function ProjectManagement() {
           </Button>
         </Box>
         <PageBreadcrumbs items={[{ label: 'Project Management' }]} />
-        <Paper>
-          <DataGrid
-            rows={projects}
-            columns={columns}
-            getRowId={row => row._id}
-            getRowClassName={params => (params.row.deleted ? 'project-disabled' : '')}
-            pageSize={25}
-            rowsPerPageOptions={[25]}
-            autoHeight
-            sx={{ width: '100%' }}
-          />
-        </Paper>
+        {loading ? (
+          <PageLoading />
+        ) : (
+          <Paper>
+            <DataGrid
+              rows={projects}
+              columns={columns}
+              getRowId={row => row._id}
+              getRowClassName={params =>
+                params.row.deleted ? 'project-disabled' : ''
+              }
+              pageSize={25}
+              rowsPerPageOptions={[25]}
+              autoHeight
+              sx={{ width: '100%' }}
+            />
+          </Paper>
+        )}
         <Popup open={open} onClose={() => setOpen(false)} title="Add Project">
           <ProjectForm
             users={users}

--- a/client/pages/project/[id].tsx
+++ b/client/pages/project/[id].tsx
@@ -13,7 +13,7 @@ import { DataGrid } from '@mui/x-data-grid';
 import { BarChart } from '@mui/x-charts';
 import Chip from '@mui/material/Chip';
 import api from '../../api';
-import { Layout, Popup, ProjectForm, useToast } from '../../components';
+import { Layout, Popup, ProjectForm, useToast, PageLoading } from '../../components';
 import { withAuth } from '../../context/AuthContext';
 import { differenceInDays, addDays, format, isAfter } from 'date-fns';
 import { fetchWorkdays } from '../../models/workdayModel';
@@ -155,7 +155,7 @@ function ProjectDetail() {
     return (
       <Layout>
         <Container maxWidth={false} sx={{ mt: 4 }}>
-          <Typography>Loading...</Typography>
+          <PageLoading />
         </Container>
       </Layout>
     );


### PR DESCRIPTION
## Summary
- create `PageLoading` component with spinner
- use `PageLoading` on pages that load data from the API
  - activity logs page
  - project management page
  - project detail page

## Testing
- `npm run check` in `client`
- `npm run check` in `service`


------
https://chatgpt.com/codex/tasks/task_e_685bc1b52b508328b40106e0a10061b6