### PR TITLE
Filter deleted projects in planning page

### DIFF
--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -24,7 +24,10 @@ function PlanningSetting() {
   const [dialog, setDialog] = useState('');
 
   useEffect(() => {
-    api.get('/api/v1/projects').then(res => setProjects(res.data)).catch(console.error);
+    api
+      .get('/api/v1/projects')
+      .then(res => setProjects(res.data.filter(p => !p.deleted)))
+      .catch(console.error);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- show only non-deleted projects in planning setting page

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685bc41e79988328b8794cd589f45700