### PR TITLE
Fix duplicate key error in project dropdown

### DIFF
--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -82,6 +82,12 @@ function PlanningSetting() {
           <Autocomplete
             options={projects}
             getOptionLabel={o => o.name}
+            isOptionEqualToValue={(o, v) => (o._id || o.id) === (v._id || v.id)}
+            renderOption={(props, option) => (
+              <li {...props} key={option._id || option.id}>
+                {option.name}
+              </li>
+            )}
             value={project}
             onChange={(_, v) => setProject(v)}
             renderInput={params => <TextField {...params} label="Project" />}


### PR DESCRIPTION
## Summary
- ensure unique keys when rendering project dropdown

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685bddee59d88328a642ccce5fdb4bfb