### PR TITLE
Add detailed planning fields and timeline

### DIFF
--- a/client/components/MilestoneForm.tsx
+++ b/client/components/MilestoneForm.tsx
@@ -7,10 +7,12 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 export default function MilestoneForm({ onSubmit, initial, existingDates = [] }) {
   const [name, setName] = useState(initial?.name || '');
   const [date, setDate] = useState(initial?.date || null);
+  const [detail, setDetail] = useState(initial?.detail || '');
 
   useEffect(() => {
     setName(initial?.name || '');
     setDate(initial?.date || null);
+    setDetail(initial?.detail || '');
   }, [initial]);
 
   const handleSubmit = e => {
@@ -19,14 +21,16 @@ export default function MilestoneForm({ onSubmit, initial, existingDates = [] })
       alert('Milestone date overlaps existing one');
       return;
     }
-    onSubmit && onSubmit({ name, date });
+    onSubmit && onSubmit({ name, date, detail });
     setName('');
     setDate(null);
+    setDetail('');
   };
 
   return (
     <form onSubmit={handleSubmit}>
       <TextField label="Name" value={name} onChange={e => setName(e.target.value)} fullWidth required sx={{ mb: 2 }} />
+      <TextField label="Detail" value={detail} onChange={e => setDetail(e.target.value)} fullWidth multiline sx={{ mb: 2 }} />
       <DatePicker label="Date" value={date} onChange={setDate} slotProps={{ textField: { required: true } }} />
       <Button type="submit" variant="contained" sx={{ display: 'block', mt: 2 }}>
         {initial ? 'Update' : 'Create'}

--- a/client/components/TaskForm.tsx
+++ b/client/components/TaskForm.tsx
@@ -2,18 +2,28 @@
 import { useState, useEffect } from 'react';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
-import Autocomplete from '@mui/material/Autocomplete';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Checkbox from '@mui/material/Checkbox';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 
-export default function TaskForm({ phases = [], onSubmit, initial }) {
+export default function TaskForm({ onSubmit, initial }) {
   const [name, setName] = useState(initial?.name || '');
-  const [phase, setPhase] = useState(initial?.phase || null);
+  const [detail, setDetail] = useState(initial?.detail || '');
+  const [startDate, setStartDate] = useState(initial?.startDate || null);
+  const [endDate, setEndDate] = useState(initial?.endDate || null);
+  const [owner, setOwner] = useState(initial?.owner || '');
+  const [manday, setManday] = useState(initial?.manday != null ? String(initial.manday) : '');
+  const [blockedBy, setBlockedBy] = useState(initial?.blockedBy || '');
   const [feature, setFeature] = useState(initial?.isFeature || false);
 
   useEffect(() => {
     setName(initial?.name || '');
-    setPhase(initial?.phase || null);
+    setDetail(initial?.detail || '');
+    setStartDate(initial?.startDate || null);
+    setEndDate(initial?.endDate || null);
+    setOwner(initial?.owner || '');
+    setManday(initial?.manday != null ? String(initial.manday) : '');
+    setBlockedBy(initial?.blockedBy || '');
     setFeature(initial?.isFeature || false);
   }, [initial]);
 
@@ -22,25 +32,33 @@ export default function TaskForm({ phases = [], onSubmit, initial }) {
     onSubmit &&
       onSubmit({
         name,
-        phase: phase?._id || phase?.id,
+        detail,
+        startDate,
+        endDate,
+        owner,
+        manday: manday ? Number(manday) : undefined,
+        blockedBy: blockedBy || undefined,
         ...(feature ? { isFeature: true } : {}),
       });
     setName('');
-    setPhase(null);
+    setDetail('');
+    setStartDate(null);
+    setEndDate(null);
+    setOwner('');
+    setManday('');
+    setBlockedBy('');
     setFeature(false);
   };
 
   return (
     <form onSubmit={handleSubmit}>
       <TextField label="Name" value={name} onChange={e => setName(e.target.value)} fullWidth required sx={{ mb: 2 }} />
-      <Autocomplete
-        options={phases}
-        getOptionLabel={o => o.name}
-        value={phase}
-        onChange={(_, v) => setPhase(v)}
-        renderInput={params => <TextField {...params} label="Phase" required />}
-        sx={{ mb: 2 }}
-      />
+      <TextField label="Detail" value={detail} onChange={e => setDetail(e.target.value)} fullWidth multiline sx={{ mb: 2 }} />
+      <DatePicker label="Start Date" value={startDate} onChange={setStartDate} sx={{ mb: 2 }} />
+      <DatePicker label="End Date" value={endDate} onChange={setEndDate} sx={{ mb: 2 }} />
+      <TextField label="Owner" value={owner} onChange={e => setOwner(e.target.value)} fullWidth sx={{ mb: 2 }} />
+      <TextField label="Manday" type="number" value={manday} onChange={e => setManday(e.target.value)} fullWidth sx={{ mb: 2 }} />
+      <TextField label="Blocked By" value={blockedBy} onChange={e => setBlockedBy(e.target.value)} fullWidth sx={{ mb: 2 }} />
       <FormControlLabel control={<Checkbox checked={feature} onChange={e => setFeature(e.target.checked)} />} label="Feature" />
       <Button type="submit" variant="contained" sx={{ display: 'block', mt: 2 }}>
         {initial ? 'Update' : 'Create'}

--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -11,14 +11,19 @@ import Stack from '@mui/material/Stack';
 import { Layout, PageBreadcrumbs, Popup } from '../../components';
 import { withAuth } from '../../context/AuthContext';
 import api from '../../api';
-import PhaseForm from '../../components/PhaseForm';
 import TaskForm from '../../components/TaskForm';
 import MilestoneForm from '../../components/MilestoneForm';
+import { DataGrid } from '@mui/x-data-grid';
+import Timeline from '@mui/lab/Timeline';
+import TimelineItem from '@mui/lab/TimelineItem';
+import TimelineSeparator from '@mui/lab/TimelineSeparator';
+import TimelineConnector from '@mui/lab/TimelineConnector';
+import TimelineContent from '@mui/lab/TimelineContent';
+import TimelineDot from '@mui/lab/TimelineDot';
 
 function PlanningSetting() {
   const [projects, setProjects] = useState([]);
   const [project, setProject] = useState(null);
-  const [phases, setPhases] = useState([]);
   const [tasks, setTasks] = useState([]);
   const [milestones, setMilestones] = useState([]);
   const [dialog, setDialog] = useState('');
@@ -33,7 +38,6 @@ function PlanningSetting() {
   useEffect(() => {
     if (!project) return;
     const pid = project._id || project.id;
-    api.get('/api/v1/planning/phases', { params: { project: pid } }).then(res => setPhases(res.data));
     api.get('/api/v1/planning/tasks', { params: { project: pid } }).then(res => setTasks(res.data));
     api.get('/api/v1/planning/milestones', { params: { project: pid } }).then(res => setMilestones(res.data));
   }, [project]);
@@ -41,20 +45,12 @@ function PlanningSetting() {
   const refreshAll = async () => {
     if (!project) return;
     const pid = project._id || project.id;
-    const [p, t, m] = await Promise.all([
-      api.get('/api/v1/planning/phases', { params: { project: pid } }),
+    const [t, m] = await Promise.all([
       api.get('/api/v1/planning/tasks', { params: { project: pid } }),
       api.get('/api/v1/planning/milestones', { params: { project: pid } }),
     ]);
-    setPhases(p.data);
     setTasks(t.data);
     setMilestones(m.data);
-  };
-
-  const handleCreatePhase = async data => {
-    await api.post('/api/v1/planning/phases', { ...data, project: project._id });
-    await refreshAll();
-    setDialog('');
   };
 
   const handleCreateTask = async data => {
@@ -97,24 +93,25 @@ function PlanningSetting() {
           <Stack spacing={2}>
             <Box>
               <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-                <Typography variant="h6">Phases</Typography>
-                <Button variant="contained" onClick={() => setDialog('phase')}>Add Phase</Button>
-              </Box>
-              <Paper sx={{ p: 2 }}>
-                {phases.map((p, idx) => (
-                  <Typography key={p._id || idx}>{p.name}</Typography>
-                ))}
-              </Paper>
-            </Box>
-            <Box>
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
                 <Typography variant="h6">Tasks / Features</Typography>
-                <Button variant="contained" onClick={() => setDialog('task')} disabled={phases.length === 0}>Add</Button>
+                <Button variant="contained" onClick={() => setDialog('task')}>Add</Button>
               </Box>
               <Paper sx={{ p: 2 }}>
-                {tasks.map((t, idx) => (
-                  <Typography key={t._id || idx}>{t.name} {t.isFeature ? '(Feature)' : ''}</Typography>
-                ))}
+                <DataGrid
+                  rows={tasks.map(t => ({ id: t._id || t.id, ...t }))}
+                  columns={[
+                    { field: 'name', headerName: 'Name', flex: 1 },
+                    { field: 'detail', headerName: 'Detail', flex: 1 },
+                    { field: 'startDate', headerName: 'Start', valueFormatter: ({ value }) => value ? new Date(value).toLocaleDateString() : '', width: 120 },
+                    { field: 'endDate', headerName: 'End', valueFormatter: ({ value }) => value ? new Date(value).toLocaleDateString() : '', width: 120 },
+                    { field: 'owner', headerName: 'Owner', width: 120 },
+                    { field: 'manday', headerName: 'Manday', width: 100, type: 'number' },
+                    { field: 'blockedBy', headerName: 'Blocked By', width: 120 },
+                    { field: 'isFeature', headerName: 'Feature', width: 80, type: 'boolean' },
+                  ]}
+                  autoHeight
+                  hideFooter
+                />
               </Paper>
             </Box>
             <Box>
@@ -123,18 +120,44 @@ function PlanningSetting() {
                 <Button variant="contained" onClick={() => setDialog('milestone')}>Add Milestone</Button>
               </Box>
               <Paper sx={{ p: 2 }}>
-                {milestones.map((m, idx) => (
-                  <Typography key={m._id || idx}>{m.name} - {new Date(m.date).toLocaleDateString()}</Typography>
-                ))}
+                <DataGrid
+                  rows={milestones.map(m => ({ id: m._id || m.id, ...m }))}
+                  columns={[
+                    { field: 'name', headerName: 'Name', flex: 1 },
+                    { field: 'detail', headerName: 'Detail', flex: 1 },
+                    { field: 'date', headerName: 'Date', valueFormatter: ({ value }) => value ? new Date(value).toLocaleDateString() : '', width: 120 },
+                  ]}
+                  autoHeight
+                  hideFooter
+                />
+              </Paper>
+            </Box>
+            <Box>
+              <Typography variant="h6" sx={{ mb: 1 }}>Timeline</Typography>
+              <Paper sx={{ p: 2 }}>
+                <Timeline>
+                  {[...tasks.map(t => ({ type: 'task', date: t.startDate || t.endDate, title: t.name })),
+                    ...milestones.map(m => ({ type: 'milestone', date: m.date, title: m.name }))]
+                    .filter(i => i.date)
+                    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+                    .map((item, idx, arr) => (
+                      <TimelineItem key={idx}>
+                        <TimelineSeparator>
+                          <TimelineDot />
+                          {idx < arr.length - 1 && <TimelineConnector />}
+                        </TimelineSeparator>
+                        <TimelineContent>
+                          {item.title} - {new Date(item.date).toLocaleDateString()}
+                        </TimelineContent>
+                      </TimelineItem>
+                    ))}
+                </Timeline>
               </Paper>
             </Box>
           </Stack>
         )}
-        <Popup open={dialog === 'phase'} onClose={() => setDialog('')} title="Add Phase">
-          <PhaseForm onSubmit={handleCreatePhase} />
-        </Popup>
         <Popup open={dialog === 'task'} onClose={() => setDialog('')} title="Add Task/Feature">
-          <TaskForm phases={phases} onSubmit={handleCreateTask} />
+          <TaskForm onSubmit={handleCreateTask} />
         </Popup>
         <Popup open={dialog === 'milestone'} onClose={() => setDialog('')} title="Add Milestone">
           <MilestoneForm onSubmit={handleCreateMilestone} existingDates={milestoneDates} />

--- a/service/src/planning/data/milestone.schema.ts
+++ b/service/src/planning/data/milestone.schema.ts
@@ -11,6 +11,9 @@ export class Milestone extends Document {
 
   @Prop({ required: true })
   date: Date;
+
+  @Prop()
+  detail?: string;
 }
 
 export const MilestoneSchema = SchemaFactory.createForClass(Milestone);

--- a/service/src/planning/data/milestones.repository.ts
+++ b/service/src/planning/data/milestones.repository.ts
@@ -7,11 +7,13 @@ export interface CreateMilestoneInput {
   project: Types.ObjectId;
   name: string;
   date: Date;
+  detail?: string;
 }
 
 export interface UpdateMilestoneInput {
   name?: string;
   date?: Date;
+  detail?: string;
 }
 
 @Injectable()

--- a/service/src/planning/data/task.schema.ts
+++ b/service/src/planning/data/task.schema.ts
@@ -15,6 +15,24 @@ export class Task extends Document {
 
   @Prop({ default: false })
   isFeature: boolean;
+
+  @Prop()
+  detail?: string;
+
+  @Prop()
+  startDate?: Date;
+
+  @Prop()
+  endDate?: Date;
+
+  @Prop()
+  owner?: string;
+
+  @Prop()
+  manday?: number;
+
+  @Prop({ type: Types.ObjectId, ref: Task.name })
+  blockedBy?: Types.ObjectId;
 }
 
 export const TaskSchema = SchemaFactory.createForClass(Task);

--- a/service/src/planning/data/tasks.repository.ts
+++ b/service/src/planning/data/tasks.repository.ts
@@ -8,12 +8,24 @@ export interface CreateTaskInput {
   phase?: Types.ObjectId;
   name: string;
   isFeature?: boolean;
+  detail?: string;
+  startDate?: Date;
+  endDate?: Date;
+  owner?: string;
+  manday?: number;
+  blockedBy?: Types.ObjectId;
 }
 
 export interface UpdateTaskInput {
   phase?: Types.ObjectId;
   name?: string;
   isFeature?: boolean;
+  detail?: string;
+  startDate?: Date;
+  endDate?: Date;
+  owner?: string;
+  manday?: number;
+  blockedBy?: Types.ObjectId;
 }
 
 @Injectable()


### PR DESCRIPTION
## Summary
- expand Task and Milestone schemas with more detail fields
- simplify Planning Setting page to use tasks and milestones only
- add table views and a timeline panel
- update task and milestone forms with new fields

## Testing
- `npm install` in `service`
- `npm test` in `service`
- `npm install` in `client`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685be370e30c8328bd962600d8167dbb