### PR TITLE
Implement validation in planning setting forms

### DIFF
--- a/client/components/MilestoneForm.tsx
+++ b/client/components/MilestoneForm.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
@@ -15,12 +15,22 @@ export default function MilestoneForm({ onSubmit, initial, existingDates = [] })
     setDetail(initial?.detail || '');
   }, [initial]);
 
+  const dateError = useMemo(
+    () =>
+      !!(
+        date && existingDates.includes(new Date(date).toDateString())
+      ),
+    [date, existingDates],
+  );
+
+  const formValid = useMemo(
+    () => name.trim() !== '' && !!date && !dateError,
+    [name, date, dateError],
+  );
+
   const handleSubmit = e => {
     e.preventDefault();
-    if (date && existingDates.includes(new Date(date).toDateString())) {
-      alert('Milestone date overlaps existing one');
-      return;
-    }
+    if (!formValid) return;
     onSubmit && onSubmit({ name, date, detail });
     setName('');
     setDate(null);
@@ -31,8 +41,24 @@ export default function MilestoneForm({ onSubmit, initial, existingDates = [] })
     <form onSubmit={handleSubmit}>
       <TextField label="Name" value={name} onChange={e => setName(e.target.value)} fullWidth required sx={{ mb: 2 }} />
       <TextField label="Detail" value={detail} onChange={e => setDetail(e.target.value)} fullWidth multiline sx={{ mb: 2 }} />
-      <DatePicker label="Date" value={date} onChange={setDate} slotProps={{ textField: { required: true } }} />
-      <Button type="submit" variant="contained" sx={{ display: 'block', mt: 2 }}>
+      <DatePicker
+        label="Date"
+        value={date}
+        onChange={setDate}
+        slotProps={{
+          textField: {
+            required: true,
+            error: dateError,
+            helperText: dateError ? 'Date overlaps existing milestone' : undefined,
+          },
+        }}
+      />
+      <Button
+        type="submit"
+        variant="contained"
+        sx={{ display: 'block', mt: 2 }}
+        disabled={!formValid}
+      >
         {initial ? 'Update' : 'Create'}
       </Button>
     </form>

--- a/client/components/TaskForm.tsx
+++ b/client/components/TaskForm.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import FormControlLabel from '@mui/material/FormControlLabel';
@@ -27,8 +27,24 @@ export default function TaskForm({ onSubmit, initial }) {
     setFeature(initial?.isFeature || false);
   }, [initial]);
 
+  const dateError = useMemo(
+    () =>
+      !!(
+        startDate &&
+        endDate &&
+        new Date(startDate).getTime() > new Date(endDate).getTime()
+      ),
+    [startDate, endDate],
+  );
+
+  const formValid = useMemo(
+    () => name.trim() !== '' && !dateError,
+    [name, dateError],
+  );
+
   const handleSubmit = e => {
     e.preventDefault();
+    if (!formValid) return;
     onSubmit &&
       onSubmit({
         name,
@@ -54,13 +70,35 @@ export default function TaskForm({ onSubmit, initial }) {
     <form onSubmit={handleSubmit}>
       <TextField label="Name" value={name} onChange={e => setName(e.target.value)} fullWidth required sx={{ mb: 2 }} />
       <TextField label="Detail" value={detail} onChange={e => setDetail(e.target.value)} fullWidth multiline sx={{ mb: 2 }} />
-      <DatePicker label="Start Date" value={startDate} onChange={setStartDate} sx={{ mb: 2 }} />
-      <DatePicker label="End Date" value={endDate} onChange={setEndDate} sx={{ mb: 2 }} />
+      <DatePicker
+        label="Start Date"
+        value={startDate}
+        onChange={setStartDate}
+        sx={{ mb: 2 }}
+        slotProps={{ textField: { error: dateError } }}
+      />
+      <DatePicker
+        label="End Date"
+        value={endDate}
+        onChange={setEndDate}
+        sx={{ mb: 2 }}
+        slotProps={{
+          textField: {
+            error: dateError,
+            helperText: dateError ? 'End date must be after start date' : undefined,
+          },
+        }}
+      />
       <TextField label="Owner" value={owner} onChange={e => setOwner(e.target.value)} fullWidth sx={{ mb: 2 }} />
       <TextField label="Manday" type="number" value={manday} onChange={e => setManday(e.target.value)} fullWidth sx={{ mb: 2 }} />
       <TextField label="Blocked By" value={blockedBy} onChange={e => setBlockedBy(e.target.value)} fullWidth sx={{ mb: 2 }} />
       <FormControlLabel control={<Checkbox checked={feature} onChange={e => setFeature(e.target.checked)} />} label="Feature" />
-      <Button type="submit" variant="contained" sx={{ display: 'block', mt: 2 }}>
+      <Button
+        type="submit"
+        variant="contained"
+        sx={{ display: 'block', mt: 2 }}
+        disabled={!formValid}
+      >
         {initial ? 'Update' : 'Create'}
       </Button>
     </form>


### PR DESCRIPTION
## Summary
- add validation to MilestoneForm with duplicate date check
- disable Create button until MilestoneForm is valid
- validate TaskForm start/end date order
- disable TaskForm Create button until fields are valid

## Testing
- `npm test` *(fails: jest not found)*
- `npm run check` in service *(fails: nest not found)*
- `npm run check` in client *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0466e79c832891065166720ab009