### PR TITLE
Add server error dialog

### DIFF
--- a/client/api.ts
+++ b/client/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { triggerError } from './context/ErrorContext';
 
 const api = axios.create();
 
@@ -14,5 +15,16 @@ api.interceptors.request.use(config => {
   }
   return config;
 });
+
+api.interceptors.response.use(
+  res => res,
+  err => {
+    if (err.response && err.response.status === 500) {
+      const msg = err.response.data?.message || 'Internal Server Error';
+      triggerError(msg);
+    }
+    return Promise.reject(err);
+  }
+);
 
 export default api;

--- a/client/components/index.tsx
+++ b/client/components/index.tsx
@@ -15,6 +15,7 @@ export { default as ProjectForm } from './ProjectForm';
 export { default as BudgetForm } from './BudgetForm';
 export { default as BudgetTable } from './BudgetTable';
 export { ToastProvider, useToast } from '../context/ToastContext';
+export { ErrorProvider } from '../context/ErrorContext';
 export { default as WorkdayForm } from './WorkdayForm';
 export { default as ConfirmDialog } from './ConfirmDialog';
 export { default as PageBreadcrumbs } from './PageBreadcrumbs';

--- a/client/context/ErrorContext.tsx
+++ b/client/context/ErrorContext.tsx
@@ -1,0 +1,60 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+
+let externalHandler: (msg: string) => void = () => {};
+export function registerErrorHandler(fn: (msg: string) => void) {
+  externalHandler = fn;
+}
+export function triggerError(message: string) {
+  externalHandler(message);
+}
+
+interface ErrorContextProps {
+  showError: (message: string) => void;
+}
+
+const ErrorContext = createContext<ErrorContextProps>({
+  showError: () => {},
+});
+
+export function ErrorProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const showError = (msg: string) => {
+    setMessage(msg);
+    setOpen(true);
+  };
+
+  const handleClose = () => setOpen(false);
+
+  useEffect(() => {
+    registerErrorHandler(showError);
+    return () => {
+      registerErrorHandler(() => {});
+    };
+  }, []);
+
+  return (
+    <ErrorContext.Provider value={{ showError }}>
+      {children}
+      <Dialog open={open} onClose={handleClose} fullWidth>
+        <DialogTitle>Error</DialogTitle>
+        <DialogContent>{message}</DialogContent>
+        <DialogActions>
+          <Button variant="contained" onClick={handleClose}>
+            OK
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </ErrorContext.Provider>
+  );
+}
+
+export function useError() {
+  return useContext(ErrorContext);
+}

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -7,7 +7,7 @@ import Head from 'next/head';
 import theme from '../theme';
 import { AuthProvider } from '../context/AuthContext';
 import { SidebarProvider } from '../context/SidebarContext';
-import { ToastProvider } from '../components';
+import { ToastProvider, ErrorProvider } from '../components';
 import '../styles/globals.scss';
 
 export default function MyApp({ Component, pageProps }) {
@@ -20,9 +20,11 @@ export default function MyApp({ Component, pageProps }) {
         </Head>
         <AuthProvider>
           <SidebarProvider>
-            <ToastProvider>
-              <Component {...pageProps} />
-            </ToastProvider>
+            <ErrorProvider>
+              <ToastProvider>
+                <Component {...pageProps} />
+              </ToastProvider>
+            </ErrorProvider>
           </SidebarProvider>
         </AuthProvider>
       </ThemeProvider>


### PR DESCRIPTION
## Summary
- show a modal dialog for 500 errors
- wire the dialog in the root app
- export the provider from the component barrel

## Testing
- `npm run check` in `client`
- `npm test` in `client`
- `npm run check` in `service`
- `npm test` in `service`


------
https://chatgpt.com/codex/tasks/task_e_685c04dc09dc83289fd339cce4910362