### PR TITLE
Fix DataGrid valueFormatter crash

### DIFF
--- a/client/components/BudgetTable.tsx
+++ b/client/components/BudgetTable.tsx
@@ -44,8 +44,10 @@ export default function BudgetTable({ data, onEdit, onDelete }) {
       type: 'number',
       headerAlign: 'right',
       align: 'right',
-      valueFormatter: ({ value }) =>
-        typeof value === 'number' ? currencyFormatter.format(value) : value,
+      valueFormatter: params => {
+        const value = params?.value;
+        return typeof value === 'number' ? currencyFormatter.format(value) : value;
+      },
     },
     (onEdit || onDelete) && {
       field: 'actions',

--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -102,8 +102,14 @@ function PlanningSetting() {
                   columns={[
                     { field: 'name', headerName: 'Name', flex: 1 },
                     { field: 'detail', headerName: 'Detail', flex: 1 },
-                    { field: 'startDate', headerName: 'Start', valueFormatter: ({ value }) => value ? new Date(value).toLocaleDateString() : '', width: 120 },
-                    { field: 'endDate', headerName: 'End', valueFormatter: ({ value }) => value ? new Date(value).toLocaleDateString() : '', width: 120 },
+                    { field: 'startDate', headerName: 'Start', valueFormatter: params => {
+                      const value = params?.value;
+                      return value ? new Date(value).toLocaleDateString() : '';
+                    }, width: 120 },
+                    { field: 'endDate', headerName: 'End', valueFormatter: params => {
+                      const value = params?.value;
+                      return value ? new Date(value).toLocaleDateString() : '';
+                    }, width: 120 },
                     { field: 'owner', headerName: 'Owner', width: 120 },
                     { field: 'manday', headerName: 'Manday', width: 100, type: 'number' },
                     { field: 'blockedBy', headerName: 'Blocked By', width: 120 },
@@ -125,7 +131,10 @@ function PlanningSetting() {
                   columns={[
                     { field: 'name', headerName: 'Name', flex: 1 },
                     { field: 'detail', headerName: 'Detail', flex: 1 },
-                    { field: 'date', headerName: 'Date', valueFormatter: ({ value }) => value ? new Date(value).toLocaleDateString() : '', width: 120 },
+                    { field: 'date', headerName: 'Date', valueFormatter: params => {
+                      const value = params?.value;
+                      return value ? new Date(value).toLocaleDateString() : '';
+                    }, width: 120 },
                   ]}
                   autoHeight
                   hideFooter


### PR DESCRIPTION
## Summary
- prevent errors when `valueFormatter` params are null in Planning Setting page
- guard against null parameters in BudgetTable rate column

## Testing
- `npm --prefix client test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685c0867b3348328866d740e7ef22697