### PR TITLE
Fix project selector crash

### DIFF
--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -137,7 +137,9 @@ function PlanningSetting() {
           <Autocomplete
             options={projects}
             getOptionLabel={o => o.name}
-            isOptionEqualToValue={(o, v) => (o._id || o.id) === (v._id || v.id)}
+            isOptionEqualToValue={(o, v) =>
+              v ? (o._id || o.id) === (v._id || v.id) : false
+            }
             renderOption={(props, option) => (
               <li {...props} key={option._id || option.id}>
                 {option.name}


### PR DESCRIPTION
## Summary
- fix `isOptionEqualToValue` null check in planning-setting page

## Testing
- `npm run test` in `client`
- `npm run build` in `client`
- `npm run test` in `service`


------
https://chatgpt.com/codex/tasks/task_e_685c09e73fdc8328963fb298bfe4dfbb