### PR TITLE
Fix empty task error in planning Gantt

### DIFF
--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -250,7 +250,17 @@ function PlanningSetting() {
                     </TreeView>
                   </Grid>
                   <Grid item xs={8}>
-                    <Gantt tasks={ganttTasks} viewMode={viewMode} onDateChange={handleDateChange} />
+                    {ganttTasks.length > 0 ? (
+                      <Gantt
+                        tasks={ganttTasks}
+                        viewMode={viewMode}
+                        onDateChange={handleDateChange}
+                      />
+                    ) : (
+                      <Typography variant="body2" align="center">
+                        No schedule data
+                      </Typography>
+                    )}
                   </Grid>
                 </Grid>
               </Paper>


### PR DESCRIPTION
## Summary
- handle empty tasks in planning-setting page so Gantt library doesn't crash
- show a message when no schedule data is available

## Testing
- `npm test --silent` in client
- `npm install --silent` & `npm test --silent` in service

------
https://chatgpt.com/codex/tasks/task_e_685c10011c988328b728d5bab705a14c