### PR TITLE
Fix closing tags in planning setting page

### DIFF
--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -263,9 +263,10 @@ function PlanningSetting() {
                   </Grid>
                 </Grid>
               </Paper>
-            </Box>
-          </Grid>
-        )}
+            </Grid>
+            {/* closing tag for outer Grid container */}
+            </Grid>
+          )}
         <Popup open={dialog === 'task'} onClose={() => setDialog('')} title="Add Task/Feature">
           <TaskForm onSubmit={handleCreateTask} />
         </Popup>


### PR DESCRIPTION
## Summary
- fix mismatched JSX tags in `planning-setting.tsx`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c17c8a3008328b5e49cfbe9a735bc