### PR TITLE
Update planning setting for duration and owners

### DIFF
--- a/client/components/TaskForm.tsx
+++ b/client/components/TaskForm.tsx
@@ -1,19 +1,22 @@
 // @ts-nocheck
 import { useState, useEffect, useMemo } from 'react';
+import Autocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Checkbox from '@mui/material/Checkbox';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { addDays } from 'date-fns';
 
-export default function TaskForm({ onSubmit, initial }) {
+export default function TaskForm({ onSubmit, initial, members = [], tasks = [], milestones = [] }) {
   const [name, setName] = useState(initial?.name || '');
   const [detail, setDetail] = useState(initial?.detail || '');
   const [startDate, setStartDate] = useState(initial?.startDate || null);
   const [endDate, setEndDate] = useState(initial?.endDate || null);
   const [owner, setOwner] = useState(initial?.owner || '');
   const [manday, setManday] = useState(initial?.manday != null ? String(initial.manday) : '');
-  const [blockedBy, setBlockedBy] = useState(initial?.blockedBy || '');
+  const [duration, setDuration] = useState(initial?.duration != null ? String(initial.duration) : '');
+  const [blocked, setBlocked] = useState(null);
   const [feature, setFeature] = useState(initial?.isFeature || false);
 
   useEffect(() => {
@@ -23,7 +26,8 @@ export default function TaskForm({ onSubmit, initial }) {
     setEndDate(initial?.endDate || null);
     setOwner(initial?.owner || '');
     setManday(initial?.manday != null ? String(initial.manday) : '');
-    setBlockedBy(initial?.blockedBy || '');
+    setDuration(initial?.duration != null ? String(initial.duration) : '');
+    setBlocked(null);
     setFeature(initial?.isFeature || false);
   }, [initial]);
 
@@ -42,6 +46,22 @@ export default function TaskForm({ onSubmit, initial }) {
     [name, dateError],
   );
 
+  useEffect(() => {
+    if (startDate && duration) {
+      try {
+        const d = addDays(new Date(startDate), Number(duration));
+        setEndDate(d);
+      } catch {}
+    }
+  }, [startDate, duration]);
+
+  useEffect(() => {
+    if (blocked?.date) {
+      const d = addDays(new Date(blocked.date), 1);
+      setStartDate(d);
+    }
+  }, [blocked]);
+
   const handleSubmit = e => {
     e.preventDefault();
     if (!formValid) return;
@@ -53,7 +73,8 @@ export default function TaskForm({ onSubmit, initial }) {
         endDate,
         owner,
         manday: manday ? Number(manday) : undefined,
-        blockedBy: blockedBy || undefined,
+        duration: duration ? Number(duration) : undefined,
+        blockedBy: blocked ? blocked.id : undefined,
         ...(feature ? { isFeature: true } : {}),
       });
     setName('');
@@ -62,7 +83,8 @@ export default function TaskForm({ onSubmit, initial }) {
     setEndDate(null);
     setOwner('');
     setManday('');
-    setBlockedBy('');
+    setDuration('');
+    setBlocked(null);
     setFeature(false);
   };
 
@@ -89,9 +111,25 @@ export default function TaskForm({ onSubmit, initial }) {
           },
         }}
       />
-      <TextField label="Owner" value={owner} onChange={e => setOwner(e.target.value)} fullWidth sx={{ mb: 2 }} />
+      <TextField label="Duration (days)" type="number" value={duration} onChange={e => setDuration(e.target.value)} fullWidth sx={{ mb: 2 }} />
+      <Autocomplete
+        options={members}
+        getOptionLabel={o => o.name}
+        value={members.find(m => m.id === owner) || null}
+        onChange={(_, v) => setOwner(v ? v.id : '')}
+        renderInput={params => <TextField {...params} label="Owner" />}
+        sx={{ mb: 2 }}
+      />
       <TextField label="Manday" type="number" value={manday} onChange={e => setManday(e.target.value)} fullWidth sx={{ mb: 2 }} />
-      <TextField label="Blocked By" value={blockedBy} onChange={e => setBlockedBy(e.target.value)} fullWidth sx={{ mb: 2 }} />
+      <Autocomplete
+        options={[...tasks.map(t => ({ id: t._id || t.id, label: t.name, date: t.endDate })),
+                  ...milestones.map(m => ({ id: m._id || m.id, label: m.name, date: m.date }))]}
+        getOptionLabel={o => o.label}
+        value={blocked}
+        onChange={(_, v) => setBlocked(v)}
+        renderInput={params => <TextField {...params} label="Blocked By" />}
+        sx={{ mb: 2 }}
+      />
       <FormControlLabel control={<Checkbox checked={feature} onChange={e => setFeature(e.target.checked)} />} label="Feature" />
       <Button
         type="submit"

--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -37,6 +37,7 @@ function PlanningSetting() {
   const [tasks, setTasks] = useState([]);
   const [milestones, setMilestones] = useState([]);
   const [phases, setPhases] = useState([]);
+  const [members, setMembers] = useState([]);
   const [viewMode, setViewMode] = useState(ViewMode.Day);
   const [dialog, setDialog] = useState('');
 
@@ -50,22 +51,40 @@ function PlanningSetting() {
   useEffect(() => {
     if (!project) return;
     const pid = project._id || project.id;
-    api.get('/api/v1/planning/phases', { params: { project: pid } }).then(res => setPhases(res.data));
-    api.get('/api/v1/planning/tasks', { params: { project: pid } }).then(res => setTasks(res.data));
-    api.get('/api/v1/planning/milestones', { params: { project: pid } }).then(res => setMilestones(res.data));
+    Promise.all([
+      api.get('/api/v1/planning/phases', { params: { project: pid } }),
+      api.get('/api/v1/planning/tasks', { params: { project: pid } }),
+      api.get('/api/v1/planning/milestones', { params: { project: pid } }),
+      api.get(`/api/v1/projects/${pid}`),
+      api.get('/api/v1/resources'),
+    ]).then(([ph, t, m, proj, res]) => {
+      setPhases(ph.data);
+      setTasks(t.data);
+      setMilestones(m.data);
+      const memIds = proj.data.members || [];
+      const leadId = proj.data.lead?._id;
+      const list = res.data.filter(u => memIds.includes(u.id) || u.id === leadId);
+      setMembers(list);
+    });
   }, [project]);
 
   const refreshAll = async () => {
     if (!project) return;
     const pid = project._id || project.id;
-    const [p, t, m] = await Promise.all([
+    const [p, t, m, proj, res] = await Promise.all([
       api.get('/api/v1/planning/phases', { params: { project: pid } }),
       api.get('/api/v1/planning/tasks', { params: { project: pid } }),
       api.get('/api/v1/planning/milestones', { params: { project: pid } }),
+      api.get(`/api/v1/projects/${pid}`),
+      api.get('/api/v1/resources'),
     ]);
     setPhases(p.data);
     setTasks(t.data);
     setMilestones(m.data);
+    const memIds = proj.data.members || [];
+    const leadId = proj.data.lead?._id;
+    const list = res.data.filter(u => memIds.includes(u.id) || u.id === leadId);
+    setMembers(list);
   };
 
   const handleCreateTask = async data => {
@@ -172,6 +191,7 @@ function PlanningSetting() {
                     }, width: 120 },
                     { field: 'owner', headerName: 'Owner', width: 120 },
                     { field: 'manday', headerName: 'Manday', width: 100, type: 'number' },
+                    { field: 'duration', headerName: 'Duration', width: 100, type: 'number' },
                     { field: 'blockedBy', headerName: 'Blocked By', width: 120 },
                     { field: 'isFeature', headerName: 'Feature', width: 80, type: 'boolean' },
                   ]}
@@ -248,13 +268,15 @@ function PlanningSetting() {
                       ))}
                     </TreeView>
                   </Grid>
-                  <Grid item xs={8}>
+                  <Grid item xs={8} sx={{ overflowX: 'auto' }}>
                     {ganttTasks.length > 0 ? (
-                      <Gantt
-                        tasks={ganttTasks}
-                        viewMode={viewMode}
-                        onDateChange={handleDateChange}
-                      />
+                      <Box sx={{ minWidth: 600 }}>
+                        <Gantt
+                          tasks={ganttTasks}
+                          viewMode={viewMode}
+                          onDateChange={handleDateChange}
+                        />
+                      </Box>
                     ) : (
                       <Typography variant="body2" align="center">
                         No schedule data
@@ -268,7 +290,7 @@ function PlanningSetting() {
             </Grid>
           )}
         <Popup open={dialog === 'task'} onClose={() => setDialog('')} title="Add Task/Feature">
-          <TaskForm onSubmit={handleCreateTask} />
+          <TaskForm onSubmit={handleCreateTask} members={members} tasks={tasks} milestones={milestones} />
         </Popup>
         <Popup open={dialog === 'milestone'} onClose={() => setDialog('')} title="Add Milestone">
           <MilestoneForm onSubmit={handleCreateMilestone} existingDates={milestoneDates} />

--- a/service/src/planning/data/task.schema.ts
+++ b/service/src/planning/data/task.schema.ts
@@ -31,6 +31,9 @@ export class Task extends Document {
   @Prop()
   manday?: number;
 
+  @Prop()
+  duration?: number;
+
   @Prop({ type: Types.ObjectId, ref: Task.name })
   blockedBy?: Types.ObjectId;
 }

--- a/service/src/planning/data/tasks.repository.ts
+++ b/service/src/planning/data/tasks.repository.ts
@@ -43,6 +43,10 @@ export class CreateTaskInput {
   manday?: number;
 
   @IsOptional()
+  @IsNumber()
+  duration?: number;
+
+  @IsOptional()
   @Type(() => String)
   @IsString()
   blockedBy?: Types.ObjectId;
@@ -81,6 +85,10 @@ export class UpdateTaskInput {
   @IsOptional()
   @IsNumber()
   manday?: number;
+
+  @IsOptional()
+  @IsNumber()
+  duration?: number;
 
   @IsOptional()
   @Type(() => String)


### PR DESCRIPTION
## Summary
- add `duration` field to planning tasks
- allow task form to pick owners from project members
- support setting start date after selected blocking task/milestone
- make schedule horizontally scrollable

## Testing
- `npm test --prefix service`
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_685c234c48388328b750205e008962fd