### PR TITLE
Add duration and member selections for planning tasks

### DIFF
--- a/client/components/TaskForm.tsx
+++ b/client/components/TaskForm.tsx
@@ -4,17 +4,33 @@ import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Checkbox from '@mui/material/Checkbox';
+import Autocomplete from '@mui/material/Autocomplete';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { addDays } from 'date-fns';
 
-export default function TaskForm({ onSubmit, initial }) {
+export default function TaskForm({ onSubmit, initial, members = [], tasks = [], milestones = [] }) {
   const [name, setName] = useState(initial?.name || '');
   const [detail, setDetail] = useState(initial?.detail || '');
   const [startDate, setStartDate] = useState(initial?.startDate || null);
   const [endDate, setEndDate] = useState(initial?.endDate || null);
   const [owner, setOwner] = useState(initial?.owner || '');
   const [manday, setManday] = useState(initial?.manday != null ? String(initial.manday) : '');
+  const [duration, setDuration] = useState(initial?.duration != null ? String(initial.duration) : '');
   const [blockedBy, setBlockedBy] = useState(initial?.blockedBy || '');
   const [feature, setFeature] = useState(initial?.isFeature || false);
+
+  const blockOptions = [
+    ...tasks.map(t => ({
+      id: t._id || t.id,
+      label: t.name,
+      end: t.endDate ? new Date(t.endDate) : null,
+    })),
+    ...milestones.map(m => ({
+      id: m._id || m.id,
+      label: m.name,
+      end: m.date ? new Date(m.date) : null,
+    })),
+  ];
 
   useEffect(() => {
     setName(initial?.name || '');
@@ -23,9 +39,26 @@ export default function TaskForm({ onSubmit, initial }) {
     setEndDate(initial?.endDate || null);
     setOwner(initial?.owner || '');
     setManday(initial?.manday != null ? String(initial.manday) : '');
+    setDuration(initial?.duration != null ? String(initial.duration) : '');
     setBlockedBy(initial?.blockedBy || '');
     setFeature(initial?.isFeature || false);
   }, [initial]);
+
+  useEffect(() => {
+    if (startDate && duration) {
+      const d = addDays(new Date(startDate), Number(duration) - 1);
+      setEndDate(d);
+    }
+  }, [startDate, duration]);
+
+  useEffect(() => {
+    if (!blockedBy) return;
+    const opt = blockOptions.find(o => String(o.id) === String(blockedBy));
+    if (opt && opt.end) {
+      const next = addDays(opt.end, 1);
+      setStartDate(next);
+    }
+  }, [blockedBy, blockOptions]);
 
   const dateError = useMemo(
     () =>
@@ -51,6 +84,7 @@ export default function TaskForm({ onSubmit, initial }) {
         detail,
         startDate,
         endDate,
+        duration: duration ? Number(duration) : undefined,
         owner,
         manday: manday ? Number(manday) : undefined,
         blockedBy: blockedBy || undefined,
@@ -62,6 +96,7 @@ export default function TaskForm({ onSubmit, initial }) {
     setEndDate(null);
     setOwner('');
     setManday('');
+    setDuration('');
     setBlockedBy('');
     setFeature(false);
   };
@@ -77,6 +112,14 @@ export default function TaskForm({ onSubmit, initial }) {
         sx={{ mb: 2 }}
         slotProps={{ textField: { error: dateError } }}
       />
+      <TextField
+        label="Duration (days)"
+        type="number"
+        value={duration}
+        onChange={e => setDuration(e.target.value)}
+        fullWidth
+        sx={{ mb: 2 }}
+      />
       <DatePicker
         label="End Date"
         value={endDate}
@@ -89,9 +132,25 @@ export default function TaskForm({ onSubmit, initial }) {
           },
         }}
       />
-      <TextField label="Owner" value={owner} onChange={e => setOwner(e.target.value)} fullWidth sx={{ mb: 2 }} />
+      <Autocomplete
+        options={members}
+        getOptionLabel={o => o.name}
+        value={members.find(m => m.name === owner) || null}
+        onChange={(_, v) => setOwner(v ? v.name : '')}
+        renderInput={params => <TextField {...params} label="Owner" />}
+        sx={{ mb: 2 }}
+        fullWidth
+      />
       <TextField label="Manday" type="number" value={manday} onChange={e => setManday(e.target.value)} fullWidth sx={{ mb: 2 }} />
-      <TextField label="Blocked By" value={blockedBy} onChange={e => setBlockedBy(e.target.value)} fullWidth sx={{ mb: 2 }} />
+      <Autocomplete
+        options={blockOptions}
+        getOptionLabel={o => o.label}
+        value={blockOptions.find(o => String(o.id) === String(blockedBy)) || null}
+        onChange={(_, v) => setBlockedBy(v ? v.id : '')}
+        renderInput={params => <TextField {...params} label="Blocked By" />}
+        sx={{ mb: 2 }}
+        fullWidth
+      />
       <FormControlLabel control={<Checkbox checked={feature} onChange={e => setFeature(e.target.checked)} />} label="Feature" />
       <Button
         type="submit"

--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -37,6 +37,7 @@ function PlanningSetting() {
   const [tasks, setTasks] = useState([]);
   const [milestones, setMilestones] = useState([]);
   const [phases, setPhases] = useState([]);
+  const [projectMembers, setProjectMembers] = useState([]);
   const [viewMode, setViewMode] = useState(ViewMode.Day);
   const [dialog, setDialog] = useState('');
 
@@ -50,22 +51,36 @@ function PlanningSetting() {
   useEffect(() => {
     if (!project) return;
     const pid = project._id || project.id;
-    api.get('/api/v1/planning/phases', { params: { project: pid } }).then(res => setPhases(res.data));
-    api.get('/api/v1/planning/tasks', { params: { project: pid } }).then(res => setTasks(res.data));
-    api.get('/api/v1/planning/milestones', { params: { project: pid } }).then(res => setMilestones(res.data));
+    Promise.all([
+      api.get('/api/v1/planning/phases', { params: { project: pid } }),
+      api.get('/api/v1/planning/tasks', { params: { project: pid } }),
+      api.get('/api/v1/planning/milestones', { params: { project: pid } }),
+      api.get(`/api/v1/projects/${pid}`),
+      api.get('/api/v1/resources'),
+    ]).then(([ph, t, m, prj, res]) => {
+      setPhases(ph.data);
+      setTasks(t.data);
+      setMilestones(m.data);
+      const ids = [...(prj.data.members || []), prj.data.lead?._id].filter(Boolean);
+      setProjectMembers(res.data.filter(r => ids.includes(r.id)));
+    });
   }, [project]);
 
   const refreshAll = async () => {
     if (!project) return;
     const pid = project._id || project.id;
-    const [p, t, m] = await Promise.all([
+    const [p, t, m, prj, res] = await Promise.all([
       api.get('/api/v1/planning/phases', { params: { project: pid } }),
       api.get('/api/v1/planning/tasks', { params: { project: pid } }),
       api.get('/api/v1/planning/milestones', { params: { project: pid } }),
+      api.get(`/api/v1/projects/${pid}`),
+      api.get('/api/v1/resources'),
     ]);
     setPhases(p.data);
     setTasks(t.data);
     setMilestones(m.data);
+    const ids = [...(prj.data.members || []), prj.data.lead?._id].filter(Boolean);
+    setProjectMembers(res.data.filter(r => ids.includes(r.id)));
   };
 
   const handleCreateTask = async data => {
@@ -170,6 +185,7 @@ function PlanningSetting() {
                       const value = params?.value;
                       return value ? new Date(value).toLocaleDateString() : '';
                     }, width: 120 },
+                    { field: 'duration', headerName: 'Duration', width: 90, type: 'number' },
                     { field: 'owner', headerName: 'Owner', width: 120 },
                     { field: 'manday', headerName: 'Manday', width: 100, type: 'number' },
                     { field: 'blockedBy', headerName: 'Blocked By', width: 120 },
@@ -250,11 +266,13 @@ function PlanningSetting() {
                   </Grid>
                   <Grid item xs={8}>
                     {ganttTasks.length > 0 ? (
-                      <Gantt
-                        tasks={ganttTasks}
-                        viewMode={viewMode}
-                        onDateChange={handleDateChange}
-                      />
+                      <Box sx={{ overflowX: 'auto' }}>
+                        <Gantt
+                          tasks={ganttTasks}
+                          viewMode={viewMode}
+                          onDateChange={handleDateChange}
+                        />
+                      </Box>
                     ) : (
                       <Typography variant="body2" align="center">
                         No schedule data
@@ -268,7 +286,7 @@ function PlanningSetting() {
             </Grid>
           )}
         <Popup open={dialog === 'task'} onClose={() => setDialog('')} title="Add Task/Feature">
-          <TaskForm onSubmit={handleCreateTask} />
+          <TaskForm onSubmit={handleCreateTask} members={projectMembers} tasks={tasks} milestones={milestones} />
         </Popup>
         <Popup open={dialog === 'milestone'} onClose={() => setDialog('')} title="Add Milestone">
           <MilestoneForm onSubmit={handleCreateMilestone} existingDates={milestoneDates} />

--- a/service/src/planning/data/task.schema.ts
+++ b/service/src/planning/data/task.schema.ts
@@ -31,6 +31,9 @@ export class Task extends Document {
   @Prop()
   manday?: number;
 
+  @Prop()
+  duration?: number;
+
   @Prop({ type: Types.ObjectId, ref: Task.name })
   blockedBy?: Types.ObjectId;
 }

--- a/service/src/planning/data/tasks.repository.ts
+++ b/service/src/planning/data/tasks.repository.ts
@@ -43,6 +43,10 @@ export class CreateTaskInput {
   manday?: number;
 
   @IsOptional()
+  @IsNumber()
+  duration?: number;
+
+  @IsOptional()
   @Type(() => String)
   @IsString()
   blockedBy?: Types.ObjectId;
@@ -81,6 +85,10 @@ export class UpdateTaskInput {
   @IsOptional()
   @IsNumber()
   manday?: number;
+
+  @IsOptional()
+  @IsNumber()
+  duration?: number;
 
   @IsOptional()
   @Type(() => String)


### PR DESCRIPTION
## Summary
- add task duration to server schema and repository
- update task form with duration field, project member owner autocomplete and block dependencies
- fetch project members for planning settings
- show duration in tasks grid and wrap schedule chart for horizontal scroll

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685c229b454c83288564597af28bd9dc