### PR TITLE
Add task type selection

### DIFF
--- a/client/components/TaskForm.tsx
+++ b/client/components/TaskForm.tsx
@@ -3,8 +3,8 @@ import { useState, useEffect, useMemo } from 'react';
 import Autocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Checkbox from '@mui/material/Checkbox';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { addDays } from 'date-fns';
 
@@ -17,7 +17,9 @@ export default function TaskForm({ onSubmit, initial, members = [], tasks = [], 
   const [manday, setManday] = useState(initial?.manday != null ? String(initial.manday) : '');
   const [duration, setDuration] = useState(initial?.duration != null ? String(initial.duration) : '');
   const [blocked, setBlocked] = useState(null);
-  const [feature, setFeature] = useState(initial?.isFeature || false);
+  const [taskType, setTaskType] = useState(
+    initial?.type || (initial?.isFeature ? 'feature' : 'milestone')
+  );
 
   useEffect(() => {
     setName(initial?.name || '');
@@ -28,7 +30,7 @@ export default function TaskForm({ onSubmit, initial, members = [], tasks = [], 
     setManday(initial?.manday != null ? String(initial.manday) : '');
     setDuration(initial?.duration != null ? String(initial.duration) : '');
     setBlocked(null);
-    setFeature(initial?.isFeature || false);
+    setTaskType(initial?.type || (initial?.isFeature ? 'feature' : 'milestone'));
   }, [initial]);
 
   const dateError = useMemo(
@@ -75,7 +77,7 @@ export default function TaskForm({ onSubmit, initial, members = [], tasks = [], 
         manday: manday ? Number(manday) : undefined,
         duration: duration ? Number(duration) : undefined,
         blockedBy: blocked ? blocked.id : undefined,
-        ...(feature ? { isFeature: true } : {}),
+        type: taskType,
       });
     setName('');
     setDetail('');
@@ -85,7 +87,7 @@ export default function TaskForm({ onSubmit, initial, members = [], tasks = [], 
     setManday('');
     setDuration('');
     setBlocked(null);
-    setFeature(false);
+    setTaskType('feature');
   };
 
   return (
@@ -130,7 +132,16 @@ export default function TaskForm({ onSubmit, initial, members = [], tasks = [], 
         renderInput={params => <TextField {...params} label="Blocked By" />}
         sx={{ mb: 2 }}
       />
-      <FormControlLabel control={<Checkbox checked={feature} onChange={e => setFeature(e.target.checked)} />} label="Feature" />
+      <ToggleButtonGroup
+        value={taskType}
+        exclusive
+        onChange={(_, v) => v && setTaskType(v)}
+        size="small"
+        sx={{ mb: 2 }}
+      >
+        <ToggleButton value="feature">Feature</ToggleButton>
+        <ToggleButton value="milestone">Milestone</ToggleButton>
+      </ToggleButtonGroup>
       <Button
         type="submit"
         variant="contained"

--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -172,7 +172,7 @@ function PlanningSetting() {
           <Grid container spacing={2}>
             <Grid item xs={12} md={6}>
               <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-                <Typography variant="h6">Tasks / Features</Typography>
+                <Typography variant="h6">Tasks</Typography>
                 <Button variant="contained" onClick={() => setDialog('task')}>Add</Button>
               </Box>
               <Paper sx={{ p: 2 }}>
@@ -193,7 +193,7 @@ function PlanningSetting() {
                     { field: 'manday', headerName: 'Manday', width: 100, type: 'number' },
                     { field: 'duration', headerName: 'Duration', width: 100, type: 'number' },
                     { field: 'blockedBy', headerName: 'Blocked By', width: 120 },
-                    { field: 'isFeature', headerName: 'Feature', width: 80, type: 'boolean' },
+                    { field: 'type', headerName: 'Type', width: 120 },
                   ]}
                   autoHeight
                   hideFooter

--- a/service/src/planning/data/task.schema.ts
+++ b/service/src/planning/data/task.schema.ts
@@ -13,6 +13,9 @@ export class Task extends Document {
   @Prop({ required: true })
   name: string;
 
+  @Prop({ enum: ['feature', 'milestone'], default: 'feature' })
+  type: string;
+
   @Prop({ default: false })
   isFeature: boolean;
 

--- a/service/src/planning/data/tasks.repository.ts
+++ b/service/src/planning/data/tasks.repository.ts
@@ -19,6 +19,10 @@ export class CreateTaskInput {
   name!: string;
 
   @IsOptional()
+  @IsString()
+  type?: string;
+
+  @IsOptional()
   @IsBoolean()
   isFeature?: boolean;
 
@@ -63,6 +67,10 @@ export class UpdateTaskInput {
   name?: string;
 
   @IsOptional()
+  @IsString()
+  type?: string;
+
+  @IsOptional()
   @IsBoolean()
   isFeature?: boolean;
 
@@ -105,12 +113,19 @@ export class TasksRepository {
   }
 
   create(data: CreateTaskInput): Promise<Task> {
-    const task = new this.model(data);
+    const task = new this.model({
+      ...data,
+      ...(data.type ? { isFeature: data.type === 'feature' } : {}),
+    });
     return task.save();
   }
 
   update(id: string, data: UpdateTaskInput): Promise<Task | null> {
-    return this.model.findByIdAndUpdate(id, data, { new: true }).exec();
+    const payload = {
+      ...data,
+      ...(data.type ? { isFeature: data.type === 'feature' } : {}),
+    };
+    return this.model.findByIdAndUpdate(id, payload, { new: true }).exec();
   }
 
   remove(id: string): Promise<Task | null> {


### PR DESCRIPTION
## Summary
- add `type` column to Task schema
- update task repository to use the new `type`
- allow selecting feature or milestone type when creating a task
- show task type in planning setting

## Testing
- `npm test --prefix service`
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_685c2ad0a1a883289c0c61ce7bbf18cc