### PR TITLE
Fix schedule section overflow

### DIFF
--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -287,9 +287,9 @@ function PlanningSetting() {
                       ))}
                     </TreeView>
                   </Grid>
-                  <Grid item xs={8} sx={{ overflowX: 'auto' }}>
+                  <Grid item xs={8} sx={{ maxHeight: 400, overflow: 'auto' }}>
                     {ganttTasks.length > 0 ? (
-                      <Box sx={{ minWidth: 600 }}>
+                      <Box sx={{ minWidth: 600, width: '100%' }}>
                         <Gantt
                           tasks={ganttTasks}
                           viewMode={viewMode}


### PR DESCRIPTION
## Summary
- allow scrolling in Gantt timeline in Planning Setting page

## Testing
- `npm test --silent` in `service`
- `npm test --silent` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685cb456a35c8328bf9996f05d015123