### PR TITLE
Enable milestone creation from task form

### DIFF
--- a/client/components/TaskForm.tsx
+++ b/client/components/TaskForm.tsx
@@ -67,18 +67,28 @@ export default function TaskForm({ onSubmit, initial, members = [], tasks = [], 
   const handleSubmit = e => {
     e.preventDefault();
     if (!formValid) return;
-    onSubmit &&
-      onSubmit({
-        name,
-        detail,
-        startDate,
-        endDate,
-        owner,
-        manday: manday ? Number(manday) : undefined,
-        duration: duration ? Number(duration) : undefined,
-        blockedBy: blocked ? blocked.id : undefined,
-        type: taskType,
-      });
+    if (taskType === 'milestone') {
+      onSubmit &&
+        onSubmit({
+          name,
+          detail,
+          date: startDate,
+          type: taskType,
+        });
+    } else {
+      onSubmit &&
+        onSubmit({
+          name,
+          detail,
+          startDate,
+          endDate,
+          owner,
+          manday: manday ? Number(manday) : undefined,
+          duration: duration ? Number(duration) : undefined,
+          blockedBy: blocked ? blocked.id : undefined,
+          type: taskType,
+        });
+    }
     setName('');
     setDetail('');
     setStartDate(null);
@@ -94,44 +104,55 @@ export default function TaskForm({ onSubmit, initial, members = [], tasks = [], 
     <form onSubmit={handleSubmit}>
       <TextField label="Name" value={name} onChange={e => setName(e.target.value)} fullWidth required sx={{ mb: 2 }} />
       <TextField label="Detail" value={detail} onChange={e => setDetail(e.target.value)} fullWidth multiline sx={{ mb: 2 }} />
-      <DatePicker
-        label="Start Date"
-        value={startDate}
-        onChange={setStartDate}
-        sx={{ mb: 2 }}
-        slotProps={{ textField: { error: dateError } }}
-      />
-      <DatePicker
-        label="End Date"
-        value={endDate}
-        onChange={setEndDate}
-        sx={{ mb: 2 }}
-        slotProps={{
-          textField: {
-            error: dateError,
-            helperText: dateError ? 'End date must be after start date' : undefined,
-          },
-        }}
-      />
-      <TextField label="Duration (days)" type="number" value={duration} onChange={e => setDuration(e.target.value)} fullWidth sx={{ mb: 2 }} />
-      <Autocomplete
-        options={members}
-        getOptionLabel={o => o.name}
-        value={members.find(m => m.id === owner) || null}
-        onChange={(_, v) => setOwner(v ? v.id : '')}
-        renderInput={params => <TextField {...params} label="Owner" />}
-        sx={{ mb: 2 }}
-      />
-      <TextField label="Manday" type="number" value={manday} onChange={e => setManday(e.target.value)} fullWidth sx={{ mb: 2 }} />
-      <Autocomplete
-        options={[...tasks.map(t => ({ id: t._id || t.id, label: t.name, date: t.endDate })),
-                  ...milestones.map(m => ({ id: m._id || m.id, label: m.name, date: m.date }))]}
-        getOptionLabel={o => o.label}
-        value={blocked}
-        onChange={(_, v) => setBlocked(v)}
-        renderInput={params => <TextField {...params} label="Blocked By" />}
-        sx={{ mb: 2 }}
-      />
+      {taskType === 'milestone' ? (
+        <DatePicker
+          label="Date"
+          value={startDate}
+          onChange={setStartDate}
+          sx={{ mb: 2 }}
+        />
+      ) : (
+        <>
+          <DatePicker
+            label="Start Date"
+            value={startDate}
+            onChange={setStartDate}
+            sx={{ mb: 2 }}
+            slotProps={{ textField: { error: dateError } }}
+          />
+          <DatePicker
+            label="End Date"
+            value={endDate}
+            onChange={setEndDate}
+            sx={{ mb: 2 }}
+            slotProps={{
+              textField: {
+                error: dateError,
+                helperText: dateError ? 'End date must be after start date' : undefined,
+              },
+            }}
+          />
+          <TextField label="Duration (days)" type="number" value={duration} onChange={e => setDuration(e.target.value)} fullWidth sx={{ mb: 2 }} />
+          <Autocomplete
+            options={members}
+            getOptionLabel={o => o.name}
+            value={members.find(m => m.id === owner) || null}
+            onChange={(_, v) => setOwner(v ? v.id : '')}
+            renderInput={params => <TextField {...params} label="Owner" />}
+            sx={{ mb: 2 }}
+          />
+          <TextField label="Manday" type="number" value={manday} onChange={e => setManday(e.target.value)} fullWidth sx={{ mb: 2 }} />
+          <Autocomplete
+            options={[...tasks.map(t => ({ id: t._id || t.id, label: t.name, date: t.endDate })),
+                      ...milestones.map(m => ({ id: m._id || m.id, label: m.name, date: m.date }))]}
+            getOptionLabel={o => o.label}
+            value={blocked}
+            onChange={(_, v) => setBlocked(v)}
+            renderInput={params => <TextField {...params} label="Blocked By" />}
+            sx={{ mb: 2 }}
+          />
+        </>
+      )}
       <ToggleButtonGroup
         value={taskType}
         exclusive

--- a/client/components/index.tsx
+++ b/client/components/index.tsx
@@ -21,4 +21,3 @@ export { default as ConfirmDialog } from './ConfirmDialog';
 export { default as PageBreadcrumbs } from './PageBreadcrumbs';
 export { default as PhaseForm } from './PhaseForm';
 export { default as TaskForm } from './TaskForm';
-export { default as MilestoneForm } from './MilestoneForm';

--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -11,7 +11,6 @@ import { Layout, PageBreadcrumbs, Popup } from '../../components';
 import { withAuth } from '../../context/AuthContext';
 import api from '../../api';
 import TaskForm from '../../components/TaskForm';
-import MilestoneForm from '../../components/MilestoneForm';
 import { DataGrid } from '@mui/x-data-grid';
 import Timeline from '@mui/lab/Timeline';
 import TimelineItem from '@mui/lab/TimelineItem';
@@ -91,13 +90,16 @@ function PlanningSetting() {
   };
 
   const handleCreateTask = async data => {
-    await api.post('/api/v1/planning/tasks', { ...data, project: project._id });
-    await refreshAll();
-    setDialog('');
-  };
-
-  const handleCreateMilestone = async data => {
-    await api.post('/api/v1/planning/milestones', { ...data, project: project._id });
+    if (data.type === 'milestone') {
+      await api.post('/api/v1/planning/milestones', {
+        name: data.name,
+        detail: data.detail,
+        date: data.startDate,
+        project: project._id,
+      });
+    } else {
+      await api.post('/api/v1/planning/tasks', { ...data, project: project._id });
+    }
     await refreshAll();
     setDialog('');
   };
@@ -118,7 +120,6 @@ function PlanningSetting() {
     await refreshAll();
   };
 
-  const milestoneDates = milestones.map(m => new Date(m.date).toDateString());
   const combinedTasks = [
     ...tasks,
     ...milestones.map(m => ({
@@ -195,9 +196,6 @@ function PlanningSetting() {
                 <Box>
                   <Button variant="contained" onClick={() => setDialog('task')} sx={{ mr: 1 }}>
                     Add Task
-                  </Button>
-                  <Button variant="contained" onClick={() => setDialog('milestone')}>
-                    Add Milestone
                   </Button>
                 </Box>
               </Box>
@@ -323,9 +321,6 @@ function PlanningSetting() {
               milestones={milestones}
             />
           )}
-        </Popup>
-        <Popup open={dialog === 'milestone'} onClose={() => setDialog('')} title="Add Milestone">
-          <MilestoneForm onSubmit={handleCreateMilestone} existingDates={milestoneDates} />
         </Popup>
       </Container>
     </Layout>


### PR DESCRIPTION
## Summary
- remove MilestoneForm export
- remove Add Milestone popup and button
- allow TaskForm to submit milestone data and hide task-only fields
- create milestones via `handleCreateTask`

## Testing
- `npm test --silent --prefix client` *(fails: jest not found)*
- `npm test --silent --prefix service` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cc37f319883289c61d7cf18c8dae9