### PR TITLE
Implement project-level calendar view

### DIFF
--- a/client/components/SimpleCalendar.tsx
+++ b/client/components/SimpleCalendar.tsx
@@ -15,7 +15,7 @@ import {
   format
 } from 'date-fns';
 
-export default function SimpleCalendar({ events = [], tasks = [] }) {
+export default function SimpleCalendar({ events = [], tasks = [], onTaskClick }: any) {
   const [currentDate, setCurrentDate] = useState(new Date());
 
   const monthStart = startOfMonth(currentDate);
@@ -97,6 +97,7 @@ export default function SimpleCalendar({ events = [], tasks = [] }) {
               {dayTasks.map(t => (
                 <Box
                   key={t._id || t.id}
+                  onClick={() => onTaskClick && onTaskClick(t)}
                   sx={{
                     mt: 0.5,
                     bgcolor: statusColor(taskStatus(t)),
@@ -106,7 +107,8 @@ export default function SimpleCalendar({ events = [], tasks = [] }) {
                     fontSize: 10,
                     whiteSpace: 'nowrap',
                     overflow: 'hidden',
-                    textOverflow: 'ellipsis'
+                    textOverflow: 'ellipsis',
+                    cursor: onTaskClick ? 'pointer' : 'default'
                   }}
                 >
                   {t.name}

--- a/client/pages/plan-management/index.tsx
+++ b/client/pages/plan-management/index.tsx
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
 import ToggleButton from '@mui/material/ToggleButton';
@@ -8,7 +9,6 @@ import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import { fetchEvents } from '../../models/eventsModel';
 import { fetchProjects } from '../../models/projectsModel';
-import { fetchTasks } from '../../models/tasksModel';
 import Timeline from '@mui/lab/Timeline';
 import TimelineItem from '@mui/lab/TimelineItem';
 import TimelineSeparator from '@mui/lab/TimelineSeparator';
@@ -22,18 +22,14 @@ function PlanManagementOverview() {
   const [view, setView] = useState('calendar');
   const [events, setEvents] = useState([]);
   const [projects, setProjects] = useState([]);
-  const [tasks, setTasks] = useState([]);
+  const router = useRouter();
 
   useEffect(() => {
     Promise.all([fetchEvents(), fetchProjects()])
-      .then(async ([ev, pro]) => {
+      .then(([ev, pro]) => {
         setEvents(ev);
         const list = pro.filter(p => !p.deleted);
         setProjects(list);
-        const taskLists = await Promise.all(
-          list.map(p => fetchTasks(p._id || p.id))
-        );
-        setTasks(taskLists.flat());
       })
       .catch(console.error);
   }, []);
@@ -63,7 +59,20 @@ function PlanManagementOverview() {
             </ToggleButtonGroup>
           </Box>
           {view === 'calendar' ? (
-            <SimpleCalendar events={events} tasks={tasks} />
+            <SimpleCalendar
+              events={events}
+              tasks={projects.map(p => ({
+                ...p,
+                name: p.name,
+                startDate: p.start,
+                endDate: p.end,
+              }))}
+              onTaskClick={p =>
+                router.push(
+                  `/plan-management/planning-setting?project=${p._id || p.id}`,
+                )
+              }
+            />
           ) : (
             <Timeline>
               {projects.map((p, idx) => (

--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
@@ -33,6 +34,7 @@ import {
 import 'gantt-task-react/dist/index.css';
 
 function PlanningSetting() {
+  const router = useRouter();
   const [projects, setProjects] = useState([]);
   const [project, setProject] = useState(null);
   const [tasks, setTasks] = useState([]);
@@ -44,11 +46,20 @@ function PlanningSetting() {
   const [editTask, setEditTask] = useState(null);
 
   useEffect(() => {
+    if (!router.isReady) return;
     api
       .get('/api/v1/projects')
-      .then(res => setProjects(res.data.filter(p => !p.deleted)))
+      .then(res => {
+        const list = res.data.filter(p => !p.deleted);
+        setProjects(list);
+        const pid = router.query.project;
+        if (pid) {
+          const p = list.find(pr => String(pr._id || pr.id) === pid);
+          if (p) setProject(p);
+        }
+      })
       .catch(console.error);
-  }, []);
+  }, [router.isReady, router.query.project]);
 
   useEffect(() => {
     if (!project) return;


### PR DESCRIPTION
## Summary
- enable clicking tasks in `SimpleCalendar`
- show projects on overview calendar
- open planning setting with project pre-selected

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685cd0f36c288328a17d33baea7237ad