### PR TITLE
Add sprint start and duration fields

### DIFF
--- a/client/components/ProjectForm.tsx
+++ b/client/components/ProjectForm.tsx
@@ -14,6 +14,7 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import MenuItem from '@mui/material/MenuItem';
 
 export default function ProjectForm({
   users = [],
@@ -35,19 +36,21 @@ export default function ProjectForm({
   const [manday, setManday] = useState(
     initial?.manday != null ? String(initial.manday) : ''
   );
+  const [sprintStart, setSprintStart] = useState(initial?.sprintStart || null);
   const [sprintLength, setSprintLength] = useState(
-    initial?.sprintLength != null ? String(initial.sprintLength) : ''
+    initial?.sprintLength != null ? String(initial.sprintLength / 7) : ''
   );
 
   useEffect(() => {
     setName(initial?.name || '');
     setDescription(initial?.description || '');
     setStart(initial?.start || null);
+    setSprintStart(initial?.sprintStart || null);
     setLead(initial?.lead || null);
     setMembers(initial?.members || []);
     setManday(initial?.manday != null ? String(initial.manday) : '');
     setSprintLength(
-      initial?.sprintLength != null ? String(initial.sprintLength) : ''
+      initial?.sprintLength != null ? String(initial.sprintLength / 7) : ''
     );
     setStatus(initial?.status || 'planing');
   }, [initial]);
@@ -56,6 +59,7 @@ export default function ProjectForm({
     if (!open) {
       setActive(0);
       setSprintLength('');
+      setSprintStart(null);
     }
   }, [open]);
 
@@ -70,10 +74,11 @@ export default function ProjectForm({
         name,
         description,
         start,
+        sprintStart,
         end: start,
         status,
         ...(manday ? { manday: Number(manday) } : {}),
-        ...(sprintLength ? { sprintLength: Number(sprintLength) } : {}),
+        ...(sprintLength ? { sprintLength: Number(sprintLength) * 7 } : {}),
         priority: 1,
         lead: lead?.id,
         members: members.map(m => m.id),
@@ -86,6 +91,7 @@ export default function ProjectForm({
     setMembers([]);
     setManday('');
     setSprintLength('');
+    setSprintStart(null);
     setStatus('planing');
     setActive(0);
     setTeam(null);
@@ -228,13 +234,27 @@ export default function ProjectForm({
       )}
 
       {active === 2 && (
-        <TextField
-          label="Sprint Length (days)"
-          type="number"
-          value={sprintLength}
-          onChange={e => setSprintLength(e.target.value)}
-          sx={{ gridColumn: 'span 2' }}
-        />
+        <>
+          <DatePicker
+            label="Sprint Start"
+            value={sprintStart}
+            onChange={setSprintStart}
+            slotProps={{ textField: { required: true } }}
+          />
+          <TextField
+            select
+            label="Sprint Duration (weeks)"
+            value={sprintLength}
+            onChange={e => setSprintLength(e.target.value)}
+            sx={{ gridColumn: 'span 2' }}
+          >
+            {[1, 2, 3, 4, 5, 6, 7, 8].map(w => (
+              <MenuItem key={w} value={String(w)}>
+                {w}
+              </MenuItem>
+            ))}
+          </TextField>
+        </>
       )}
 
       {active === 3 && (
@@ -257,7 +277,11 @@ export default function ProjectForm({
             <strong>Manday:</strong> {manday}
           </Typography>
           <Typography>
-            <strong>Sprint Length:</strong> {sprintLength}
+            <strong>Sprint Start:</strong>{' '}
+            {sprintStart ? new Date(sprintStart).toLocaleDateString() : ''}
+          </Typography>
+          <Typography>
+            <strong>Sprint Duration:</strong> {sprintLength} week(s)
           </Typography>
           <Typography>
             <strong>Status:</strong> {status}

--- a/client/pages/project/[id].tsx
+++ b/client/pages/project/[id].tsx
@@ -272,10 +272,12 @@ function ProjectDetail() {
                 name: project.name,
                 description: project.description,
                 start: project.start ? new Date(project.start) : null,
+                sprintStart: project.sprintStart ? new Date(project.sprintStart) : null,
                 status: project.status || 'planing',
                 lead: leadResource || null,
                 members,
-                manday: project.manday ?? ''
+                manday: project.manday ?? '',
+                sprintLength: project.sprintLength ? project.sprintLength / 7 : ''
               }}
               submitText="Save"
             />

--- a/service/src/projects/data/project.schema.ts
+++ b/service/src/projects/data/project.schema.ts
@@ -22,6 +22,9 @@ export class Project extends Document {
   manday: number;
 
   @Prop()
+  sprintStart: Date;
+
+  @Prop()
   sprintLength: number;
 
   @Prop({ required: true })

--- a/service/src/projects/data/projects.repository.ts
+++ b/service/src/projects/data/projects.repository.ts
@@ -20,6 +20,11 @@ export class CreateProjectInput {
   @IsDate()
   start!: Date;
 
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  sprintStart?: Date;
+
   @Type(() => Date)
   @IsDate()
   end!: Date;
@@ -74,6 +79,11 @@ export class UpdateProjectInput {
   @Type(() => Date)
   @IsDate()
   start?: Date;
+
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  sprintStart?: Date;
 
   @IsOptional()
   @Type(() => Date)


### PR DESCRIPTION
## Summary
- allow specifying the start of a sprint and duration in weeks
- store `sprintStart` in project schema and repository
- show sprint start and duration in project forms

## Testing
- `npm --prefix client test`
- `npm --prefix service test`
- `npm --prefix client run check`
- `npm --prefix service run check`


------
https://chatgpt.com/codex/tasks/task_e_685cd4f0c43c8328a12b86bb735beb2a