### PR TITLE
Add agenda calendar

### DIFF
--- a/client/components/AgendaCalendar.tsx
+++ b/client/components/AgendaCalendar.tsx
@@ -1,0 +1,96 @@
+import { useMemo } from 'react';
+import { Calendar, dateFnsLocalizer } from 'react-big-calendar';
+import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import { DndProvider } from 'react-dnd';
+import { format, parse, startOfWeek, getDay } from 'date-fns';
+import Avatar from '@mui/material/Avatar';
+import Box from '@mui/material/Box';
+import 'react-big-calendar/lib/css/react-big-calendar.css';
+import 'react-big-calendar/lib/addons/dragAndDrop/styles.css';
+
+const locales = {
+  'en-US': require('date-fns/locale/en-US'),
+};
+
+const localizer = dateFnsLocalizer({
+  format,
+  parse,
+  startOfWeek: () => startOfWeek(new Date(), { weekStartsOn: 1 }),
+  getDay,
+  locales,
+});
+
+const DnDCalendar = withDragAndDrop(Calendar);
+
+function stringToColor(name: string) {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const h = hash % 360;
+  return `hsl(${h},70%,60%)`;
+}
+
+export default function AgendaCalendar({ tasks = [], onEventDrop }: any) {
+  const events = useMemo(
+    () =>
+      tasks.map((t: any) => ({
+        title: t.name,
+        start: new Date(t.startDate),
+        end: new Date(t.endDate || t.startDate),
+        allDay: true,
+        resource: t,
+      })),
+    [tasks],
+  );
+
+  const Event = ({ event }: any) => {
+    const t = event.resource;
+    const owner = t.owner || '';
+    const initials = owner
+      .split(' ')
+      .map((s: string) => s[0])
+      .join('')
+      .slice(0, 2)
+      .toUpperCase();
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+        <Avatar sx={{ width: 18, height: 18, bgcolor: stringToColor(owner), mr: 0.5 }}>
+          <Box component="span" sx={{ fontSize: 10 }}>
+            {initials}
+          </Box>
+        </Avatar>
+        <Box component="span" sx={{ fontSize: 12, mr: 0.5 }}>
+          {event.title}
+        </Box>
+        <Box
+          component="span"
+          sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: stringToColor(t.status || 'none') }}
+        />
+      </Box>
+    );
+  };
+
+  const eventPropGetter = (event: any) => {
+    const color = stringToColor(event.resource.status || 'none');
+    return { style: { backgroundColor: color, borderRadius: 4, border: 'none' } };
+  };
+
+  return (
+    <DndProvider backend={HTML5Backend}>
+      <DnDCalendar
+        localizer={localizer}
+        events={events}
+        defaultView="month"
+        views={["month", "week", "day"]}
+        style={{ height: 600 }}
+        eventPropGetter={eventPropGetter}
+        components={{ event: Event }}
+        onEventDrop={({ event, start, end }) => onEventDrop && onEventDrop(event.resource, start, end)}
+        resizable
+        onEventResize={({ event, start, end }) => onEventDrop && onEventDrop(event.resource, start, end)}
+      />
+    </DndProvider>
+  );
+}

--- a/client/components/index.tsx
+++ b/client/components/index.tsx
@@ -10,6 +10,7 @@ export { default as Sidebar } from './Sidebar';
 export { default as Layout } from './Layout';
 export { default as ResourceForm } from './ResourceForm';
 export { default as SimpleCalendar } from './SimpleCalendar';
+export { default as AgendaCalendar } from './AgendaCalendar';
 export { default as TeamForm } from './TeamForm';
 export { default as ProjectForm } from './ProjectForm';
 export { default as BudgetForm } from './BudgetForm';

--- a/client/models/projectsModel.ts
+++ b/client/models/projectsModel.ts
@@ -4,3 +4,8 @@ export async function fetchProjects() {
   const { data } = await api.get('/api/v1/projects');
   return data;
 }
+
+export async function updateProject(id: string, project: any) {
+  const { data } = await api.patch(`/api/v1/projects/${id}`, project);
+  return data;
+}

--- a/client/package.json
+++ b/client/package.json
@@ -25,6 +25,9 @@
     "gantt-task-react": "^0.3.9",
     "next": "15.3.4",
     "react": "^18.0.0",
+    "react-big-calendar": "^1.11.3",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^18.0.0",
     "sass": "^1.73.0"
   },

--- a/client/pages/plan-management/index.tsx
+++ b/client/pages/plan-management/index.tsx
@@ -8,7 +8,7 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import { fetchEvents } from '../../models/eventsModel';
-import { fetchProjects } from '../../models/projectsModel';
+import { fetchProjects, updateProject } from '../../models/projectsModel';
 import { fetchTasks } from '../../models/tasksModel';
 import { fetchWorkdays } from '../../models/workdayModel';
 import Timeline from '@mui/lab/Timeline';
@@ -17,7 +17,7 @@ import TimelineSeparator from '@mui/lab/TimelineSeparator';
 import TimelineConnector from '@mui/lab/TimelineConnector';
 import TimelineContent from '@mui/lab/TimelineContent';
 import TimelineDot from '@mui/lab/TimelineDot';
-import { Layout, SimpleCalendar, PageBreadcrumbs } from '../../components';
+import { Layout, AgendaCalendar, PageBreadcrumbs } from '../../components';
 import { withAuth } from '../../context/AuthContext';
 
 function PlanManagementOverview() {
@@ -80,20 +80,21 @@ function PlanManagementOverview() {
             </ToggleButtonGroup>
           </Box>
           {view === 'calendar' ? (
-            <SimpleCalendar
-              events={events}
-              holidays={holidays}
+            <AgendaCalendar
               tasks={projects.map(p => ({
                 ...p,
                 name: p.name,
                 startDate: p.start,
                 endDate: p.end,
+                owner: p.lead?.name || '',
+                status: p.status,
               }))}
-              onTaskClick={p =>
-                router.push(
-                  `/plan-management/planning-setting?project=${p._id || p.id}`,
-                )
-              }
+              onEventDrop={(proj, start, end) => {
+                updateProject(proj._id || proj.id, {
+                  start,
+                  end,
+                }).catch(console.error);
+              }}
             />
           ) : (
             <Timeline>


### PR DESCRIPTION
## Summary
- implement `AgendaCalendar` with drag and drop using react-big-calendar
- expose `updateProject` model method
- switch plan management overview to use new agenda calendar
- export the component and update dependencies

## Testing
- `npm test` *(fails: Cannot find module `@jest/core`)*
- `npm run check` *(fails: Cannot find module `caniuse-lite/dist/unpacker/agents`)*
- `npm test` in `service` passed
- `npm run check` in `service`

------
https://chatgpt.com/codex/tasks/task_e_685d15583c648328865a04a55c70af87