### PR TITLE
Enable navigation to project details from plan overview

### DIFF
--- a/client/components/AgendaCalendar.tsx
+++ b/client/components/AgendaCalendar.tsx
@@ -32,7 +32,13 @@ function stringToColor(name: string) {
   return `hsl(${h},70%,60%)`;
 }
 
-export default function AgendaCalendar({ tasks = [], events = [], holidays = [], onEventDrop }: any) {
+export default function AgendaCalendar({
+  tasks = [],
+  events = [],
+  holidays = [],
+  onEventDrop,
+  onTaskClick,
+}: any) {
   const taskEvents = useMemo(
     () =>
       tasks.map((t: any) => ({
@@ -148,6 +154,9 @@ export default function AgendaCalendar({ tasks = [], events = [], holidays = [],
         eventPropGetter={eventPropGetter}
         dayPropGetter={dayPropGetter}
         components={{ event: Event }}
+        onSelectEvent={event =>
+          onTaskClick && event.resource?.type === 'task' && onTaskClick(event.resource)
+        }
         onEventDrop={({ event, start, end }) => onEventDrop && onEventDrop(event.resource, start, end)}
         resizable
         onEventResize={({ event, start, end }) => onEventDrop && onEventDrop(event.resource, start, end)}

--- a/client/pages/plan-management/index.tsx
+++ b/client/pages/plan-management/index.tsx
@@ -91,6 +91,7 @@ function PlanManagementOverview() {
               }))}
               events={events}
               holidays={holidays}
+              onTaskClick={proj => router.push(`/project/${proj._id || proj.id}`)}
               onEventDrop={(proj, start, end) => {
                 updateProject(proj._id || proj.id, {
                   start,
@@ -106,7 +107,10 @@ function PlanManagementOverview() {
                     <TimelineDot />
                     {idx < projects.length - 1 && <TimelineConnector />}
                   </TimelineSeparator>
-                  <TimelineContent>
+                  <TimelineContent
+                    onClick={() => router.push(`/project/${p._id || p.id}`)}
+                    sx={{ cursor: 'pointer' }}
+                  >
                     {p.name} ({new Date(p.start).toLocaleDateString()} - {new Date(p.end).toLocaleDateString()})
                   </TimelineContent>
                 </TimelineItem>


### PR DESCRIPTION
## Summary
- allow AgendaCalendar items to be clicked
- open project detail page from Plan Management overview
- make timeline items clickable

## Testing
- `npm test --silent` in `client`
- `npm test --silent` in `service`


------
https://chatgpt.com/codex/tasks/task_e_685d2bbdf51c83289193a8efeab73873