### PR TITLE
Update calendar route to open planning settings

### DIFF
--- a/client/pages/plan-management/index.tsx
+++ b/client/pages/plan-management/index.tsx
@@ -91,7 +91,12 @@ function PlanManagementOverview() {
               }))}
               events={events}
               holidays={holidays}
-              onTaskClick={proj => router.push(`/project/${proj._id || proj.id}`)}
+              onTaskClick={proj =>
+                router.push(
+                  `/plan-management/planning-setting?project=${
+                    proj._id || proj.id
+                  }`,
+                )}
               onEventDrop={(proj, start, end) => {
                 updateProject(proj._id || proj.id, {
                   start,


### PR DESCRIPTION
## Summary
- change Plan Management calendar to open Planning Setting when clicking a project

## Testing
- `npm test` in `client`
- `npm test` in `service`


------
https://chatgpt.com/codex/tasks/task_e_685d31e7480c83289c0d3d98ffa03cb1