### PR TITLE
Fix onClick type error by sanitizing fetched data

### DIFF
--- a/client/models/projectsModel.ts
+++ b/client/models/projectsModel.ts
@@ -1,8 +1,9 @@
 import api from '../api';
+import { sanitizeList } from '../utils/sanitize';
 
 export async function fetchProjects() {
   const { data } = await api.get('/api/v1/projects');
-  return data;
+  return sanitizeList(data);
 }
 
 export async function updateProject(id: string, project: any) {

--- a/client/models/tasksModel.ts
+++ b/client/models/tasksModel.ts
@@ -1,13 +1,8 @@
 import api from '../api';
+import { sanitizeList } from '../utils/sanitize';
 
 export async function fetchTasks(projectId: string) {
   const { data } = await api.get('/api/v1/planning/tasks', { params: { project: projectId } });
-  return data.map((t: any) => {
-    if (typeof t.onClick !== 'undefined') {
-      const { onClick, ...rest } = t;
-      return rest;
-    }
-    return t;
-  });
+  return sanitizeList(data);
 }
 

--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -29,6 +29,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import Chip from '@mui/material/Chip';
+import { sanitizeList } from '../../utils/sanitize';
 import { addDays, differenceInCalendarDays } from 'date-fns';
 import {
   Gantt,
@@ -71,29 +72,14 @@ function PlanningSetting() {
     cancelled: 'error',
   };
 
-  const cleanList = (items: any[]) =>
-    items.map(it => {
-      if (typeof it.onClick !== 'undefined') {
-        const { onClick, ...rest } = it;
-        return rest;
-      }
-      return it;
-    });
+  const cleanList = (items: any[]) => sanitizeList(items);
 
   useEffect(() => {
     if (!router.isReady) return;
     api
       .get('/api/v1/projects')
       .then(res => {
-        const list = res.data
-          .filter(p => !p.deleted)
-          .map((p: any) => {
-            if (typeof p.onClick !== 'undefined') {
-              const { onClick, ...rest } = p;
-              return rest;
-            }
-            return p;
-          });
+        const list = sanitizeList(res.data.filter(p => !p.deleted));
         setProjects(list);
         const pid = router.query.project;
         if (pid) {

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -25,6 +25,7 @@ import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import Chip from '@mui/material/Chip';
 import api from '../api';
+import { sanitizeList } from '../utils/sanitize';
 import { Layout, Popup, ProjectForm, useToast, ConfirmDialog, PageBreadcrumbs, PageLoading } from '../components';
 import { withAuth, useAuth } from '../context/AuthContext';
 
@@ -102,14 +103,7 @@ function ProjectManagement() {
         api.get('/api/v1/teams'),
         api.get('/api/v1/budgets/overview'),
       ]);
-      const cleaned = pro.data.map((p: any) => {
-        if (typeof p.onClick !== 'undefined') {
-          const { onClick, ...rest } = p;
-          return rest;
-        }
-        return p;
-      });
-      setProjects(cleaned);
+      setProjects(sanitizeList(pro.data));
       setUsers(usr.data);
       setTeams(tm.data);
       setBudgets(bg.data);

--- a/client/utils/sanitize.ts
+++ b/client/utils/sanitize.ts
@@ -1,0 +1,9 @@
+export function sanitizeList<T extends Record<string, any>>(items: T[]): T[] {
+  return items.map(item => {
+    if (item && typeof item.onClick !== 'undefined') {
+      const { onClick, ...rest } = item;
+      return rest as T;
+    }
+    return item;
+  });
+}


### PR DESCRIPTION
## Summary
- centralize item sanitization in new `sanitizeList` util
- use `sanitizeList` when fetching tasks and projects
- apply sanitization in planning setting and project management pages

## Testing
- `npm test --prefix client` *(fails: jest not found)*
- `npm test --prefix service` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2efb04c48328be4da0e2b96d8034