### PR TITLE
Disable calendar editing in Plan Management

### DIFF
--- a/client/components/AgendaCalendar.tsx
+++ b/client/components/AgendaCalendar.tsx
@@ -142,9 +142,11 @@ export default function AgendaCalendar({
     return {};
   };
 
+  const CalendarComponent: any = onEventDrop ? DnDCalendar : Calendar;
+
   return (
     <DndProvider backend={HTML5Backend}>
-      <DnDCalendar
+      <CalendarComponent
         localizer={localizer}
         events={eventsAll}
         defaultView="month"
@@ -157,9 +159,15 @@ export default function AgendaCalendar({
         onSelectEvent={event =>
           onTaskClick && event.resource?.type === 'task' && onTaskClick(event.resource)
         }
-        onEventDrop={({ event, start, end }) => onEventDrop && onEventDrop(event.resource, start, end)}
-        resizable
-        onEventResize={({ event, start, end }) => onEventDrop && onEventDrop(event.resource, start, end)}
+        {...(onEventDrop
+          ? {
+              onEventDrop: ({ event, start, end }: any) =>
+                onEventDrop && onEventDrop(event.resource, start, end),
+              onEventResize: ({ event, start, end }: any) =>
+                onEventDrop && onEventDrop(event.resource, start, end),
+              resizable: true,
+            }
+          : {})}
       />
     </DndProvider>
   );

--- a/client/pages/plan-management/index.tsx
+++ b/client/pages/plan-management/index.tsx
@@ -97,12 +97,6 @@ function PlanManagementOverview() {
                     proj._id || proj.id
                   }`,
                 )}
-              onEventDrop={(proj, start, end) => {
-                updateProject(proj._id || proj.id, {
-                  start,
-                  end,
-                }).catch(console.error);
-              }}
             />
           ) : (
             <Timeline>


### PR DESCRIPTION
## Summary
- disable drag & drop in AgendaCalendar when no handler is supplied
- remove onEventDrop from Plan Management Overview page

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685e4192cad083289b446bcee74546ff