### PR TITLE
Fix workload formatter crash

### DIFF
--- a/client/pages/summary/overview.tsx
+++ b/client/pages/summary/overview.tsx
@@ -305,7 +305,8 @@ function DashboardOverview() {
                       label: {
                         show: true,
                         position: 'right',
-                        formatter: (_: any, idx: number) => `${utilData[idx].workload}%`,
+                        formatter: (params: any) =>
+                          `${utilData[params.dataIndex]?.workload ?? 0}%`,
                       },
                     },
                   ],


### PR DESCRIPTION
## Summary
- handle dataIndex lookup safely in Resource Utilization chart

## Testing
- `npm test --silent` in `client`
- `npm test --silent` in `service`
- `npm run check --silent` in `client` *(fails: Failed to collect page data for /budget-management)*
- `npm run build` in `service`


------
https://chatgpt.com/codex/tasks/task_e_685e41b3fc5c832888cf52ee215921fc