### PR TITLE
Improve resource summary view

### DIFF
--- a/client/components/RoleCard.tsx
+++ b/client/components/RoleCard.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import Accordion from '@mui/material/Accordion';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import Grid from '@mui/material/Grid';
+import LinearProgress from '@mui/material/LinearProgress';
+
+export interface LevelInfo {
+  level: string;
+  headcount: number;
+  manday: number;
+  avgRate: number;
+  utilization: number;
+}
+
+export interface RoleInfo {
+  role: string;
+  headcount: number;
+  manday: number;
+  avgRate: number;
+  utilization: number;
+  levels: LevelInfo[];
+}
+
+export default function RoleCard({ data }: { data: RoleInfo }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <Accordion expanded={expanded} onChange={() => setExpanded(!expanded)} sx={{ width: '100%' }}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Box sx={{ width: '100%' }}>
+          <Typography variant="subtitle1" gutterBottom>
+            {data.role}
+          </Typography>
+          <Grid container spacing={1} alignItems="center">
+            <Grid item xs={6}>
+              <Typography variant="body2">👤 {data.headcount}</Typography>
+              <Typography variant="body2">📅 {data.manday}</Typography>
+              <Typography variant="body2">💰 {data.avgRate}</Typography>
+            </Grid>
+            <Grid item xs={6}>
+              <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                <Typography variant="body2" sx={{ mr: 1 }}>
+                  ⚙
+                </Typography>
+                <LinearProgress
+                  variant="determinate"
+                  value={data.utilization}
+                  sx={{ flexGrow: 1, height: 8, borderRadius: 5 }}
+                />
+                <Typography variant="body2" sx={{ ml: 1 }}>
+                  {data.utilization}%
+                </Typography>
+              </Box>
+            </Grid>
+          </Grid>
+        </Box>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Grid container spacing={1}>
+          {data.levels.map(level => (
+            <Grid key={level.level} item xs={12}>
+              <Paper variant="outlined" sx={{ p: 1 }}>
+                <Grid container>
+                  <Grid item xs={3}>
+                    <Typography variant="body2">{level.level}</Typography>
+                  </Grid>
+                  <Grid item xs={9}>
+                    <Typography variant="caption" component="div">
+                      👤 {level.headcount} | 📅 {level.manday} | 💰 {level.avgRate} | ⚙ {level.utilization}%
+                    </Typography>
+                  </Grid>
+                </Grid>
+              </Paper>
+            </Grid>
+          ))}
+        </Grid>
+      </AccordionDetails>
+    </Accordion>
+  );
+}

--- a/client/components/index.tsx
+++ b/client/components/index.tsx
@@ -22,3 +22,7 @@ export { default as ConfirmDialog } from './ConfirmDialog';
 export { default as PageBreadcrumbs } from './PageBreadcrumbs';
 export { default as PhaseForm } from './PhaseForm';
 export { default as TaskForm } from './TaskForm';
+
+export { default as RoleCard } from './RoleCard';
+
+export { default as RoleCard } from "./RoleCard";

--- a/client/pages/summary/overview.tsx
+++ b/client/pages/summary/overview.tsx
@@ -8,7 +8,7 @@ import Grid from '@mui/material/Grid';
 import { PieChart, LineChart, BarChart } from '@mui/x-charts';
 import ReactECharts from 'echarts-for-react';
 import { differenceInDays, addDays } from 'date-fns';
-import { Layout, PageBreadcrumbs } from '../../components';
+import { Layout, PageBreadcrumbs, RoleCard } from '../../components';
 import { withAuth } from '../../context/AuthContext';
 import { fetchBudgetOverview } from '../../models/budgetModel';
 import api from '../../api';
@@ -143,8 +143,65 @@ function DashboardOverview() {
     };
   });
 
-  const totalResources = resources.length;
-  const totalManday = projects.reduce((s, p) => s + (p.manday || 0), 0);
+  const positionMap: Record<string, { role: string; level: string; rate: number; count: number }> = {};
+  overview.forEach(o => {
+    const slug = `${o.role} ${o.level}`.toLowerCase().replace(/\s+/g, '_');
+    positionMap[slug] = { role: o.role, level: o.level, rate: o.rate, count: o.count };
+  });
+
+  const rolesSummary: Record<string, any> = {};
+  Object.values(positionMap).forEach(p => {
+    if (!rolesSummary[p.role]) {
+      rolesSummary[p.role] = {
+        role: p.role,
+        headcount: 0,
+        manday: 0,
+        available: 0,
+        rateSum: 0,
+        levels: {},
+      };
+    }
+    rolesSummary[p.role].headcount += p.count;
+    rolesSummary[p.role].rateSum += p.rate * p.count;
+    rolesSummary[p.role].levels[p.level] = {
+      headcount: p.count,
+      manday: 0,
+      available: 0,
+      avgRate: p.rate,
+    };
+  });
+
+  const today = new Date();
+  resources.forEach(r => {
+    const pos = positionMap[r.position];
+    if (!pos) return;
+    const days = differenceInDays(today, new Date(r.startDate || today)) + 1;
+    const roleData = rolesSummary[pos.role];
+    const levelData = roleData.levels[pos.level];
+    roleData.manday += days;
+    roleData.available += 220;
+    levelData.manday += days;
+    levelData.available = (levelData.available || 0) + 220;
+  });
+
+  const roleCards = Object.values(rolesSummary).map(r => ({
+    role: r.role,
+    headcount: r.headcount,
+    manday: r.manday,
+    avgRate: r.headcount ? Math.round(r.rateSum / r.headcount) : 0,
+    utilization: r.available ? Math.round((r.manday / r.available) * 100) : 0,
+    levels: Object.keys(r.levels).map(lvl => {
+      const lv = r.levels[lvl];
+      return {
+        level: lvl,
+        headcount: lv.headcount,
+        manday: lv.manday,
+        avgRate: lv.avgRate,
+        utilization: lv.available ? Math.round((lv.manday / lv.available) * 100) : 0,
+      };
+    }),
+  }));
+
 
   const barData = Object.keys(roleCounts).map(role => ({
     role,
@@ -155,19 +212,6 @@ function DashboardOverview() {
   Object.keys(roleRates).forEach(r => {
     roleRateAvg[r] = Math.round(roleRates[r].sum / roleRates[r].cnt);
   });
-
-  const cards = [
-    { label: 'Total Resources', value: totalResources },
-    { label: 'Total Manday', value: totalManday },
-    ...Object.keys(roleCounts).map(role => ({
-      label: `${role} Resources`,
-      value: roleCounts[role],
-    })),
-    ...Object.keys(roleRateAvg).map(role => ({
-      label: `${role} Rate`,
-      value: roleRateAvg[role],
-    })),
-  ];
 
   return (
     <Layout>
@@ -183,15 +227,12 @@ function DashboardOverview() {
           </Typography>
           <Grid container spacing={2}>
             <Grid xs={12} container spacing={2}>
-              {cards.map(card => (
-                <Grid key={card.label} xs={6} md={2}>
-                  <Paper sx={{ p: 2, textAlign: 'center' }}>
-                    <Typography variant="body1">{card.label}</Typography>
-                    <Typography variant="h6">{card.value}</Typography>
-                  </Paper>
+              {roleCards.map(card => (
+                <Grid key={card.role} xs={12} md={6}>
+                  <RoleCard data={card} />
                 </Grid>
               ))}
-              <Grid xs={6} md={2}>
+              <Grid xs={12} md={6}>
                 <Paper sx={{ p: 2, textAlign: 'center' }}>
                   <Typography variant="body1">Unassigned</Typography>
                   <Typography variant="h6">{unassigned}</Typography>


### PR DESCRIPTION
## Summary
- add RoleCard component
- export RoleCard from components
- rework summary page to display grouped role cards with collapsible levels

## Testing
- `npm test` in `client`
- `npm test` in `service`

------
https://chatgpt.com/codex/tasks/task_e_685e688943c0832888c773feb6bc76e7