### PR TITLE
Refactor planning repositories

### DIFF
--- a/client/models/planningModel.ts
+++ b/client/models/planningModel.ts
@@ -1,0 +1,47 @@
+import api from '../api';
+import { sanitizeList } from '../utils/sanitize';
+
+export async function fetchPhases(projectId: string) {
+  const { data } = await api.get('/api/v1/planning/phases', {
+    params: { project: projectId },
+  });
+  return sanitizeList(data);
+}
+
+export async function fetchTasks(projectId: string) {
+  const { data } = await api.get('/api/v1/planning/tasks', {
+    params: { project: projectId },
+  });
+  return sanitizeList(data);
+}
+
+export async function fetchMilestones(projectId: string) {
+  const { data } = await api.get('/api/v1/planning/milestones', {
+    params: { project: projectId },
+  });
+  return sanitizeList(data);
+}
+
+export async function createTask(projectId: string, data: any) {
+  return api.post('/api/v1/planning/tasks', { ...data, project: projectId });
+}
+
+export async function updateTask(id: string, data: any) {
+  return api.patch(`/api/v1/planning/tasks/${id}`, data);
+}
+
+export async function deleteTask(id: string) {
+  return api.delete(`/api/v1/planning/tasks/${id}`);
+}
+
+export async function createMilestone(projectId: string, data: any) {
+  return api.post('/api/v1/planning/milestones', { ...data, project: projectId });
+}
+
+export async function updateMilestone(id: string, data: any) {
+  return api.patch(`/api/v1/planning/milestones/${id}`, data);
+}
+
+export async function deleteMilestone(id: string) {
+  return api.delete(`/api/v1/planning/milestones/${id}`);
+}

--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -11,6 +11,17 @@ import TextField from '@mui/material/TextField';
 import { Layout, PageBreadcrumbs, Popup, ConfirmDialog, useToast } from '../../components';
 import { withAuth } from '../../context/AuthContext';
 import api from '../../api';
+import {
+  fetchPhases,
+  fetchTasks,
+  fetchMilestones,
+  createTask,
+  updateTask,
+  deleteTask,
+  createMilestone,
+  updateMilestone,
+  deleteMilestone,
+} from '../../models/planningModel';
 import TaskForm from '../../components/TaskForm';
 import { DataGrid } from '@mui/x-data-grid';
 import Timeline from '@mui/lab/Timeline';
@@ -98,15 +109,15 @@ function PlanningSetting() {
     if (!project) return;
     const pid = project._id || project.id;
     Promise.all([
-      api.get('/api/v1/planning/phases', { params: { project: pid } }),
-      api.get('/api/v1/planning/tasks', { params: { project: pid } }),
-      api.get('/api/v1/planning/milestones', { params: { project: pid } }),
+      fetchPhases(pid),
+      fetchTasks(pid),
+      fetchMilestones(pid),
       api.get(`/api/v1/projects/${pid}`),
       api.get('/api/v1/resources'),
     ]).then(([ph, t, m, proj, res]) => {
-      setPhases(ph.data);
-      setTasks(cleanList(t.data));
-      setMilestones(cleanList(m.data));
+      setPhases(ph);
+      setTasks(cleanList(t));
+      setMilestones(cleanList(m));
       const memIds = proj.data.members || [];
       const leadId = proj.data.lead?._id;
       const list = res.data.filter(u => memIds.includes(u.id) || u.id === leadId);
@@ -141,15 +152,15 @@ function PlanningSetting() {
     if (!project) return;
     const pid = project._id || project.id;
     const [p, t, m, proj, res] = await Promise.all([
-      api.get('/api/v1/planning/phases', { params: { project: pid } }),
-      api.get('/api/v1/planning/tasks', { params: { project: pid } }),
-      api.get('/api/v1/planning/milestones', { params: { project: pid } }),
+      fetchPhases(pid),
+      fetchTasks(pid),
+      fetchMilestones(pid),
       api.get(`/api/v1/projects/${pid}`),
       api.get('/api/v1/resources'),
     ]);
-    setPhases(p.data);
-    setTasks(cleanList(t.data));
-    setMilestones(cleanList(m.data));
+    setPhases(p);
+    setTasks(cleanList(t));
+    setMilestones(cleanList(m));
     const memIds = proj.data.members || [];
     const leadId = proj.data.lead?._id;
     const list = res.data.filter(u => memIds.includes(u.id) || u.id === leadId);
@@ -158,14 +169,13 @@ function PlanningSetting() {
 
   const handleCreateTask = async data => {
     if (data.type === 'milestone') {
-      await api.post('/api/v1/planning/milestones', {
+      await createMilestone(project._id, {
         name: data.name,
         detail: data.detail,
         date: data.startDate,
-        project: project._id,
       });
     } else {
-      await api.post('/api/v1/planning/tasks', { ...data, project: project._id });
+      await createTask(project._id, data);
     }
     await refreshAll();
     setDialog('');
@@ -173,7 +183,7 @@ function PlanningSetting() {
 
   const handleUpdateTask = async data => {
     if (!editTask) return;
-    await api.patch(`/api/v1/planning/tasks/${editTask._id || editTask.id}`, data);
+    await updateTask(editTask._id || editTask.id, data);
     await refreshAll();
     setEditTask(null);
   };
@@ -185,9 +195,9 @@ function PlanningSetting() {
   const confirmDelete = async () => {
     try {
       if (deleteRow.type === 'milestone') {
-        await api.delete(`/api/v1/planning/milestones/${deleteRow._id || deleteRow.id}`);
+        await deleteMilestone(deleteRow._id || deleteRow.id);
       } else {
-        await api.delete(`/api/v1/planning/tasks/${deleteRow._id || deleteRow.id}`);
+        await deleteTask(deleteRow._id || deleteRow.id);
       }
       showToast('Item deleted');
       await refreshAll();
@@ -200,7 +210,7 @@ function PlanningSetting() {
 
   const handleDateChange = async (task: GanttTask) => {
     if (task.type !== 'task') return;
-    await api.patch(`/api/v1/planning/tasks/${task.id}`, {
+    await updateTask(task.id, {
       startDate: task.start,
       endDate: task.end,
     });

--- a/service/src/planning/data/base.repository.ts
+++ b/service/src/planning/data/base.repository.ts
@@ -1,0 +1,22 @@
+import { Model } from 'mongoose';
+
+export abstract class BaseRepository<T> {
+  constructor(protected readonly model: Model<T>) {}
+
+  findByProject(project: string): Promise<T[]> {
+    return this.model.find({ project }).exec();
+  }
+
+  create(data: any): Promise<T> {
+    const doc = new this.model(data);
+    return doc.save();
+  }
+
+  update(id: string, data: any): Promise<T | null> {
+    return this.model.findByIdAndUpdate(id, data, { new: true }).exec();
+  }
+
+  remove(id: string): Promise<T | null> {
+    return this.model.findByIdAndDelete(id).exec();
+  }
+}

--- a/service/src/planning/data/milestones.repository.ts
+++ b/service/src/planning/data/milestones.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types } from 'mongoose';
 import { Milestone } from './milestone.schema';
+import { BaseRepository } from './base.repository';
 import { IsString, IsOptional, IsDate } from 'class-validator';
 import { Type } from 'class-transformer';
 
@@ -38,23 +39,24 @@ export class UpdateMilestoneInput {
 }
 
 @Injectable()
-export class MilestonesRepository {
-  constructor(@InjectModel(Milestone.name) private model: Model<Milestone>) {}
+export class MilestonesRepository extends BaseRepository<Milestone> {
+  constructor(@InjectModel(Milestone.name) model: Model<Milestone>) {
+    super(model);
+  }
 
   findByProject(project: string): Promise<Milestone[]> {
     return this.model.find({ project }).sort({ date: 1 }).exec();
   }
 
   create(data: CreateMilestoneInput): Promise<Milestone> {
-    const mile = new this.model(data);
-    return mile.save();
+    return super.create(data);
   }
 
   update(id: string, data: UpdateMilestoneInput): Promise<Milestone | null> {
-    return this.model.findByIdAndUpdate(id, data, { new: true }).exec();
+    return super.update(id, data);
   }
 
   remove(id: string): Promise<Milestone | null> {
-    return this.model.findByIdAndDelete(id).exec();
+    return super.remove(id);
   }
 }

--- a/service/src/planning/data/phases.repository.ts
+++ b/service/src/planning/data/phases.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types } from 'mongoose';
 import { Phase } from './phase.schema';
+import { BaseRepository } from './base.repository';
 import { IsString, IsOptional, IsNumber } from 'class-validator';
 import { Type } from 'class-transformer';
 
@@ -29,23 +30,24 @@ export class UpdatePhaseInput {
 }
 
 @Injectable()
-export class PhasesRepository {
-  constructor(@InjectModel(Phase.name) private model: Model<Phase>) {}
+export class PhasesRepository extends BaseRepository<Phase> {
+  constructor(@InjectModel(Phase.name) model: Model<Phase>) {
+    super(model);
+  }
 
   findByProject(project: string): Promise<Phase[]> {
     return this.model.find({ project }).sort({ order: 1 }).exec();
   }
 
   create(data: CreatePhaseInput): Promise<Phase> {
-    const phase = new this.model(data);
-    return phase.save();
+    return super.create(data);
   }
 
   update(id: string, data: UpdatePhaseInput): Promise<Phase | null> {
-    return this.model.findByIdAndUpdate(id, data, { new: true }).exec();
+    return super.update(id, data);
   }
 
   remove(id: string): Promise<Phase | null> {
-    return this.model.findByIdAndDelete(id).exec();
+    return super.remove(id);
   }
 }

--- a/service/src/planning/data/tasks.repository.ts
+++ b/service/src/planning/data/tasks.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types } from 'mongoose';
 import { Task } from './task.schema';
+import { BaseRepository } from './base.repository';
 import { IsString, IsOptional, IsBoolean, IsNumber } from 'class-validator';
 import { Type } from 'class-transformer';
 
@@ -105,19 +106,21 @@ export class UpdateTaskInput {
 }
 
 @Injectable()
-export class TasksRepository {
-  constructor(@InjectModel(Task.name) private model: Model<Task>) {}
+export class TasksRepository extends BaseRepository<Task> {
+  constructor(@InjectModel(Task.name) model: Model<Task>) {
+    super(model);
+  }
 
   findByProject(project: string): Promise<Task[]> {
     return this.model.find({ project }).sort({ createdAt: 1 }).exec();
   }
 
   create(data: CreateTaskInput): Promise<Task> {
-    const task = new this.model({
+    const payload = {
       ...data,
       ...(data.type ? { isFeature: data.type === 'feature' } : {}),
-    });
-    return task.save();
+    };
+    return super.create(payload);
   }
 
   update(id: string, data: UpdateTaskInput): Promise<Task | null> {
@@ -125,10 +128,10 @@ export class TasksRepository {
       ...data,
       ...(data.type ? { isFeature: data.type === 'feature' } : {}),
     };
-    return this.model.findByIdAndUpdate(id, payload, { new: true }).exec();
+    return super.update(id, payload);
   }
 
   remove(id: string): Promise<Task | null> {
-    return this.model.findByIdAndDelete(id).exec();
+    return super.remove(id);
   }
 }


### PR DESCRIPTION
## Summary
- use base repository for Planning service repos
- extract API helpers in the client
- update planning page to use helper functions

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685e6980e8fc83288c3c7fa3d435e964