### PR TITLE
Improve login layout and accessibility

### DIFF
--- a/client/components/Topbar.tsx
+++ b/client/components/Topbar.tsx
@@ -37,13 +37,19 @@ export default function Topbar({ onMenuClick }) {
       }}
     >
       <Toolbar variant="dense">
-        <IconButton color="inherit" edge="start" sx={{ mr: 1 }} onClick={onMenuClick}>
+        <IconButton
+          color="inherit"
+          edge="start"
+          aria-label="open sidebar"
+          sx={{ mr: 1 }}
+          onClick={onMenuClick}
+        >
           <MenuIcon />
         </IconButton>
         <Typography variant="h6" sx={{ flexGrow: 1, fontWeight: 500 }}>
           Budget Manager
         </Typography>
-        <IconButton color="inherit" onClick={handleMenu}>
+        <IconButton color="inherit" aria-label="account options" onClick={handleMenu}>
           <AccountCircle />
         </IconButton>
         <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>

--- a/client/styles/index.module.scss
+++ b/client/styles/index.module.scss
@@ -9,6 +9,7 @@
 .paper {
   padding: 2rem;
   width: 100%;
+  max-width: 420px;
   background-color: #ffffff;
 }
 


### PR DESCRIPTION
## Summary
- tighten login screen width for better usability on large displays
- add aria labels to topbar buttons for improved accessibility

## Testing
- `npm test --silent` in `client`
- `npm test --silent -- -i` in `service`


------
https://chatgpt.com/codex/tasks/task_e_685e6e9638ac8328a79d86dd15bb19ec