### PR TITLE
Refactor service duration helpers

### DIFF
--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -13,14 +13,8 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import RestoreIcon from '@mui/icons-material/Restore';
 import DownloadIcon from '@mui/icons-material/Download';
 import { DataGrid } from '@mui/x-data-grid';
-import {
-  differenceInDays,
-  format,
-  differenceInYears,
-  differenceInMonths,
-  addYears,
-  addMonths,
-} from 'date-fns';
+import { differenceInDays, format } from 'date-fns';
+import { getServiceDuration } from '../utils/date';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import Chip from '@mui/material/Chip';
@@ -156,16 +150,7 @@ function ProjectManagement() {
     }
   };
 
-  function getServiceDuration(date: string | Date) {
-    const start = new Date(date);
-    const now = new Date();
-    const years = differenceInYears(now, start);
-    const afterYears = addYears(start, years);
-    const months = differenceInMonths(now, afterYears);
-    const afterMonths = addMonths(afterYears, months);
-    const days = differenceInDays(now, afterMonths);
-    return `${years}y ${months}m ${days}d`;
-  }
+
 
   const columns = [
     {

--- a/client/pages/team-setting/index.tsx
+++ b/client/pages/team-setting/index.tsx
@@ -11,14 +11,8 @@ import IconButton from '@mui/material/IconButton';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import DownloadIcon from '@mui/icons-material/Download';
-import {
-  format,
-  differenceInYears,
-  differenceInMonths,
-  differenceInDays,
-  addYears,
-  addMonths,
-} from 'date-fns';
+import { format } from 'date-fns';
+import { getServiceDuration, getServiceExp } from '../../utils/date';
 import { Layout, ResourceForm, Popup, useToast, ConfirmDialog, PageBreadcrumbs } from '../../components';
 import { withAuth, useAuth } from '../../context/AuthContext';
 import {
@@ -38,24 +32,7 @@ function TeamSetting() {
   const [editRow, setEditRow] = useState(null);
   const [deleteRow, setDeleteRow] = useState(null);
 
-  function getServiceDuration(date: string | Date) {
-    const start = new Date(date);
-    const now = new Date();
-    const years = differenceInYears(now, start);
-    const afterYears = addYears(start, years);
-    const months = differenceInMonths(now, afterYears);
-    const afterMonths = addMonths(afterYears, months);
-    const days = differenceInDays(now, afterMonths);
-    return `${years}y ${months}m ${days}d`;
-  }
 
-  function getServiceExp(date: string | Date) {
-    const years = differenceInYears(new Date(), new Date(date));
-    if (years <= 2) return 'junior';
-    if (years <= 4) return 'intermediate';
-    if (years <= 6) return 'senior';
-    return 'advance';
-  }
 
   async function loadData() {
     const [res, pos] = await Promise.all([

--- a/client/utils/date.ts
+++ b/client/utils/date.ts
@@ -1,0 +1,26 @@
+import {
+  differenceInYears,
+  differenceInMonths,
+  differenceInDays,
+  addYears,
+  addMonths,
+} from 'date-fns';
+
+export function getServiceDuration(date: string | Date): string {
+  const start = new Date(date);
+  const now = new Date();
+  const years = differenceInYears(now, start);
+  const afterYears = addYears(start, years);
+  const months = differenceInMonths(now, afterYears);
+  const afterMonths = addMonths(afterYears, months);
+  const days = differenceInDays(now, afterMonths);
+  return `${years}y ${months}m ${days}d`;
+}
+
+export function getServiceExp(date: string | Date): string {
+  const years = differenceInYears(new Date(), new Date(date));
+  if (years <= 2) return 'junior';
+  if (years <= 4) return 'intermediate';
+  if (years <= 6) return 'senior';
+  return 'advance';
+}


### PR DESCRIPTION
## Summary
- centralize duplicate helper functions in `client/utils/date.ts`
- use these helpers in TeamSetting and ProjectManagement pages

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685e710ed4d083288930a748eca254de