### PR TITLE
Improve dashboard metrics

### DIFF
--- a/client/components/MetricCard.tsx
+++ b/client/components/MetricCard.tsx
@@ -1,0 +1,24 @@
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import { ReactNode } from 'react';
+
+interface MetricCardProps {
+  label: string;
+  value: ReactNode;
+  icon?: ReactNode;
+}
+
+export default function MetricCard({ label, value, icon }: MetricCardProps) {
+  return (
+    <Paper sx={{ p: 2, display: 'flex', alignItems: 'center' }}>
+      {icon && <Box sx={{ mr: 2 }}>{icon}</Box>}
+      <Box>
+        <Typography variant="body2" color="text.secondary">
+          {label}
+        </Typography>
+        <Typography variant="h6">{value}</Typography>
+      </Box>
+    </Paper>
+  );
+}

--- a/client/components/index.tsx
+++ b/client/components/index.tsx
@@ -23,3 +23,4 @@ export { default as PageBreadcrumbs } from './PageBreadcrumbs';
 export { default as PhaseForm } from './PhaseForm';
 export { default as TaskForm } from './TaskForm';
 export { default as RoleCard } from "./RoleCard";
+export { default as MetricCard } from './MetricCard';

--- a/client/pages/summary/overview.tsx
+++ b/client/pages/summary/overview.tsx
@@ -8,7 +8,15 @@ import Grid from '@mui/material/Grid';
 import { PieChart, LineChart, BarChart } from '@mui/x-charts';
 import ReactECharts from 'echarts-for-react';
 import { differenceInDays, addDays } from 'date-fns';
-import { Layout, PageBreadcrumbs, RoleCard } from '../../components';
+import {
+  Layout,
+  PageBreadcrumbs,
+  RoleCard,
+  MetricCard,
+} from '../../components';
+import PeopleAltIcon from '@mui/icons-material/PeopleAlt';
+import WorkOutlineIcon from '@mui/icons-material/WorkOutline';
+import PersonOffIcon from '@mui/icons-material/PersonOff';
 import { withAuth } from '../../context/AuthContext';
 import { fetchBudgetOverview } from '../../models/budgetModel';
 import api from '../../api';
@@ -21,6 +29,9 @@ function DashboardOverview() {
   const [dailyManday, setDailyManday] = useState([]);
   const [dailyCost, setDailyCost] = useState([]);
   const [utilData, setUtilData] = useState([]);
+
+  const totalProjects = projects.length;
+  const totalResources = resources.length;
 
   async function loadData() {
     const [ov, res, pro] = await Promise.all([
@@ -220,6 +231,30 @@ function DashboardOverview() {
           Dashboard Overview
         </Typography>
         <PageBreadcrumbs items={[{ label: 'Dashboard Overview' }]} />
+
+        <Grid container spacing={2} sx={{ mb: 2 }}>
+          <Grid xs={12} md={4}>
+            <MetricCard
+              label="Projects"
+              value={totalProjects}
+              icon={<WorkOutlineIcon />}
+            />
+          </Grid>
+          <Grid xs={12} md={4}>
+            <MetricCard
+              label="Resources"
+              value={totalResources}
+              icon={<PeopleAltIcon />}
+            />
+          </Grid>
+          <Grid xs={12} md={4}>
+            <MetricCard
+              label="Unassigned"
+              value={unassigned}
+              icon={<PersonOffIcon />}
+            />
+          </Grid>
+        </Grid>
 
         <Paper sx={{ p: 2 }}>
           <Typography variant="h6" gutterBottom>


### PR DESCRIPTION
## Summary
- add `MetricCard` component for displaying dashboard KPIs
- export it from the component index
- show project/resource counts on the Dashboard Overview page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e73f5b3648328b3bd89318131976c