### PR TITLE
Focus schedule Gantt on today

### DIFF
--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -589,6 +589,8 @@ function PlanningSetting() {
                             viewMode={viewMode}
                             onDateChange={handleDateChange}
                             columnWidth={columnWidth}
+                            viewDate={new Date()}
+                            preStepsCount={0}
                           />
                         </Box>
                       </Box>


### PR DESCRIPTION
## Summary
- set `viewDate` and remove pre-step spacing for schedule Gantt

## Testing
- `npm run check` (fails: `next` not found)
- `npm run check` in service (fails: `nest` not found)


------
https://chatgpt.com/codex/tasks/task_e_685ed323d5f0832886ce277e310c910a