### PR TITLE
Add manday analysis chart

### DIFF
--- a/client/pages/summary/overview.tsx
+++ b/client/pages/summary/overview.tsx
@@ -224,6 +224,11 @@ function DashboardOverview() {
     roleRateAvg[r] = Math.round(roleRates[r].sum / roleRates[r].cnt);
   });
 
+  const mandayBarData = Object.keys(rolesSummary).map(role => ({
+    role,
+    manday: rolesSummary[role].manday,
+  }));
+
   return (
     <Layout>
       <Container maxWidth={false} sx={{ mt: 4 }}>
@@ -307,6 +312,19 @@ function DashboardOverview() {
                     dataset={costData}
                     xAxis={[{ dataKey: 'month', scaleType: 'band' }]}
                     series={[{ dataKey: 'cost', label: 'Cost' }]}
+                  />
+                </Paper>
+              </Grid>
+              <Grid xs={12} md={12}>
+                <Paper sx={{ p: 2 }}>
+                  <Typography variant="h6" gutterBottom>
+                    Mandays by Role
+                  </Typography>
+                  <BarChart
+                    height={200}
+                    dataset={mandayBarData}
+                    xAxis={[{ dataKey: 'role', scaleType: 'band' }]}
+                    series={[{ dataKey: 'manday', label: 'Mandays' }]}
                   />
                 </Paper>
               </Grid>


### PR DESCRIPTION
## Summary
- add man-day bar chart on dashboard

## Testing
- `npm --prefix client test`
- `npm --prefix service test`


------
https://chatgpt.com/codex/tasks/task_e_685ed53fa3648328b95b4af75374458b