### PR TITLE
Fix Gantt date crash

### DIFF
--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -253,10 +253,15 @@ function PlanningSetting() {
   const statusColor = status =>
     ({ 'not-started': 'grey', 'in-progress': '#2196f3', late: 'red' }[status] || 'grey');
 
+  const safeDate = (value: any) => {
+    const d = value ? new Date(value) : undefined;
+    return d && !isNaN(d.getTime()) ? d : new Date();
+  };
+
   const ganttTasks: GanttTask[] = [
     ...tasks.map(t => ({
-      start: t.startDate ? new Date(t.startDate) : new Date(),
-      end: t.endDate ? new Date(t.endDate) : new Date(),
+      start: safeDate(t.startDate),
+      end: safeDate(t.endDate),
       name: t.name,
       id: t._id || t.id,
       type: 'task',
@@ -265,8 +270,8 @@ function PlanningSetting() {
       styles: { backgroundColor: statusColor(taskStatus(t)) },
     })),
     ...milestones.map(m => ({
-      start: new Date(m.date),
-      end: new Date(m.date),
+      start: safeDate(m.date),
+      end: safeDate(m.date),
       name: m.name,
       id: m._id || m.id,
       type: 'milestone',


### PR DESCRIPTION
## Summary
- sanitize dates before passing to `gantt-task-react`

## Testing
- `npm test --silent` in `client`
- `npm test --silent` in `service`
- `npm run check --silent` in `client` *(fails: Type error in RoleCard.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_685ed6c039b88328a05caa3a9b63222b