### PR TITLE
Fix Gantt date parsing

### DIFF
--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -254,8 +254,9 @@ function PlanningSetting() {
     ({ 'not-started': 'grey', 'in-progress': '#2196f3', late: 'red' }[status] || 'grey');
 
   const safeDate = (value: any) => {
-    const d = value ? new Date(value) : undefined;
-    return d && !isNaN(d.getTime()) ? d : new Date();
+    if (!value) return new Date();
+    const d = new Date(value);
+    return isNaN(d.getTime()) ? new Date() : d;
   };
 
   const ganttTasks: GanttTask[] = [


### PR DESCRIPTION
## Summary
- sanitize date inputs in planning-setting page

## Testing
- `npm test` in `client`
- `npm test` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6861f8e84f348328a06db45def070797