### PR TITLE
Fix Gantt date parsing

### DIFF
--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -255,21 +255,26 @@ function PlanningSetting() {
 
   const safeDate = (value: any) => {
     if (!value) return new Date();
+    if (value instanceof Date) {
+      return isNaN(value.getTime()) ? new Date() : value;
+    }
     const d = new Date(value);
     return isNaN(d.getTime()) ? new Date() : d;
   };
 
   const ganttTasks: GanttTask[] = [
-    ...tasks.map(t => ({
-      start: safeDate(t.startDate),
-      end: safeDate(t.endDate),
-      name: t.name,
-      id: t._id || t.id,
-      type: 'task',
-      progress: 0,
-      dependencies: t.blockedBy ? [String(t.blockedBy)] : [],
-      styles: { backgroundColor: statusColor(taskStatus(t)) },
-    })),
+    ...tasks
+      .filter(t => t.startDate)
+      .map(t => ({
+        start: safeDate(t.startDate),
+        end: safeDate(t.endDate || t.startDate),
+        name: t.name,
+        id: t._id || t.id,
+        type: 'task',
+        progress: 0,
+        dependencies: t.blockedBy ? [String(t.blockedBy)] : [],
+        styles: { backgroundColor: statusColor(taskStatus(t)) },
+      })),
     ...milestones.map(m => ({
       start: safeDate(m.date),
       end: safeDate(m.date),


### PR DESCRIPTION
## Summary
- handle Date instances in `safeDate`
- filter out tasks without a start date when building Gantt tasks

## Testing
- `npm test --prefix client`
- `npm test --prefix service`


------
https://chatgpt.com/codex/tasks/task_e_6861fe9f026c83288c1ed55693a2b07f