### PR TITLE
Add manage task button on project detail

### DIFF
--- a/client/pages/project/[id].tsx
+++ b/client/pages/project/[id].tsx
@@ -210,6 +210,19 @@ function ProjectDetail() {
           <Button variant="outlined" onClick={() => setOpen(true)}>
             Edit
           </Button>
+          <Button
+            variant="contained"
+            sx={{ ml: 1 }}
+            onClick={() =>
+              router.push(
+                `/plan-management/planning-setting?project=${
+                  project._id || project.id
+                }`,
+              )
+            }
+          >
+            Manage Task
+          </Button>
         </Box>
         <PageBreadcrumbs
           items={[


### PR DESCRIPTION
## Summary
- add `Manage Task` button in project detail view that links to planning setting

## Testing
- `npm test` in `client`
- `npm test` in `service`


------
https://chatgpt.com/codex/tasks/task_e_68624b1b81048328a81f02ab1cc24179