### PR TITLE
Remove any usage from service

### DIFF
--- a/service/src/activity-logs/activity-logs.interceptor.ts
+++ b/service/src/activity-logs/activity-logs.interceptor.ts
@@ -8,7 +8,7 @@ import { getActivityDescription } from './activity.constants';
 export class ActivityLogsInterceptor implements NestInterceptor {
   constructor(private readonly logsService: ActivityLogsService) {}
 
-  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     const req = context.switchToHttp().getRequest();
     const res = context.switchToHttp().getResponse();
     const { method, originalUrl: url, body } = req;

--- a/service/src/activity-logs/activity-logs.service.ts
+++ b/service/src/activity-logs/activity-logs.service.ts
@@ -12,7 +12,7 @@ export class ActivityLogsService {
   create(data: {
     method: string;
     url: string;
-    body: any;
+    body: Record<string, unknown>;
     statusCode: number;
     processTime: number;
     name?: string;

--- a/service/src/activity-logs/data/activity-log.schema.ts
+++ b/service/src/activity-logs/data/activity-log.schema.ts
@@ -10,7 +10,7 @@ export class ActivityLog extends Document {
   url: string;
 
   @Prop({ type: Object })
-  body: any;
+  body: Record<string, unknown>;
 
   @Prop({ required: true })
   statusCode: number;

--- a/service/src/auth/auth.service.ts
+++ b/service/src/auth/auth.service.ts
@@ -26,9 +26,13 @@ export class AuthService {
     return jwt.sign({ sub: userId }, this.SECRET, { expiresIn: '30m' });
   }
 
-  verifyToken(token: string): { sub: string } | null {
+  interface TokenPayload {
+    sub: string;
+  }
+
+  verifyToken(token: string): TokenPayload | null {
     try {
-      return jwt.verify(token, this.SECRET) as any;
+      return jwt.verify(token, this.SECRET) as TokenPayload;
     } catch {
       return null;
     }

--- a/service/src/budgets/budgets.service.ts
+++ b/service/src/budgets/budgets.service.ts
@@ -71,7 +71,12 @@ export class BudgetsService {
       idMap[slug] = b._id.toString();
     });
 
-    const positions: any[] = [];
+    interface PositionInfo {
+      slug: string;
+      role: string;
+      level: string;
+    }
+    const positions: PositionInfo[] = [];
     roles.forEach(role => {
       role.levels.forEach((level: string) => {
         const slug = `${role.name} ${level}`.toLowerCase().replace(/\s+/g, '_');

--- a/service/src/logger/logger.service.ts
+++ b/service/src/logger/logger.service.ts
@@ -4,7 +4,7 @@ type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 @Injectable()
 export class LoggerService {
-  private output(level: LogLevel, log: any) {
+  private output(level: LogLevel, log: Record<string, unknown>) {
     const msg = JSON.stringify(log);
     switch (level) {
       case 'debug':
@@ -22,19 +22,23 @@ export class LoggerService {
     }
   }
 
-  private log(log_type: 'info' | 'app' | 'service', level: LogLevel, data: any) {
+  private log(
+    log_type: 'info' | 'app' | 'service',
+    level: LogLevel,
+    data: Record<string, unknown>,
+  ) {
     this.output(level, { log_type, level, ...data });
   }
 
-  logInfo(level: LogLevel, data: any) {
+  logInfo(level: LogLevel, data: Record<string, unknown>) {
     this.log('info', level, data);
   }
 
-  logApp(level: LogLevel, data: any) {
+  logApp(level: LogLevel, data: Record<string, unknown>) {
     this.log('app', level, data);
   }
 
-  logService(level: LogLevel, data: any) {
+  logService(level: LogLevel, data: Record<string, unknown>) {
     this.log('service', level, data);
   }
 }

--- a/service/src/logger/logging.interceptor.ts
+++ b/service/src/logger/logging.interceptor.ts
@@ -12,7 +12,7 @@ import { LoggerService } from './logger.service';
 export class LoggingInterceptor implements NestInterceptor {
   constructor(private readonly logger: LoggerService) {}
 
-  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     const req = context.switchToHttp().getRequest();
     const res = context.switchToHttp().getResponse();
     const { method, originalUrl: url } = req;

--- a/service/src/planning/data/base.repository.ts
+++ b/service/src/planning/data/base.repository.ts
@@ -7,12 +7,12 @@ export abstract class BaseRepository<T> {
     return this.model.find({ project }).exec();
   }
 
-  create(data: any): Promise<T> {
+  create(data: Partial<T>): Promise<T> {
     const doc = new this.model(data);
     return doc.save();
   }
 
-  update(id: string, data: any): Promise<T | null> {
+  update(id: string, data: Partial<T>): Promise<T | null> {
     return this.model.findByIdAndUpdate(id, data, { new: true }).exec();
   }
 

--- a/service/src/positions/positions.service.ts
+++ b/service/src/positions/positions.service.ts
@@ -2,12 +2,17 @@ import { Injectable } from '@nestjs/common';
 import { RolesService } from '../roles/roles.service';
 
 @Injectable()
+export interface PositionOption {
+  value: string;
+  label: string;
+}
+
 export class PositionsService {
   constructor(private readonly rolesService: RolesService) {}
 
-  async getPositions() {
+  async getPositions(): Promise<PositionOption[]> {
     const roles = await this.rolesService.getRoles();
-    const pos = [] as any[];
+    const pos: PositionOption[] = [];
     roles.forEach(r => {
       r.levels.forEach(l => {
         const slug = `${r.name} ${l}`

--- a/service/src/users/users.controller.ts
+++ b/service/src/users/users.controller.ts
@@ -1,5 +1,9 @@
 import { Body, Controller, Get, Post, Req, UseGuards, UnauthorizedException } from '@nestjs/common';
 import { Request } from 'express';
+
+interface AuthRequest extends Request {
+  userId: string;
+}
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { UsersService } from './users.service';
 
@@ -9,8 +13,8 @@ export class UsersController {
 
   @UseGuards(JwtAuthGuard)
   @Get('profile')
-  async profile(@Req() req: Request) {
-    const profile = await this.usersService.getProfile((req as any).userId);
+  async profile(@Req() req: AuthRequest) {
+    const profile = await this.usersService.getProfile(req.userId);
     if (!profile) throw new UnauthorizedException();
     return profile;
   }


### PR DESCRIPTION
## Summary
- add `PositionOption` interface and return typed array in `PositionsService`
- add `PositionInfo` interface in `BudgetsService`
- type payloads in activity logs service and schema
- refine logging types and interceptors
- type token payload in auth service
- add `AuthRequest` interface for `UsersController`
- update `BaseRepository` to use `Partial<T>` instead of `any`

## Testing
- `npm run build` *(fails: `nest` not found)*
- `npx nest build` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_686256fcab488328a2780c2e18139990