### PR TITLE
Fix interface placement and adjust repository types

### DIFF
--- a/service/src/auth/auth.service.ts
+++ b/service/src/auth/auth.service.ts
@@ -5,6 +5,7 @@ import { UsersRepository } from '../users/data/users.repository';
 import { User } from '../users/data/user.schema';
 import { randomBytes } from 'crypto';
 import Redis from 'ioredis';
+import { TokenPayload } from '../interfaces/token-payload.interface';
 
 @Injectable()
 export class AuthService {
@@ -24,10 +25,6 @@ export class AuthService {
 
   signToken(userId: string): string {
     return jwt.sign({ sub: userId }, this.SECRET, { expiresIn: '30m' });
-  }
-
-  interface TokenPayload {
-    sub: string;
   }
 
   verifyToken(token: string): TokenPayload | null {

--- a/service/src/interfaces/token-payload.interface.ts
+++ b/service/src/interfaces/token-payload.interface.ts
@@ -1,0 +1,3 @@
+export interface TokenPayload {
+  sub: string;
+}

--- a/service/src/planning/data/base.repository.ts
+++ b/service/src/planning/data/base.repository.ts
@@ -1,6 +1,6 @@
-import { Model } from 'mongoose';
+import { Model, Document } from 'mongoose';
 
-export abstract class BaseRepository<T> {
+export abstract class BaseRepository<T extends Document> {
   constructor(protected readonly model: Model<T>) {}
 
   findByProject(project: string): Promise<T[]> {

--- a/service/src/positions/positions.service.ts
+++ b/service/src/positions/positions.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { RolesService } from '../roles/roles.service';
 
-@Injectable()
 export interface PositionOption {
   value: string;
   label: string;
 }
 
+@Injectable()
 export class PositionsService {
   constructor(private readonly rolesService: RolesService) {}
 


### PR DESCRIPTION
## Summary
- move `TokenPayload` interface to new `service/src/interfaces` directory
- remove nested interface from AuthService and import it instead
- fix misplaced decorator in `positions.service.ts`
- tighten generic constraint in `BaseRepository` to avoid compilation error

## Testing
- `npm --prefix service test`
- `npm --prefix client test`
- `npx --no-install tsc -p service/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_686259101d8c832884515063ef66095a