### PR TITLE
Add dynamic activity descriptions

### DIFF
--- a/service/src/activity-logs/activity.constants.ts
+++ b/service/src/activity-logs/activity.constants.ts
@@ -38,5 +38,32 @@ export function getActivityDescription(
 ): { name?: string; detail?: string } {
   const key = `${method} ${url}`;
   const entry = ACTIVITY_DESCRIPTIONS.find(d => d.pattern.test(key));
-  return entry ? { name: entry.name, detail: entry.detail } : {};
+  if (entry) {
+    return { name: entry.name, detail: entry.detail };
+  }
+
+  const base = url.split('?')[0];
+  const match = base.match(/^\/api\/v1\/([^/]+)/);
+  if (!match) return {};
+
+  const resource = match[1].replace(/s$/, '');
+  let action = '';
+
+  switch (method) {
+    case 'POST':
+      action = 'Create';
+      break;
+    case 'PATCH':
+    case 'PUT':
+      action = 'Update';
+      break;
+    case 'DELETE':
+      action = 'Delete';
+      break;
+    default:
+      return {};
+  }
+
+  const name = `${action} ${resource}`;
+  return { name, detail: name };
 }

--- a/service/src/planning/planning.service.ts
+++ b/service/src/planning/planning.service.ts
@@ -37,16 +37,51 @@ export class PlanningService {
     return this.tasks.findByProject(project);
   }
 
-  createTask(data: CreateTaskInput) {
+  async createTask(data: CreateTaskInput) {
     if (data.startDate && data.endDate && data.startDate > data.endDate) {
       throw new BadRequestException('End date must be after start date');
+    }
+    if (data.type === 'milestone' && data.startDate) {
+      const list = await this.tasks.findByProject(String(data.project));
+      const target = new Date(data.startDate).toISOString().split('T')[0];
+      if (
+        list.some(
+          t =>
+            t.type === 'milestone' &&
+            t.startDate &&
+            new Date(t.startDate).toISOString().split('T')[0] === target,
+        )
+      ) {
+        throw new BadRequestException('Milestone date overlaps existing one');
+      }
+      return this.tasks.create(data);
     }
     return this.tasks.create(data);
   }
 
-  updateTask(id: string, data: UpdateTaskInput) {
+  async updateTask(id: string, data: UpdateTaskInput) {
     if (data.startDate && data.endDate && data.startDate > data.endDate) {
       throw new BadRequestException('End date must be after start date');
+    }
+    if (data.type === 'milestone' && data.startDate) {
+      const existing = await this.tasks.findById(id);
+      const project = existing?.project ? String(existing.project) : undefined;
+      if (project) {
+        const list = await this.tasks.findByProject(project);
+        const target = new Date(data.startDate!).toISOString().split('T')[0];
+        if (
+          list.some(
+            t =>
+              t.type === 'milestone' &&
+              String(t._id) !== id &&
+              t.startDate &&
+              new Date(t.startDate).toISOString().split('T')[0] === target,
+          )
+        ) {
+          throw new BadRequestException('Milestone date overlaps existing one');
+        }
+      }
+      return this.tasks.update(id, data);
     }
     return this.tasks.update(id, data);
   }


### PR DESCRIPTION
## Summary
- generate activity names dynamically when no static description matches
- restore milestone overlap validation in planning service

## Testing
- `npm test --silent --prefix service`
- `npm test --silent --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_6863a4ef0b748328a98f3e19032c0801