### PR TITLE
Fix milestone display and overlap handling

### DIFF
--- a/client/components/TaskForm.tsx
+++ b/client/components/TaskForm.tsx
@@ -11,7 +11,7 @@ import { addDays } from 'date-fns';
 export default function TaskForm({ onSubmit, initial, members = [], tasks = [] }) {
   const [name, setName] = useState(initial?.name || '');
   const [detail, setDetail] = useState(initial?.detail || '');
-  const [startDate, setStartDate] = useState(initial?.startDate || null);
+  const [startDate, setStartDate] = useState(initial?.startDate || initial?.date || null);
   const [endDate, setEndDate] = useState(initial?.endDate || null);
   const [owner, setOwner] = useState(initial?.owner || '');
   const [manday, setManday] = useState(initial?.manday != null ? String(initial.manday) : '');
@@ -24,7 +24,7 @@ export default function TaskForm({ onSubmit, initial, members = [], tasks = [] }
   useEffect(() => {
     setName(initial?.name || '');
     setDetail(initial?.detail || '');
-    setStartDate(initial?.startDate || null);
+    setStartDate(initial?.startDate || initial?.date || null);
     setEndDate(initial?.endDate || null);
     setOwner(initial?.owner || '');
     setManday(initial?.manday != null ? String(initial.manday) : '');
@@ -72,7 +72,7 @@ export default function TaskForm({ onSubmit, initial, members = [], tasks = [] }
         onSubmit({
           name,
           detail,
-          date: startDate,
+          startDate,
           type: taskType,
         });
     } else {

--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -236,7 +236,7 @@ function PlanningSetting() {
   };
 
   const toGanttTask = (t: any): GanttTask | null => {
-    const start = parseValidDate(t.startDate);
+    const start = parseValidDate(t.startDate || t.date);
     if (!start) return null;
     const end = parseValidDate(t.endDate) || start;
     if (!end) return null;
@@ -358,7 +358,7 @@ function PlanningSetting() {
                         field: 'startDate',
                         headerName: 'Start Date',
                         valueFormatter: params => {
-                          const value = params?.value;
+                          const value = params?.value || params.row.date;
                           return value ? new Date(value).toLocaleDateString() : '';
                         },
                         width: 140,
@@ -393,8 +393,9 @@ function PlanningSetting() {
                       width: 120,
                       type: 'number',
                       valueGetter: (_value, row) => {
-                        if (!row.startDate) return '';
-                        const start = new Date(row.startDate);
+                        const startValue = row.startDate || row.date;
+                        if (!startValue) return '';
+                        const start = new Date(startValue);
                         const end = row.endDate ? new Date(row.endDate) : new Date();
                         const today = new Date();
                         const until = end < today ? end : today;

--- a/service/src/planning/planning.service.ts
+++ b/service/src/planning/planning.service.ts
@@ -37,16 +37,38 @@ export class PlanningService {
     return this.tasks.findByProject(project);
   }
 
-  createTask(data: CreateTaskInput) {
+  async createTask(data: CreateTaskInput) {
     if (data.startDate && data.endDate && data.startDate > data.endDate) {
       throw new BadRequestException('End date must be after start date');
+    }
+    if (data.type === 'milestone' && data.startDate) {
+      const existing = await this.tasks.findByProject(String(data.project));
+      const clash = existing.find(
+        t => t.type === 'milestone' && t.startDate && new Date(t.startDate).getTime() === new Date(data.startDate as Date).getTime(),
+      );
+      if (clash) {
+        throw new BadRequestException('milestone date overlaps');
+      }
     }
     return this.tasks.create(data);
   }
 
-  updateTask(id: string, data: UpdateTaskInput) {
+  async updateTask(id: string, data: UpdateTaskInput) {
     if (data.startDate && data.endDate && data.startDate > data.endDate) {
       throw new BadRequestException('End date must be after start date');
+    }
+    if (data.type === 'milestone' && data.startDate) {
+      const current = await this.tasks.findById(id);
+      const projectId = current?.project.toString();
+      if (projectId) {
+        const existing = await this.tasks.findByProject(projectId);
+        const clash = existing.find(
+          t => String(t._id) !== id && t.type === 'milestone' && t.startDate && new Date(t.startDate).getTime() === new Date(data.startDate as Date).getTime(),
+        );
+        if (clash) {
+          throw new BadRequestException('milestone date overlaps');
+        }
+      }
     }
     return this.tasks.update(id, data);
   }


### PR DESCRIPTION
## Summary
- support milestones properly in task form and planning view
- show milestone dates in the grid and gantt chart
- prevent overlapping milestone dates in planning service

## Testing
- `cd service && npx jest --runInBand`
- `cd client && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6863a54d93388328a36ba72b23308ec0