### PR TITLE
Allow milestone edit

### DIFF
--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -422,14 +422,9 @@ function PlanningSetting() {
                       sortable: false,
                       renderCell: params => (
                         <Stack direction="row" spacing={1}>
-                          {params.row.type !== 'milestone' && (
-                            <IconButton
-                              size="small"
-                              onClick={() => setEditTask(params.row)}
-                            >
-                              <EditIcon fontSize="small" />
-                            </IconButton>
-                          )}
+                          <IconButton size="small" onClick={() => setEditTask(params.row)}>
+                            <EditIcon fontSize="small" />
+                          </IconButton>
                           <IconButton size="small" onClick={() => handleDelete(params.row)}>
                             <DeleteIcon fontSize="small" />
                           </IconButton>


### PR DESCRIPTION
## Summary
- remove condition preventing edit button for milestone tasks

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6863a86872c48328ade957e780375d8c