### PR TITLE
Ensure Mongo indexes on startup

### DIFF
--- a/service/src/app.module.ts
+++ b/service/src/app.module.ts
@@ -14,10 +14,14 @@ import { RolesModule } from './roles/roles.module';
 import { WorkdaysModule } from './workdays/workdays.module';
 import { ActivityLogsModule } from './activity-logs/activity-logs.module';
 import { PlanningModule } from './planning/planning.module';
+import { IndexInitializer } from './index.initializer';
 
 @Module({
   imports: [
-    MongooseModule.forRoot(process.env.MONGO_URL || 'mongodb://mongo:27017/budget'),
+    MongooseModule.forRoot(
+      process.env.MONGO_URL || 'mongodb://mongo:27017/budget',
+      { autoIndex: true },
+    ),
     RedisModule,
     UsersModule,
     ResourcesModule,
@@ -32,7 +36,7 @@ import { PlanningModule } from './planning/planning.module';
     ActivityLogsModule,
     PlanningModule,
   ],
-  providers: [LoggerService],
+  providers: [LoggerService, IndexInitializer],
   exports: [LoggerService],
 })
 export class AppModule {}

--- a/service/src/index.initializer.ts
+++ b/service/src/index.initializer.ts
@@ -1,0 +1,26 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { InjectConnection } from '@nestjs/mongoose';
+import { Connection } from 'mongoose';
+import { LoggerService } from './logger/logger.service';
+
+@Injectable()
+export class IndexInitializer implements OnModuleInit {
+  constructor(
+    @InjectConnection() private readonly connection: Connection,
+    private readonly logger: LoggerService,
+  ) {}
+
+  async onModuleInit() {
+    for (const name of this.connection.modelNames()) {
+      try {
+        await this.connection.model(name).createIndexes();
+        this.logger.logApp('info', { msg: `indexes ensured for ${name}` });
+      } catch (err: any) {
+        this.logger.logApp('error', {
+          msg: `failed to create indexes for ${name}`,
+          error: err.message,
+        });
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create `IndexInitializer` service to build Mongo indexes on module init
- configure Mongoose to enable `autoIndex`

## Testing
- `npm --prefix service run build`
- `npm --prefix service test`


------
https://chatgpt.com/codex/tasks/task_e_6863ab58c9908328bfdac930130cae76