### PR TITLE
Update planning task defaults

### DIFF
--- a/client/components/TaskForm.tsx
+++ b/client/components/TaskForm.tsx
@@ -18,7 +18,8 @@ export default function TaskForm({ onSubmit, initial, members = [], tasks = [] }
   const [duration, setDuration] = useState(initial?.duration != null ? String(initial.duration) : '');
   const [blocked, setBlocked] = useState(null);
   const [taskType, setTaskType] = useState(
-    initial?.type || (initial?.isFeature ? 'feature' : 'milestone')
+    initial?.type ||
+      (initial ? (initial.isFeature ? 'feature' : 'milestone') : 'feature')
   );
 
   useEffect(() => {
@@ -30,7 +31,10 @@ export default function TaskForm({ onSubmit, initial, members = [], tasks = [] }
     setManday(initial?.manday != null ? String(initial.manday) : '');
     setDuration(initial?.duration != null ? String(initial.duration) : '');
     setBlocked(null);
-    setTaskType(initial?.type || (initial?.isFeature ? 'feature' : 'milestone'));
+    setTaskType(
+      initial?.type ||
+        (initial ? (initial.isFeature ? 'feature' : 'milestone') : 'feature')
+    );
   }, [initial]);
 
   const dateError = useMemo(
@@ -67,28 +71,18 @@ export default function TaskForm({ onSubmit, initial, members = [], tasks = [] }
   const handleSubmit = e => {
     e.preventDefault();
     if (!formValid) return;
-    if (taskType === 'milestone') {
-      onSubmit &&
-        onSubmit({
-          name,
-          detail,
-          startDate,
-          type: taskType,
-        });
-    } else {
-      onSubmit &&
-        onSubmit({
-          name,
-          detail,
-          startDate,
-          endDate,
-          owner,
-          manday: manday ? Number(manday) : undefined,
-          duration: duration ? Number(duration) : undefined,
-          blockedBy: blocked ? blocked.id : undefined,
-          type: taskType,
-        });
-    }
+    onSubmit &&
+      onSubmit({
+        name,
+        detail,
+        startDate,
+        endDate,
+        owner,
+        manday: manday ? Number(manday) : undefined,
+        duration: duration ? Number(duration) : undefined,
+        blockedBy: blocked ? blocked.id : undefined,
+        type: taskType,
+      });
     setName('');
     setDetail('');
     setStartDate(null);
@@ -104,54 +98,45 @@ export default function TaskForm({ onSubmit, initial, members = [], tasks = [] }
     <form onSubmit={handleSubmit}>
       <TextField label="Name" value={name} onChange={e => setName(e.target.value)} fullWidth required sx={{ mb: 2 }} />
       <TextField label="Detail" value={detail} onChange={e => setDetail(e.target.value)} fullWidth multiline sx={{ mb: 2 }} />
-      {taskType === 'milestone' ? (
+      <>
         <DatePicker
-          label="Date"
+          label="Start Date"
           value={startDate}
           onChange={setStartDate}
           sx={{ mb: 2 }}
+          slotProps={{ textField: { error: dateError } }}
         />
-      ) : (
-        <>
-          <DatePicker
-            label="Start Date"
-            value={startDate}
-            onChange={setStartDate}
-            sx={{ mb: 2 }}
-            slotProps={{ textField: { error: dateError } }}
-          />
-          <DatePicker
-            label="End Date"
-            value={endDate}
-            onChange={setEndDate}
-            sx={{ mb: 2 }}
-            slotProps={{
-              textField: {
-                error: dateError,
-                helperText: dateError ? 'End date must be after start date' : undefined,
-              },
-            }}
-          />
-          <TextField label="Duration (days)" type="number" value={duration} onChange={e => setDuration(e.target.value)} fullWidth sx={{ mb: 2 }} />
-          <Autocomplete
-            options={members}
-            getOptionLabel={o => o.name}
-            value={members.find(m => m.id === owner) || null}
-            onChange={(_, v) => setOwner(v ? v.id : '')}
-            renderInput={params => <TextField {...params} label="Owner" />}
-            sx={{ mb: 2 }}
-          />
-          <TextField label="Manday" type="number" value={manday} onChange={e => setManday(e.target.value)} fullWidth sx={{ mb: 2 }} />
-          <Autocomplete
-            options={tasks.map(t => ({ id: t._id || t.id, label: t.name, date: t.endDate }))}
-            getOptionLabel={o => o.label}
-            value={blocked}
-            onChange={(_, v) => setBlocked(v)}
-            renderInput={params => <TextField {...params} label="Blocked By" />}
-            sx={{ mb: 2 }}
-          />
-        </>
-      )}
+        <DatePicker
+          label="End Date"
+          value={endDate}
+          onChange={setEndDate}
+          sx={{ mb: 2 }}
+          slotProps={{
+            textField: {
+              error: dateError,
+              helperText: dateError ? 'End date must be after start date' : undefined,
+            },
+          }}
+        />
+        <TextField label="Duration (days)" type="number" value={duration} onChange={e => setDuration(e.target.value)} fullWidth sx={{ mb: 2 }} />
+        <Autocomplete
+          options={members}
+          getOptionLabel={o => o.name}
+          value={members.find(m => m.id === owner) || null}
+          onChange={(_, v) => setOwner(v ? v.id : '')}
+          renderInput={params => <TextField {...params} label="Owner" />}
+          sx={{ mb: 2 }}
+        />
+        <TextField label="Manday" type="number" value={manday} onChange={e => setManday(e.target.value)} fullWidth sx={{ mb: 2 }} />
+        <Autocomplete
+          options={tasks.map(t => ({ id: t._id || t.id, label: t.name, date: t.endDate }))}
+          getOptionLabel={o => o.label}
+          value={blocked}
+          onChange={(_, v) => setBlocked(v)}
+          renderInput={params => <TextField {...params} label="Blocked By" />}
+          sx={{ mb: 2 }}
+        />
+      </>
       <ToggleButtonGroup
         value={taskType}
         exclusive
@@ -159,7 +144,7 @@ export default function TaskForm({ onSubmit, initial, members = [], tasks = [] }
         size="small"
         sx={{ mb: 2 }}
       >
-        <ToggleButton value="feature">Feature</ToggleButton>
+        <ToggleButton value="feature">Task</ToggleButton>
         <ToggleButton value="milestone">Milestone</ToggleButton>
       </ToggleButtonGroup>
       <Button

--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -478,10 +478,10 @@ function PlanningSetting() {
             {/* closing tag for outer Grid container */}
             </Grid>
           )}
-        <Popup open={dialog === 'task'} onClose={() => setDialog('')} title="Add Task/Feature">
+        <Popup open={dialog === 'task'} onClose={() => setDialog('')} title="Add Task">
           <TaskForm onSubmit={handleCreateTask} members={members} tasks={tasks} />
         </Popup>
-        <Popup open={!!editTask} onClose={() => setEditTask(null)} title="Edit Task/Feature">
+        <Popup open={!!editTask} onClose={() => setEditTask(null)} title="Edit Task">
           {editTask && (
             <TaskForm
               onSubmit={handleUpdateTask}


### PR DESCRIPTION
## Summary
- default new tasks to "task" type instead of milestone
- rename dialog titles to "Add Task" and "Edit Task"
- always include full task fields for milestone
- show "Task" label in form toggle

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6863ac293c4c8328b7fa3e7b748d9071