### PR TITLE
Remove any usage in client interfaces

### DIFF
--- a/client/models/projectsModel.ts
+++ b/client/models/projectsModel.ts
@@ -1,12 +1,29 @@
 import api from '../api';
 import { sanitizeList } from '../utils/sanitize';
 
+export interface ProjectUpdate {
+  name?: string;
+  description?: string;
+  resources?: number;
+  start?: Date;
+  sprintStart?: Date;
+  end?: Date;
+  manday?: number;
+  sprintLength?: number;
+  priority?: number;
+  lead?: string;
+  status?: string;
+  members?: string[];
+  deleted?: boolean;
+  deletedAt?: Date;
+}
+
 export async function fetchProjects() {
   const { data } = await api.get('/api/v1/projects');
   return sanitizeList(data);
 }
 
-export async function updateProject(id: string, project: any) {
+export async function updateProject(id: string, project: ProjectUpdate) {
   const { data } = await api.patch(`/api/v1/projects/${id}`, project);
   return data;
 }

--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -73,7 +73,7 @@ function PlanningSetting() {
     'cancelled',
   ];
 
-  const statusColors: Record<string, any> = {
+  const statusColors: Record<string, string> = {
     planing: 'default',
     'in progress': 'info',
     break: 'warning',
@@ -83,7 +83,8 @@ function PlanningSetting() {
     cancelled: 'error',
   };
 
-  const cleanList = (items: any[]) => sanitizeList(items);
+  const cleanList = <T extends Record<string, unknown>>(items: T[]) =>
+    sanitizeList(items);
 
   useEffect(() => {
     if (!router.isReady) return;

--- a/client/pages/project-management.tsx
+++ b/client/pages/project-management.tsx
@@ -33,7 +33,7 @@ const statusOptions = [
   'cancelled',
 ];
 
-const statusColors: Record<string, any> = {
+const statusColors: Record<string, string> = {
   planing: 'default',
   'in progress': 'info',
   break: 'warning',

--- a/client/pages/summary/overview.tsx
+++ b/client/pages/summary/overview.tsx
@@ -21,6 +21,22 @@ import { withAuth } from '../../context/AuthContext';
 import { fetchBudgetOverview } from '../../models/budgetModel';
 import api from '../../api';
 
+interface LevelSummary {
+  headcount: number;
+  manday: number;
+  available: number;
+  avgRate: number;
+}
+
+interface RoleSummary {
+  role: string;
+  headcount: number;
+  manday: number;
+  available: number;
+  rateSum: number;
+  levels: Record<string, LevelSummary>;
+}
+
 function DashboardOverview() {
   const [overview, setOverview] = useState([]);
   const [resources, setResources] = useState([]);
@@ -160,7 +176,10 @@ function DashboardOverview() {
     positionMap[slug] = { role: o.role, level: o.level, rate: o.rate, count: o.count };
   });
 
-  const rolesSummary: Record<string, any> = {};
+  const rolesSummary: Record<string, RoleSummary> = {} as Record<
+    string,
+    RoleSummary
+  >;
   Object.values(positionMap).forEach(p => {
     if (!rolesSummary[p.role]) {
       rolesSummary[p.role] = {
@@ -169,7 +188,7 @@ function DashboardOverview() {
         manday: 0,
         available: 0,
         rateSum: 0,
-        levels: {},
+        levels: {} as Record<string, LevelSummary>,
       };
     }
     rolesSummary[p.role].headcount += p.count;

--- a/client/utils/sanitize.ts
+++ b/client/utils/sanitize.ts
@@ -1,4 +1,4 @@
-export function sanitizeList<T extends Record<string, any>>(items: T[]): T[] {
+export function sanitizeList<T extends Record<string, unknown>>(items: T[]): T[] {
   return items.map(item => {
     if (item && typeof item.onClick !== 'undefined') {
       const { onClick, ...rest } = item;


### PR DESCRIPTION
## Summary
- avoid `any` in sanitize utility
- define `ProjectUpdate` type for project model
- type project status color maps with strings
- strengthen summary overview types

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6863ac9a78548328832f78b5158bf2ef