### PR TITLE
Add admin settings module

### DIFF
--- a/client/components/ProjectForm.tsx
+++ b/client/components/ProjectForm.tsx
@@ -15,6 +15,7 @@ import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import MenuItem from '@mui/material/MenuItem';
+import { fetchSettings } from '../models/settingsModel';
 
 export default function ProjectForm({
   users = [],
@@ -33,6 +34,7 @@ export default function ProjectForm({
   const [status, setStatus] = useState(initial?.status || 'planing');
   const [lead, setLead] = useState(initial?.lead || null);
   const [members, setMembers] = useState(initial?.members || []);
+  const [multiplier, setMultiplier] = useState(1);
   const [manday, setManday] = useState(
     initial?.manday != null ? String(initial.manday) : ''
   );
@@ -62,6 +64,16 @@ export default function ProjectForm({
       setSprintStart(null);
     }
   }, [open]);
+
+  useEffect(() => {
+    fetchSettings()
+      .then(data => {
+        if (data?.costMultiplier != null) {
+          setMultiplier(Number(data.costMultiplier));
+        }
+      })
+      .catch(() => {});
+  }, []);
 
   const handleNext = () => setActive(a => Math.min(a + 1, 3));
   const handleBack = () => setActive(a => Math.max(a - 1, 0));
@@ -127,12 +139,12 @@ export default function ProjectForm({
     });
     const rows = Object.entries(counts).map(([pos, count]) => {
       const rate = rateMap[pos] || 0;
-      const cost = count * rate * 0.83; // apply 17% reduction
+      const cost = count * rate * multiplier;
       return { pos, count, rate, cost };
     });
     const total = rows.reduce((s, r) => s + r.cost, 0);
     return { rows, total };
-  }, [lead, members, rateMap]);
+  }, [lead, members, rateMap, multiplier]);
 
   const currencyFormatter = useMemo(
     () => new Intl.NumberFormat('th-TH', { style: 'currency', currency: 'THB' }),

--- a/client/components/Topbar.tsx
+++ b/client/components/Topbar.tsx
@@ -72,6 +72,14 @@ export default function Topbar({ onMenuClick }) {
           <MenuItem
             onClick={() => {
               handleClose();
+              router.push('/settings');
+            }}
+          >
+            Settings
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              handleClose();
               logout();
             }}
           >

--- a/client/models/settingsModel.ts
+++ b/client/models/settingsModel.ts
@@ -1,0 +1,16 @@
+import api from '../api';
+
+export async function fetchSettings() {
+  const { data } = await api.get('/api/v1/settings');
+  return data;
+}
+
+export async function updateCostMultiplier(value: number) {
+  const { data } = await api.patch('/api/v1/settings/costMultiplier', { value });
+  return data;
+}
+
+export async function resetAdminPassword(password: string) {
+  const { data } = await api.post('/api/v1/settings/reset-admin', { password });
+  return data;
+}

--- a/client/pages/project/[id].tsx
+++ b/client/pages/project/[id].tsx
@@ -17,6 +17,7 @@ import { Layout, Popup, ProjectForm, useToast, PageLoading } from '../../compone
 import { withAuth } from '../../context/AuthContext';
 import { differenceInDays, addDays, format, isAfter } from 'date-fns';
 import { fetchWorkdays } from '../../models/workdayModel';
+import { fetchSettings } from '../../models/settingsModel';
 
 function ProjectDetail() {
   const router = useRouter();
@@ -29,6 +30,7 @@ function ProjectDetail() {
   const [positions, setPositions] = useState([]);
   const [holidays, setHolidays] = useState<Record<string, boolean>>({});
   const [open, setOpen] = useState(false);
+  const [multiplier, setMultiplier] = useState(1);
 
   useEffect(() => {
     if (id) {
@@ -44,6 +46,13 @@ function ProjectDetail() {
         setTeams(t.data);
         setBudgets(b.data);
         setPositions(pos.data);
+        fetchSettings()
+          .then(s => {
+            if (s?.costMultiplier != null) {
+              setMultiplier(Number(s.costMultiplier));
+            }
+          })
+          .catch(() => {});
       });
     }
   }, [id]);
@@ -105,10 +114,9 @@ function ProjectDetail() {
     m[b.id] = b.rate;
     return m;
   }, {} as Record<string, number>);
-  const dailyCost = uniqueMembers.reduce(
-    (s, r) => s + (rateMap[r.position] || 0),
-    0,
-  );
+  const dailyCost =
+    uniqueMembers.reduce((s, r) => s + (rateMap[r.position] || 0), 0) *
+    multiplier;
   const workStart = project?.start ? new Date(project.start) : null;
   const workEnd = project?.end ? new Date(project.end) : new Date();
   const lastDay = workEnd && isAfter(workEnd, new Date()) ? new Date() : workEnd;

--- a/client/pages/settings.tsx
+++ b/client/pages/settings.tsx
@@ -1,0 +1,93 @@
+// @ts-nocheck
+import { useEffect, useState } from 'react';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import { Layout, PageBreadcrumbs, useToast } from '../components';
+import { withAuth, useAuth } from '../context/AuthContext';
+import {
+  fetchSettings,
+  updateCostMultiplier,
+  resetAdminPassword,
+} from '../models/settingsModel';
+
+function SettingsPage() {
+  const { token } = useAuth();
+  const { showToast } = useToast();
+  const [cost, setCost] = useState('1');
+  const [password, setPassword] = useState('');
+
+  useEffect(() => {
+    if (!token) return;
+    fetchSettings()
+      .then(data => {
+        if (data?.costMultiplier != null) {
+          setCost(String(data.costMultiplier));
+        }
+      })
+      .catch(console.error);
+  }, [token]);
+
+  const handleSaveCost = async () => {
+    try {
+      await updateCostMultiplier(Number(cost));
+      showToast('Cost multiplier saved');
+    } catch (e) {
+      showToast('Error saving', { severity: 'error' });
+    }
+  };
+
+  const handleReset = async () => {
+    try {
+      await resetAdminPassword(password);
+      setPassword('');
+      showToast('Password updated');
+    } catch (e) {
+      showToast('Error updating password', { severity: 'error' });
+    }
+  };
+
+  return (
+    <Layout>
+      <Container maxWidth={false} sx={{ mt: 4 }}>
+        <Typography variant="h5" gutterBottom>
+          Settings
+        </Typography>
+        <PageBreadcrumbs items={[{ label: 'Settings' }]} />
+        <Box sx={{ my: 2 }}>
+          <Typography variant="h6">Cost Multiplier</Typography>
+          <TextField
+            size="small"
+            type="number"
+            label="Multiplier"
+            value={cost}
+            onChange={e => setCost(e.target.value)}
+            sx={{ mr: 1, width: 120 }}
+            inputProps={{ step: '0.01', min: '0', max: '1' }}
+          />
+          <Button variant="contained" onClick={handleSaveCost}>
+            Save
+          </Button>
+        </Box>
+        <Box sx={{ my: 2 }}>
+          <Typography variant="h6">Reset Admin Password</Typography>
+          <TextField
+            size="small"
+            type="password"
+            label="New Password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            sx={{ mr: 1, width: 200 }}
+          />
+          <Button variant="contained" onClick={handleReset}>
+            Reset
+          </Button>
+        </Box>
+      </Container>
+    </Layout>
+  );
+}
+
+export default withAuth(SettingsPage);

--- a/client/pages/summary/detail.tsx
+++ b/client/pages/summary/detail.tsx
@@ -26,12 +26,14 @@ import { fetchProjects } from '../../models/projectsModel';
 import { fetchTeams } from '../../models/teamModel';
 import { fetchResources } from '../../models/resourceModel';
 import { fetchBudgets } from '../../models/budgetModel';
+import { fetchSettings } from '../../models/settingsModel';
 
 function DashboardDetail() {
   const [projects, setProjects] = useState([]);
   const [teams, setTeams] = useState([]);
   const [resources, setResources] = useState([]);
   const [budgets, setBudgets] = useState([]);
+  const [costMultiplier, setCostMultiplier] = useState(1);
 
   const [projectFilter, setProjectFilter] = useState([]);
   const [teamFilter, setTeamFilter] = useState([]);
@@ -48,8 +50,9 @@ function DashboardDetail() {
       fetchTeams(),
       fetchResources(),
       fetchBudgets(),
+      fetchSettings(),
     ])
-      .then(([p, t, r, b]) => {
+      .then(([p, t, r, b, s]) => {
         const activeProjects = Array.isArray(p)
           ? p.filter(pr => !pr.deleted)
           : [];
@@ -57,6 +60,9 @@ function DashboardDetail() {
         setTeams(t);
         setResources(r);
         setBudgets(b);
+        if (s?.costMultiplier != null) {
+          setCostMultiplier(Number(s.costMultiplier));
+        }
       })
       .catch(console.error);
   }, []);
@@ -118,7 +124,7 @@ function DashboardDetail() {
     filteredResources.forEach(r => {
       const days = differenceInDays(today, new Date(r.startDate || today)) + 1;
       const rate = rateMap[r.position] || 0;
-      const cost = days * rate;
+      const cost = days * rate * costMultiplier;
       total += cost;
       const role = r.position.split('_')[0];
       byRole[role] = (byRole[role] || 0) + cost;
@@ -141,7 +147,7 @@ function DashboardDetail() {
       avgRate[role] = roleRes.length ? sumRate / roleRes.length : 0;
     });
     return { total, byRole, avgRate, resourceRows };
-  }, [filteredResources, rateMap]);
+  }, [filteredResources, rateMap, costMultiplier]);
 
   const mandayChartData = [
     { label: 'Estimated', value: mandaySummary.est },

--- a/client/pages/summary/overview.tsx
+++ b/client/pages/summary/overview.tsx
@@ -20,6 +20,7 @@ import PersonOffIcon from '@mui/icons-material/PersonOff';
 import { withAuth } from '../../context/AuthContext';
 import { fetchBudgetOverview } from '../../models/budgetModel';
 import api from '../../api';
+import { fetchSettings } from '../../models/settingsModel';
 
 interface LevelSummary {
   headcount: number;
@@ -45,19 +46,24 @@ function DashboardOverview() {
   const [dailyManday, setDailyManday] = useState([]);
   const [dailyCost, setDailyCost] = useState([]);
   const [utilData, setUtilData] = useState([]);
+  const [costMultiplier, setCostMultiplier] = useState(1);
 
   const totalProjects = projects.length;
   const totalResources = resources.length;
 
   async function loadData() {
-    const [ov, res, pro] = await Promise.all([
+    const [ov, res, pro, set] = await Promise.all([
       fetchBudgetOverview(),
       api.get('/api/v1/resources'),
       api.get('/api/v1/projects'),
+      fetchSettings(),
     ]);
     setOverview(ov);
     setResources(res.data);
     setProjects(pro.data);
+    if (set?.costMultiplier != null) {
+      setCostMultiplier(Number(set.costMultiplier));
+    }
 
     const assigned = new Set();
     pro.data.forEach(p => {
@@ -121,7 +127,8 @@ function DashboardOverview() {
           const rs = new Date(r.startDate || Date.now());
           if (d >= rs) {
             const role = roleMap[r.position] || 'Other';
-            byRole[role] = (byRole[role] || 0) + (rateMap[r.position] || 0);
+            byRole[role] =
+              (byRole[role] || 0) + (rateMap[r.position] || 0) * costMultiplier;
           }
         });
         cost.unshift({ date: dateStr, ...byRole });
@@ -150,7 +157,10 @@ function DashboardOverview() {
     loadData();
   }, []);
 
-  const totalCost = overview.reduce((sum, o) => sum + o.count * o.rate, 0);
+  const totalCost = overview.reduce(
+    (sum, o) => sum + o.count * o.rate * costMultiplier,
+    0,
+  );
   const costData = Array.from({ length: 6 }, (_, i) => ({
     month: `M${i + 1}`,
     cost: Math.round(totalCost * Math.pow(0.9, i)),

--- a/service/src/app.module.ts
+++ b/service/src/app.module.ts
@@ -14,6 +14,7 @@ import { RolesModule } from './roles/roles.module';
 import { WorkdaysModule } from './workdays/workdays.module';
 import { ActivityLogsModule } from './activity-logs/activity-logs.module';
 import { PlanningModule } from './planning/planning.module';
+import { SettingsModule } from './settings/settings.module';
 import { IndexInitializer } from './index.initializer';
 
 @Module({
@@ -35,6 +36,7 @@ import { IndexInitializer } from './index.initializer';
     WorkdaysModule,
     ActivityLogsModule,
     PlanningModule,
+    SettingsModule,
   ],
   providers: [LoggerService, IndexInitializer],
   exports: [LoggerService],

--- a/service/src/settings/data/setting.schema.ts
+++ b/service/src/settings/data/setting.schema.ts
@@ -1,0 +1,13 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class Setting extends Document {
+  @Prop({ required: true, unique: true })
+  key: string;
+
+  @Prop()
+  value: any;
+}
+
+export const SettingSchema = SchemaFactory.createForClass(Setting);

--- a/service/src/settings/data/settings.repository.ts
+++ b/service/src/settings/data/settings.repository.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Setting } from './setting.schema';
+
+@Injectable()
+export class SettingsRepository {
+  constructor(@InjectModel(Setting.name) private readonly model: Model<Setting>) {}
+
+  findByKey(key: string): Promise<Setting | null> {
+    return this.model.findOne({ key }).exec();
+  }
+
+  async setValue(key: string, value: any): Promise<Setting> {
+    return this.model
+      .findOneAndUpdate({ key }, { value }, { upsert: true, new: true })
+      .exec();
+  }
+}

--- a/service/src/settings/settings.controller.ts
+++ b/service/src/settings/settings.controller.ts
@@ -1,0 +1,23 @@
+import { Body, Controller, Get, Patch, Post } from '@nestjs/common';
+import { SettingsService } from './settings.service';
+
+@Controller('settings')
+export class SettingsController {
+  constructor(private readonly service: SettingsService) {}
+
+  @Get()
+  async getSettings() {
+    const costMultiplier = await this.service.getCostMultiplier();
+    return { costMultiplier };
+  }
+
+  @Patch('costMultiplier')
+  setCost(@Body() body: { value: number }) {
+    return this.service.setCostMultiplier(body.value);
+  }
+
+  @Post('reset-admin')
+  resetAdmin(@Body() body: { password: string }) {
+    return this.service.resetAdminPassword(body.password);
+  }
+}

--- a/service/src/settings/settings.module.ts
+++ b/service/src/settings/settings.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { SettingsController } from './settings.controller';
+import { SettingsService } from './settings.service';
+import { SettingsRepository } from './data/settings.repository';
+import { Setting, SettingSchema } from './data/setting.schema';
+import { UsersModule } from '../users/users.module';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Setting.name, schema: SettingSchema }]),
+    UsersModule,
+  ],
+  controllers: [SettingsController],
+  providers: [SettingsService, SettingsRepository],
+  exports: [SettingsService],
+})
+export class SettingsModule {}

--- a/service/src/settings/settings.service.ts
+++ b/service/src/settings/settings.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import * as bcrypt from 'bcryptjs';
+import { SettingsRepository } from './data/settings.repository';
+import { UsersRepository } from '../users/data/users.repository';
+
+@Injectable()
+export class SettingsService {
+  constructor(
+    private readonly repo: SettingsRepository,
+    private readonly users: UsersRepository,
+  ) {}
+
+  async getCostMultiplier(): Promise<number> {
+    const setting = await this.repo.findByKey('costMultiplier');
+    return setting?.value != null ? Number(setting.value) : 1;
+  }
+
+  async setCostMultiplier(value: number): Promise<void> {
+    await this.repo.setValue('costMultiplier', value);
+  }
+
+  async resetAdminPassword(password: string): Promise<void> {
+    const user = await this.users.findByUsername('admin');
+    if (user) {
+      const hash = bcrypt.hashSync(password, 10);
+      await this.users.updatePassword(user._id.toString(), hash);
+    }
+  }
+}

--- a/service/src/users/data/users.repository.ts
+++ b/service/src/users/data/users.repository.ts
@@ -23,4 +23,10 @@ export class UsersRepository {
     const user = new this.userModel({ username, passwordHash });
     return user.save();
   }
+
+  updatePassword(id: string, passwordHash: string): Promise<User | null> {
+    return this.userModel
+      .findByIdAndUpdate(id, { passwordHash }, { new: true })
+      .exec();
+  }
 }


### PR DESCRIPTION
## Summary
- add settings backend to store cost multiplier and reset admin password
- expose `/settings` endpoints via SettingsModule
- fetch settings in client and update cost calculations
- show Settings page and link it in user menu

## Testing
- `npm --prefix service run build`
- `npm --prefix service test`

------
https://chatgpt.com/codex/tasks/task_e_6863d5211314832897ba56cf263827e1