### PR TITLE
Fix schema type for settings

### DIFF
--- a/service/src/settings/data/setting.schema.ts
+++ b/service/src/settings/data/setting.schema.ts
@@ -1,12 +1,12 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Document } from 'mongoose';
+import { Document, SchemaTypes } from 'mongoose';
 
 @Schema({ timestamps: true })
 export class Setting extends Document {
   @Prop({ required: true, unique: true })
   key: string;
 
-  @Prop()
+  @Prop({ type: SchemaTypes.Mixed })
   value: any;
 }
 


### PR DESCRIPTION
## Summary
- fix Setting schema when storing generic values

## Testing
- `npm run check` in `service`

------
https://chatgpt.com/codex/tasks/task_e_6864019376a08328945f22ad573f702b