### PR TITLE
Fix budget delete button

### DIFF
--- a/client/components/BudgetTable.tsx
+++ b/client/components/BudgetTable.tsx
@@ -61,7 +61,7 @@ export default function BudgetTable({ data, onEdit, onDelete }) {
               <EditIcon fontSize="small" />
             </IconButton>
           )}
-          {onDelete && (
+          {onDelete && params.row.budgetId && (
             <IconButton size="small" onClick={() => onDelete(params.row)}>
               <DeleteIcon fontSize="small" />
             </IconButton>

--- a/client/pages/budget-management/index.tsx
+++ b/client/pages/budget-management/index.tsx
@@ -63,9 +63,11 @@ function BudgetManagement() {
 
   const confirmDelete = async () => {
     try {
-      await deleteBudget(deleteRow.budgetId);
-      showToast('Rate deleted');
-      loadData();
+      if (deleteRow?.budgetId) {
+        await deleteBudget(deleteRow.budgetId);
+        showToast('Rate deleted');
+        loadData();
+      }
     } catch (e) {
       showToast('Error deleting rate', { severity: 'error' });
     }


### PR DESCRIPTION
## Summary
- disable Delete action in Budget table when no budgetId exists
- guard the delete handler against undefined budgetId

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_686543dfc1b88328ad92250f4b7d72b3