### PR TITLE
Add project progress display

### DIFF
--- a/client/components/AgendaCalendar.tsx
+++ b/client/components/AgendaCalendar.tsx
@@ -104,6 +104,11 @@ export default function AgendaCalendar({
         <Box component="span" sx={{ fontSize: 12, mr: 0.5 }}>
           {event.title}
         </Box>
+        {typeof res.progress === 'number' && (
+          <Box component="span" sx={{ fontSize: 12, mr: 0.5 }}>
+            {res.progress}%
+          </Box>
+        )}
         <Box
           component="span"
           sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: stringToColor(res.status || 'none') }}

--- a/client/pages/plan-management/index.tsx
+++ b/client/pages/plan-management/index.tsx
@@ -11,6 +11,7 @@ import { fetchEvents } from '../../models/eventsModel';
 import { fetchProjects, updateProject } from '../../models/projectsModel';
 import { fetchTasks } from '../../models/tasksModel';
 import { fetchWorkdays } from '../../models/workdayModel';
+import { differenceInCalendarDays } from 'date-fns';
 import Timeline from '@mui/lab/Timeline';
 import TimelineItem from '@mui/lab/TimelineItem';
 import TimelineSeparator from '@mui/lab/TimelineSeparator';
@@ -19,6 +20,7 @@ import TimelineContent from '@mui/lab/TimelineContent';
 import TimelineDot from '@mui/lab/TimelineDot';
 import { Layout, AgendaCalendar, PageBreadcrumbs } from '../../components';
 import { withAuth } from '../../context/AuthContext';
+import LinearProgress from '@mui/material/LinearProgress';
 
 function PlanManagementOverview() {
   const [view, setView] = useState('calendar');
@@ -26,6 +28,23 @@ function PlanManagementOverview() {
   const [projects, setProjects] = useState([]);
   const [holidays, setHolidays] = useState([]);
   const router = useRouter();
+
+  const calcProgress = (p: any) => {
+    try {
+      const start = p.start ? new Date(p.start) : null;
+      const end = p.end ? new Date(p.end) : null;
+      if (!start || !end) return 0;
+      if (end.getTime() <= start.getTime()) return 0;
+      const now = new Date();
+      if (now.getTime() <= start.getTime()) return 0;
+      if (now.getTime() >= end.getTime()) return 100;
+      const total = differenceInCalendarDays(end, start);
+      const done = differenceInCalendarDays(now, start);
+      return Math.round((done / total) * 100);
+    } catch {
+      return 0;
+    }
+  };
 
   useEffect(() => {
     const year = new Date().getFullYear();
@@ -88,6 +107,7 @@ function PlanManagementOverview() {
                 endDate: p.end,
                 owner: p.lead?.name || '',
                 status: p.status,
+                progress: calcProgress(p),
               }))}
               events={events}
               holidays={holidays}
@@ -110,7 +130,19 @@ function PlanManagementOverview() {
                     onClick={() => router.push(`/project/${p._id || p.id}`)}
                     sx={{ cursor: 'pointer' }}
                   >
-                    {p.name} ({new Date(p.start).toLocaleDateString()} - {new Date(p.end).toLocaleDateString()})
+                    <Box>
+                      <Typography variant="body1">
+                        {p.name} ({new Date(p.start).toLocaleDateString()} - {new Date(p.end).toLocaleDateString()})
+                      </Typography>
+                      <Box sx={{ display: 'flex', alignItems: 'center', mt: 0.5 }}>
+                        <LinearProgress
+                          variant="determinate"
+                          value={calcProgress(p)}
+                          sx={{ flexGrow: 1, height: 8, borderRadius: 5, mr: 1 }}
+                        />
+                        <Typography variant="caption">{calcProgress(p)}%</Typography>
+                      </Box>
+                    </Box>
                   </TimelineContent>
                 </TimelineItem>
               ))}


### PR DESCRIPTION
## Summary
- compute progress based on current date and project end date
- display progress in timeline view with a progress bar
- show progress percent inside calendar events

## Testing
- `npm test` *(fails: jest not found)*
- `npm run check` in client *(fails: next not found)*
- `npm run check` in service *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865491ef6b8832885d8039e8fdb8f15