### PR TITLE
Add project timeline view

### DIFF
--- a/client/components/ProjectTimeline.tsx
+++ b/client/components/ProjectTimeline.tsx
@@ -1,0 +1,85 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+interface Task {
+  name: string;
+  startDate?: string | Date;
+  endDate?: string | Date;
+  type?: string;
+}
+
+interface Project {
+  _id?: string;
+  id?: string;
+  name: string;
+  start?: string | Date;
+  end?: string | Date;
+  tasks?: Task[];
+}
+
+function stringToColor(name: string) {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const h = hash % 360;
+  return `hsl(${h},70%,60%)`;
+}
+
+export default function ProjectTimeline({ projects, year = new Date().getFullYear() }: { projects: Project[]; year?: number }) {
+  const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  const startYear = new Date(year, 0, 1).getTime();
+  const endYear = new Date(year, 11, 31).getTime();
+  const range = endYear - startYear;
+
+  const renderTask = (t: Task, color: string, key: number) => {
+    const s = new Date(t.startDate || t.endDate || Date.now()).getTime();
+    const e = new Date(t.endDate || t.startDate || t.endDate || Date.now()).getTime();
+    if (isNaN(s)) return null;
+    const start = Math.max(s, startYear);
+    const end = Math.max(start, Math.min(e || s, endYear));
+    const left = ((start - startYear) / range) * 100;
+    const width = ((end - start) / range) * 100 || 0.5;
+    const isMilestone = t.type === 'milestone' || width < 1;
+    return (
+      <Box key={key} sx={{ position: 'absolute', left: `${left}%`, width: isMilestone ? 8 : `${width}%`, minWidth: isMilestone ? 8 : 'auto', height: 14, bgcolor: color, borderRadius: 2 }}>
+        {isMilestone && (
+          <Box sx={{ position: 'absolute', top: -3, left: '50%', width: 8, height: 8, bgcolor: color, borderRadius: '50%', transform: 'translateX(-50%)' }} />
+        )}
+        {!isMilestone && (
+          <Typography sx={{ fontSize: 10, color: '#fff', pl: 0.5, whiteSpace: 'nowrap', overflow: 'hidden' }}>{t.name}</Typography>
+        )}
+      </Box>
+    );
+  };
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      <Box sx={{ display: 'flex', ml: 16 }}>
+        {months.map(m => (
+          <Box key={m} sx={{ flex: 1, textAlign: 'center', fontWeight: 'bold', fontSize: 12 }}>
+            {m}
+          </Box>
+        ))}
+      </Box>
+      {projects.map((p, idx) => {
+        const color = stringToColor(p.name + idx);
+        return (
+          <Box key={p._id || p.id || idx} sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+            <Box sx={{ width: 160, pr: 1 }}>
+              <Typography variant="body2" noWrap>
+                {p.name}
+              </Typography>
+            </Box>
+            <Box sx={{ flex: 1, position: 'relative', height: 20, borderBottom: '1px solid #ddd' }}>
+              {p.tasks?.map((t, i) => renderTask(t, color, i))}
+            </Box>
+          </Box>
+        );
+      })}
+      <Typography variant="body2" sx={{ mt: 2 }}>
+        Use this view to monitor project schedules and milestones throughout the year.
+      </Typography>
+    </Box>
+  );
+}

--- a/client/components/index.tsx
+++ b/client/components/index.tsx
@@ -24,3 +24,4 @@ export { default as PhaseForm } from './PhaseForm';
 export { default as TaskForm } from './TaskForm';
 export { default as RoleCard } from "./RoleCard";
 export { default as MetricCard } from './MetricCard';
+export { default as ProjectTimeline } from './ProjectTimeline';

--- a/client/pages/plan-management/index.tsx
+++ b/client/pages/plan-management/index.tsx
@@ -8,16 +8,10 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import { fetchEvents } from '../../models/eventsModel';
-import { fetchProjects, updateProject } from '../../models/projectsModel';
+import { fetchProjects } from '../../models/projectsModel';
 import { fetchTasks } from '../../models/tasksModel';
 import { fetchWorkdays } from '../../models/workdayModel';
-import Timeline from '@mui/lab/Timeline';
-import TimelineItem from '@mui/lab/TimelineItem';
-import TimelineSeparator from '@mui/lab/TimelineSeparator';
-import TimelineConnector from '@mui/lab/TimelineConnector';
-import TimelineContent from '@mui/lab/TimelineContent';
-import TimelineDot from '@mui/lab/TimelineDot';
-import { Layout, AgendaCalendar, PageBreadcrumbs } from '../../components';
+import { Layout, AgendaCalendar, PageBreadcrumbs, ProjectTimeline } from '../../components';
 import { withAuth } from '../../context/AuthContext';
 
 function PlanManagementOverview() {
@@ -43,11 +37,11 @@ function PlanManagementOverview() {
                 return end && new Date(end) > acc ? new Date(end) : acc;
               }, projectEnd || new Date(0));
               const finalEnd = projectEnd && maxEnd > projectEnd ? maxEnd : projectEnd || maxEnd;
-              return { ...p, end: finalEnd };
+              return { ...p, end: finalEnd, tasks };
             } catch {
-              return p;
+              return { ...p, tasks: [] };
             }
-          }),
+          })
         );
         setProjects(withTasks);
         setHolidays(hol);
@@ -99,22 +93,7 @@ function PlanManagementOverview() {
                 )}
             />
           ) : (
-            <Timeline>
-              {projects.map((p, idx) => (
-                <TimelineItem key={p._id || idx}>
-                  <TimelineSeparator>
-                    <TimelineDot />
-                    {idx < projects.length - 1 && <TimelineConnector />}
-                  </TimelineSeparator>
-                  <TimelineContent
-                    onClick={() => router.push(`/project/${p._id || p.id}`)}
-                    sx={{ cursor: 'pointer' }}
-                  >
-                    {p.name} ({new Date(p.start).toLocaleDateString()} - {new Date(p.end).toLocaleDateString()})
-                  </TimelineContent>
-                </TimelineItem>
-              ))}
-            </Timeline>
+            <ProjectTimeline projects={projects} />
           )}
         </Paper>
       </Container>


### PR DESCRIPTION
## Summary
- add new `ProjectTimeline` component for horizontal project timelines
- integrate timeline view into Plan Management Overview
- export the new component via components index

## Testing
- `npm test` in `client`
- `npm run check` in `client`
- `npm test` in `service`
- `npm run check` in `service`


------
https://chatgpt.com/codex/tasks/task_e_68654a9281f88328aff8e509c62e3c10