### PR TITLE
Fix Thai font support in timeline views

### DIFF
--- a/client/components/ProjectTimeline.tsx
+++ b/client/components/ProjectTimeline.tsx
@@ -51,7 +51,7 @@ export default function ProjectTimeline({ projects, year = new Date().getFullYea
           <Box sx={{ position: 'absolute', top: -3, left: '50%', width: 8, height: 8, bgcolor: color, borderRadius: '50%', transform: 'translateX(-50%)' }} />
         )}
         {!isMilestone && (
-          <Typography sx={{ fontSize: 10, color: '#fff', pl: 0.5, whiteSpace: 'nowrap', overflow: 'hidden' }}>{t.name}</Typography>
+          <Typography sx={{ fontSize: 12, color: '#fff', pl: 0.5, whiteSpace: 'nowrap', overflow: 'hidden' }}>{t.name}</Typography>
         )}
       </Box>
     );

--- a/client/pages/plan-management/generate.tsx
+++ b/client/pages/plan-management/generate.tsx
@@ -64,14 +64,14 @@ function GenerateTimeline() {
           size: { width: 40, height: 40 },
           attrs: {
             body: { fill: '#fafafa', stroke: '#555' },
-            label: { text: t.name, fill: '#000', fontSize: 11, y: 55 },
+            label: { text: t.name, fill: '#000', fontSize: 14, y: 55 },
           },
         });
         const yearText = new shapes.standard.Rectangle({
           position: { x, y: 20 },
           size: { width: 1, height: 1 },
           attrs: {
-            label: { text: String(year), fill: '#fff', fontSize: 12, textAnchor: 'middle', x: 20 },
+            label: { text: String(year), fill: '#fff', fontSize: 14, textAnchor: 'middle', x: 20 },
             body: { stroke: 'none', fill: 'none' },
           },
         });
@@ -93,7 +93,7 @@ function GenerateTimeline() {
         size: { width: 40, height: 40 },
         attrs: {
           body: { fill: '#fafafa', stroke: '#555' },
-          label: { text: 'present', fill: '#000', fontSize: 11, y: 55 },
+          label: { text: 'present', fill: '#000', fontSize: 14, y: 55 },
         },
       });
       cells.push(end);

--- a/client/styles/globals.scss
+++ b/client/styles/globals.scss
@@ -1,7 +1,8 @@
 @import url('https://fonts.googleapis.com/css2?family=Fira+Code&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;700&display=swap');
 
 body {
-  font-family: 'Fira Code', monospace;
+  font-family: 'Noto Sans Thai', 'Fira Code', monospace;
   color: #24292e;
   background-color: #f6f8fa;
 }

--- a/client/theme.ts
+++ b/client/theme.ts
@@ -17,7 +17,7 @@ const theme = createTheme({
     },
   },
   typography: {
-    fontFamily: '"Fira Code", monospace',
+    fontFamily: '"Noto Sans Thai", "Fira Code", monospace',
   },
 });
 


### PR DESCRIPTION
## Summary
- include Noto Sans Thai for better Thai language support
- bump font sizes in timeline visualisations

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_686569790ca48328a6539126bff19a27