### PR TITLE
Add roles multi-select for tasks

### DIFF
--- a/client/components/AgendaCalendar.tsx
+++ b/client/components/AgendaCalendar.tsx
@@ -87,9 +87,9 @@ export default function AgendaCalendar({
     if (res.type && res.type !== 'task') {
       return <Box sx={{ fontSize: 12 }}>{event.title}</Box>;
     }
-    const owner = res.owner || '';
-    const initials = owner
-      .split(' ')
+    const roles = Array.isArray(res.roles) ? res.roles : [];
+    const owner = roles.join(', ');
+    const initials = roles
       .map((s: string) => s[0])
       .join('')
       .slice(0, 2)

--- a/client/components/TaskForm.tsx
+++ b/client/components/TaskForm.tsx
@@ -8,12 +8,12 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { addDays } from 'date-fns';
 
-export default function TaskForm({ onSubmit, initial, members = [], tasks = [] }) {
+export default function TaskForm({ onSubmit, initial, tasks = [] }) {
   const [name, setName] = useState(initial?.name || '');
   const [detail, setDetail] = useState(initial?.detail || '');
   const [startDate, setStartDate] = useState(initial?.startDate || initial?.date || null);
   const [endDate, setEndDate] = useState(initial?.endDate || null);
-  const [owner, setOwner] = useState(initial?.owner || '');
+  const [roles, setRoles] = useState(initial?.roles || []);
   const [manday, setManday] = useState(initial?.manday != null ? String(initial.manday) : '');
   const [duration, setDuration] = useState(initial?.duration != null ? String(initial.duration) : '');
   const [blocked, setBlocked] = useState(null);
@@ -27,7 +27,7 @@ export default function TaskForm({ onSubmit, initial, members = [], tasks = [] }
     setDetail(initial?.detail || '');
     setStartDate(initial?.startDate || initial?.date || null);
     setEndDate(initial?.endDate || null);
-    setOwner(initial?.owner || '');
+    setRoles(initial?.roles || []);
     setManday(initial?.manday != null ? String(initial.manday) : '');
     setDuration(initial?.duration != null ? String(initial.duration) : '');
     setBlocked(null);
@@ -77,7 +77,7 @@ export default function TaskForm({ onSubmit, initial, members = [], tasks = [] }
         detail,
         startDate,
         endDate,
-        owner,
+        roles,
         manday: manday ? Number(manday) : undefined,
         duration: duration ? Number(duration) : undefined,
         blockedBy: blocked ? blocked.id : undefined,
@@ -87,7 +87,7 @@ export default function TaskForm({ onSubmit, initial, members = [], tasks = [] }
     setDetail('');
     setStartDate(null);
     setEndDate(null);
-    setOwner('');
+    setRoles([]);
     setManday('');
     setDuration('');
     setBlocked(null);
@@ -120,11 +120,11 @@ export default function TaskForm({ onSubmit, initial, members = [], tasks = [] }
         />
         <TextField label="Duration (days)" type="number" value={duration} onChange={e => setDuration(e.target.value)} fullWidth sx={{ mb: 2 }} />
         <Autocomplete
-          options={members}
-          getOptionLabel={o => o.name}
-          value={members.find(m => m.id === owner) || null}
-          onChange={(_, v) => setOwner(v ? v.id : '')}
-          renderInput={params => <TextField {...params} label="Owner" />}
+          multiple
+          options={['SA', 'PA', 'QA']}
+          value={roles}
+          onChange={(_, v) => setRoles(v)}
+          renderInput={params => <TextField {...params} label="Roles" />}
           sx={{ mb: 2 }}
         />
         <TextField label="Manday" type="number" value={manday} onChange={e => setManday(e.target.value)} fullWidth sx={{ mb: 2 }} />

--- a/client/pages/plan-management/index.tsx
+++ b/client/pages/plan-management/index.tsx
@@ -105,7 +105,7 @@ function PlanManagementOverview() {
                 name: p.name,
                 startDate: p.start,
                 endDate: p.end,
-                owner: p.lead?.name || '',
+                roles: p.lead?.name ? [p.lead.name] : [],
                 status: p.status,
                 progress: calcProgress(p),
               }))}

--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -371,13 +371,11 @@ function PlanningSetting() {
                         width: 140,
                       },
                       {
-                        field: 'owner',
-                        headerName: 'Owner',
+                        field: 'roles',
+                        headerName: 'Roles',
                         width: 160,
-                        valueGetter: (_value, row) => {
-                          const mem = members.find(m => m.id === row.owner);
-                          return mem ? mem.name : row.owner || '-';
-                        },
+                        valueGetter: (_value, row) =>
+                          Array.isArray(row.roles) ? row.roles.join(', ') : '-',
                       },
                     {
                       field: 'manday',
@@ -480,14 +478,13 @@ function PlanningSetting() {
             </Grid>
           )}
         <Popup open={dialog === 'task'} onClose={() => setDialog('')} title="Add Task">
-          <TaskForm onSubmit={handleCreateTask} members={members} tasks={tasks} />
+          <TaskForm onSubmit={handleCreateTask} tasks={tasks} />
         </Popup>
         <Popup open={!!editTask} onClose={() => setEditTask(null)} title="Edit Task">
           {editTask && (
             <TaskForm
               onSubmit={handleUpdateTask}
               initial={editTask}
-              members={members}
               tasks={tasks}
             />
           )}

--- a/service/src/planning/data/task.schema.ts
+++ b/service/src/planning/data/task.schema.ts
@@ -28,8 +28,8 @@ export class Task extends Document {
   @Prop()
   endDate?: Date;
 
-  @Prop()
-  owner?: string;
+  @Prop({ type: [String], enum: ['SA', 'PA', 'QA'] })
+  roles?: string[];
 
   @Prop()
   manday?: number;

--- a/service/src/planning/data/tasks.repository.ts
+++ b/service/src/planning/data/tasks.repository.ts
@@ -3,7 +3,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types } from 'mongoose';
 import { Task } from './task.schema';
 import { BaseRepository } from './base.repository';
-import { IsString, IsOptional, IsBoolean, IsNumber } from 'class-validator';
+import { IsString, IsOptional, IsBoolean, IsNumber, IsArray } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class CreateTaskInput {
@@ -40,8 +40,9 @@ export class CreateTaskInput {
   endDate?: Date;
 
   @IsOptional()
-  @IsString()
-  owner?: string;
+  @IsArray()
+  @IsString({ each: true })
+  roles?: string[];
 
   @IsOptional()
   @IsNumber()
@@ -88,8 +89,9 @@ export class UpdateTaskInput {
   startDate?: Date;
 
   @IsOptional()
-  @IsString()
-  owner?: string;
+  @IsArray()
+  @IsString({ each: true })
+  roles?: string[];
 
   @IsOptional()
   @IsNumber()


### PR DESCRIPTION
## Summary
- support assigning multiple roles to a task
- show role badges in calendar and tables

## Testing
- `npm test --silent` in `client`
- `npm test --silent` in `service`


------
https://chatgpt.com/codex/tasks/task_e_686de4acc7b48328bb048381ec5d9b9c