### PR TITLE
Allow assigning multiple members to tasks

### DIFF
--- a/client/components/TaskForm.tsx
+++ b/client/components/TaskForm.tsx
@@ -8,12 +8,12 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { addDays } from 'date-fns';
 
-export default function TaskForm({ onSubmit, initial, tasks = [] }) {
+export default function TaskForm({ onSubmit, initial, tasks = [], members = [] }) {
   const [name, setName] = useState(initial?.name || '');
   const [detail, setDetail] = useState(initial?.detail || '');
   const [startDate, setStartDate] = useState(initial?.startDate || initial?.date || null);
   const [endDate, setEndDate] = useState(initial?.endDate || null);
-  const [roles, setRoles] = useState(initial?.roles || []);
+  const [assignees, setAssignees] = useState({});
   const [manday, setManday] = useState(initial?.manday != null ? String(initial.manday) : '');
   const [duration, setDuration] = useState(initial?.duration != null ? String(initial.duration) : '');
   const [blocked, setBlocked] = useState(null);
@@ -22,12 +22,30 @@ export default function TaskForm({ onSubmit, initial, tasks = [] }) {
       (initial ? (initial.isFeature ? 'feature' : 'milestone') : 'feature')
   );
 
+  const roleMap = useMemo(() => {
+    const map: any = {};
+    members.forEach(m => {
+      const role = String(m.position).split('_')[0].toUpperCase();
+      if (!map[role]) map[role] = [];
+      map[role].push(m);
+    });
+    return map;
+  }, [members]);
+
   useEffect(() => {
     setName(initial?.name || '');
     setDetail(initial?.detail || '');
     setStartDate(initial?.startDate || initial?.date || null);
     setEndDate(initial?.endDate || null);
-    setRoles(initial?.roles || []);
+    const initAssign: any = {};
+    Object.keys(roleMap).forEach(r => (initAssign[r] = []));
+    if (initial?.assignees) {
+      const idMap = Object.fromEntries(members.map(m => [m.id, m]));
+      Object.entries(initial.assignees).forEach(([r, ids]: any) => {
+        initAssign[r] = ids.map((id: string) => idMap[id]).filter(Boolean);
+      });
+    }
+    setAssignees(initAssign);
     setManday(initial?.manday != null ? String(initial.manday) : '');
     setDuration(initial?.duration != null ? String(initial.duration) : '');
     setBlocked(null);
@@ -35,7 +53,7 @@ export default function TaskForm({ onSubmit, initial, tasks = [] }) {
       initial?.type ||
         (initial ? (initial.isFeature ? 'feature' : 'milestone') : 'feature')
     );
-  }, [initial]);
+  }, [initial, roleMap, members]);
 
   const dateError = useMemo(
     () =>
@@ -71,13 +89,22 @@ export default function TaskForm({ onSubmit, initial, tasks = [] }) {
   const handleSubmit = e => {
     e.preventDefault();
     if (!formValid) return;
+    const roleList: string[] = [];
+    const assignData: any = {};
+    Object.entries(assignees).forEach(([r, list]: any) => {
+      if (list.length) {
+        roleList.push(r);
+        assignData[r] = list.map((m: any) => m.id);
+      }
+    });
     onSubmit &&
       onSubmit({
         name,
         detail,
         startDate,
         endDate,
-        roles,
+        roles: roleList,
+        assignees: assignData,
         manday: manday ? Number(manday) : undefined,
         duration: duration ? Number(duration) : undefined,
         blockedBy: blocked ? blocked.id : undefined,
@@ -87,7 +114,7 @@ export default function TaskForm({ onSubmit, initial, tasks = [] }) {
     setDetail('');
     setStartDate(null);
     setEndDate(null);
-    setRoles([]);
+    setAssignees(Object.fromEntries(Object.keys(roleMap).map(r => [r, []])));
     setManday('');
     setDuration('');
     setBlocked(null);
@@ -119,14 +146,20 @@ export default function TaskForm({ onSubmit, initial, tasks = [] }) {
           }}
         />
         <TextField label="Duration (days)" type="number" value={duration} onChange={e => setDuration(e.target.value)} fullWidth sx={{ mb: 2 }} />
-        <Autocomplete
-          multiple
-          options={['SA', 'PA', 'QA']}
-          value={roles}
-          onChange={(_, v) => setRoles(v)}
-          renderInput={params => <TextField {...params} label="Roles" />}
-          sx={{ mb: 2 }}
-        />
+        {Object.entries(roleMap).map(([r, opts]) => (
+          <Autocomplete
+            key={r}
+            multiple
+            options={opts as any}
+            getOptionLabel={(o: any) => o.name}
+            value={assignees[r] || []}
+            onChange={(_, v) =>
+              setAssignees(a => ({ ...a, [r]: v }))
+            }
+            renderInput={params => <TextField {...params} label={r} />}
+            sx={{ mb: 2 }}
+          />
+        ))}
         <TextField label="Manday" type="number" value={manday} onChange={e => setManday(e.target.value)} fullWidth sx={{ mb: 2 }} />
         <Autocomplete
           options={tasks.map(t => ({ id: t._id || t.id, label: t.name, date: t.endDate }))}

--- a/client/pages/plan-management/planning-setting.tsx
+++ b/client/pages/plan-management/planning-setting.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { useRouter } from 'next/router';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
@@ -62,6 +62,14 @@ function PlanningSetting() {
   const [sprints, setSprints] = useState([]);
   const ganttRef = useRef<HTMLDivElement | null>(null);
   const columnWidth = 60;
+
+  const idNameMap = useMemo(() => {
+    const m: Record<string, string> = {};
+    members.forEach(mem => {
+      m[mem.id] = mem.name;
+    });
+    return m;
+  }, [members]);
 
   const statusOptions = [
     'planing',
@@ -377,6 +385,23 @@ function PlanningSetting() {
                         valueGetter: (_value, row) =>
                           Array.isArray(row.roles) ? row.roles.join(', ') : '-',
                       },
+                      {
+                        field: 'assignees',
+                        headerName: 'Assignees',
+                        width: 160,
+                        valueGetter: (_value, row) => {
+                          if (!row.assignees) return '';
+                          const list: string[] = [];
+                          Object.values(row.assignees).forEach((ids: any) => {
+                            if (Array.isArray(ids)) {
+                              ids.forEach((id: string) => {
+                                if (idNameMap[id]) list.push(idNameMap[id]);
+                              });
+                            }
+                          });
+                          return list.join(', ');
+                        },
+                      },
                     {
                       field: 'manday',
                       headerName: 'Manday',
@@ -478,7 +503,7 @@ function PlanningSetting() {
             </Grid>
           )}
         <Popup open={dialog === 'task'} onClose={() => setDialog('')} title="Add Task">
-          <TaskForm onSubmit={handleCreateTask} tasks={tasks} />
+          <TaskForm onSubmit={handleCreateTask} tasks={tasks} members={members} />
         </Popup>
         <Popup open={!!editTask} onClose={() => setEditTask(null)} title="Edit Task">
           {editTask && (
@@ -486,6 +511,7 @@ function PlanningSetting() {
               onSubmit={handleUpdateTask}
               initial={editTask}
               tasks={tasks}
+              members={members}
             />
           )}
         </Popup>

--- a/service/src/planning/data/task.schema.ts
+++ b/service/src/planning/data/task.schema.ts
@@ -31,6 +31,9 @@ export class Task extends Document {
   @Prop({ type: [String], enum: ['SA', 'PA', 'QA'] })
   roles?: string[];
 
+  @Prop({ type: [Types.ObjectId], ref: 'Resource', default: [] })
+  assignees?: Types.ObjectId[];
+
   @Prop()
   manday?: number;
 

--- a/service/src/planning/data/tasks.repository.ts
+++ b/service/src/planning/data/tasks.repository.ts
@@ -12,10 +12,6 @@ export class CreateTaskInput {
   project!: Types.ObjectId;
 
   @IsOptional()
-  @Type(() => String)
-  @IsString()
-  phase?: Types.ObjectId;
-
   @IsString()
   name!: string;
 
@@ -43,6 +39,14 @@ export class CreateTaskInput {
   @IsArray()
   @IsString({ each: true })
   roles?: string[];
+
+  @IsOptional()
+  @IsArray()
+  @Type(() => String)
+  @IsString({ each: true })
+  assignees?: Types.ObjectId[];
+
+
 
   @IsOptional()
   @IsNumber()
@@ -92,6 +96,12 @@ export class UpdateTaskInput {
   @IsArray()
   @IsString({ each: true })
   roles?: string[];
+  @IsOptional()
+  @IsArray()
+  @Type(() => String)
+  @IsString({ each: true })
+  assignees?: Types.ObjectId[];
+
 
   @IsOptional()
   @IsNumber()


### PR DESCRIPTION
## Summary
- track task assignees in the API
- group available project members by role for selection
- display assignees in task table

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_686e5b0f95d88328ab53ea16059cb17b