### PR TITLE
Implement GitHub-style project views

### DIFF
--- a/client/components/BoardView.tsx
+++ b/client/components/BoardView.tsx
@@ -1,0 +1,59 @@
+import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
+import { Task } from './sampleData';
+
+interface Props {
+  tasks: Task[];
+  setTasks: (t: Task[]) => void;
+}
+
+const columns = ['To Do', 'In Progress', 'Done'];
+
+export default function BoardView({ tasks, setTasks }: Props) {
+  const onDragEnd = (result: DropResult) => {
+    if (!result.destination) return;
+    const { draggableId, destination } = result;
+    setTasks(
+      tasks.map(t =>
+        t.id === draggableId ? { ...t, status: destination.droppableId as any } : t,
+      ),
+    );
+  };
+
+  return (
+    <DragDropContext onDragEnd={onDragEnd}>
+      <div className="flex space-x-4">
+        {columns.map(col => (
+          <Droppable droppableId={col} key={col}>
+            {provided => (
+              <div
+                ref={provided.innerRef}
+                {...provided.droppableProps}
+                className="flex-1 bg-gray-100 rounded p-2"
+              >
+                <h3 className="font-semibold mb-2">{col}</h3>
+                {tasks
+                  .filter(t => t.status === col)
+                  .map((t, idx) => (
+                    <Draggable key={t.id} draggableId={t.id} index={idx}>
+                      {p => (
+                        <div
+                          ref={p.innerRef}
+                          {...p.draggableProps}
+                          {...p.dragHandleProps}
+                          className="bg-white rounded p-2 mb-2 shadow"
+                        >
+                          <div className="text-sm font-medium">{t.name}</div>
+                          <div className="text-xs text-gray-500">{t.type}</div>
+                        </div>
+                      )}
+                    </Draggable>
+                  ))}
+                {provided.placeholder}
+              </div>
+            )}
+          </Droppable>
+        ))}
+      </div>
+    </DragDropContext>
+  );
+}

--- a/client/components/CapacityView.tsx
+++ b/client/components/CapacityView.tsx
@@ -1,0 +1,42 @@
+import { Task, sampleUsers, sampleIterations } from './sampleData';
+
+interface Props {
+  tasks: Task[];
+}
+
+export default function CapacityView({ tasks }: Props) {
+  const totals: Record<string, Record<string, number>> = {};
+  sampleUsers.forEach(u => {
+    totals[u] = {};
+    sampleIterations.forEach(it => {
+      totals[u][it.name] = tasks
+        .filter(t => t.assignees.includes(u) && t.iteration === it.name)
+        .reduce((s, t) => s + t.manday, 0);
+    });
+  });
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm bg-white rounded border">
+        <thead className="bg-gray-100">
+          <tr>
+            <th className="px-2 py-1">Member</th>
+            {sampleIterations.map(it => (
+              <th key={it.name} className="px-2 py-1">{it.name}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {sampleUsers.map(u => (
+            <tr key={u} className="border-t">
+              <td className="px-2 py-1 font-medium">{u}</td>
+              {sampleIterations.map(it => (
+                <td key={it.name} className="px-2 py-1 text-center">{totals[u][it.name]}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/client/components/IterationsView.tsx
+++ b/client/components/IterationsView.tsx
@@ -1,0 +1,26 @@
+import { Task, sampleIterations } from './sampleData';
+
+interface Props {
+  tasks: Task[];
+}
+
+export default function IterationsView({ tasks }: Props) {
+  return (
+    <div className="space-y-4">
+      {sampleIterations.map(it => (
+        <div key={it.name} className="bg-white rounded border p-2">
+          <h3 className="font-semibold mb-1">
+            {it.name} ({it.start} - {it.end})
+          </h3>
+          <ul className="list-disc ml-4 text-sm">
+            {tasks
+              .filter(t => t.iteration === it.name)
+              .map(t => (
+                <li key={t.id}>{t.name} - {t.status}</li>
+              ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/components/ProjectPage.tsx
+++ b/client/components/ProjectPage.tsx
@@ -1,7 +1,12 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import Layout from './Layout';
 import TaskTable from './TaskTable';
-import RoadmapGantt from './RoadmapGantt';
+import BoardView from './BoardView';
+import TimelineView from './TimelineView';
+import IterationsView from './IterationsView';
+import CapacityView from './CapacityView';
+import { ViewProvider, useView } from '../context/ViewContext';
+import { sampleTasks, Task } from './sampleData';
 
 const views = [
   { key: 'table', label: 'Table' },
@@ -11,14 +16,26 @@ const views = [
   { key: 'capacity', label: 'Team Capacity' },
 ];
 
-export default function ProjectPage() {
-  const [view, setView] = useState('table');
+function InnerPage() {
+  const { view, setView } = useView();
+  const [tasks, setTasks] = useState<Task[]>(sampleTasks);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+
+  const filtered = tasks
+    .filter(t =>
+      [t.name, t.status, t.assignees.join(' '), t.iteration]
+        .join(' ')
+        .toLowerCase()
+        .includes(search.toLowerCase()),
+    )
+    .filter(t => (statusFilter ? t.status === statusFilter : true));
 
   return (
     <Layout>
       <div className="p-4 space-y-4">
         <h1 className="text-2xl font-semibold">Roadmap</h1>
-        <div className="flex space-x-2">
+        <div className="flex space-x-2 items-center">
           {views.map(v => (
             <button
               key={v.key}
@@ -30,11 +47,40 @@ export default function ProjectPage() {
               {v.label}
             </button>
           ))}
+          <select
+            value={statusFilter}
+            onChange={e => setStatusFilter(e.target.value)}
+            className="ml-auto border px-2 py-1 text-sm rounded"
+          >
+            <option value="">All Status</option>
+            <option>To Do</option>
+            <option>In Progress</option>
+            <option>Done</option>
+          </select>
+          <input
+            type="text"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search"
+            className="ml-2 border px-2 py-1 text-sm rounded"
+          />
         </div>
         <div>
-          {view === 'timeline' ? <RoadmapGantt /> : <TaskTable />}
+          {view === 'table' && <TaskTable tasks={filtered} setTasks={setTasks} />}
+          {view === 'board' && <BoardView tasks={filtered} setTasks={setTasks} />}
+          {view === 'timeline' && <TimelineView tasks={filtered} />}
+          {view === 'iterations' && <IterationsView tasks={filtered} />}
+          {view === 'capacity' && <CapacityView tasks={filtered} />}
         </div>
       </div>
     </Layout>
+  );
+}
+
+export default function ProjectPage() {
+  return (
+    <ViewProvider>
+      <InnerPage />
+    </ViewProvider>
   );
 }

--- a/client/components/TaskTable.tsx
+++ b/client/components/TaskTable.tsx
@@ -1,7 +1,83 @@
-import React from 'react';
+import { useState } from 'react';
+import { Task } from './sampleData';
 
-export default function TaskTable() {
+interface Props {
+  tasks: Task[];
+  setTasks: (t: Task[]) => void;
+}
+
+export default function TableView({ tasks, setTasks }: Props) {
+  const [sortKey, setSortKey] = useState<keyof Task>('name');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+
+  const sorted = [...tasks].sort((a, b) => {
+    const aVal = a[sortKey] as any;
+    const bVal = b[sortKey] as any;
+    if (aVal === bVal) return 0;
+    return (aVal > bVal ? 1 : -1) * (sortDir === 'asc' ? 1 : -1);
+  });
+
+  const handleSort = (key: keyof Task) => {
+    if (sortKey === key) {
+      setSortDir(sortDir === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortKey(key);
+      setSortDir('asc');
+    }
+  };
+
+  const addTask = () => {
+    const nextId = (tasks.length + 1).toString();
+    setTasks([
+      ...tasks,
+      {
+        id: nextId,
+        name: 'New Task',
+        status: 'To Do',
+        startDate: new Date().toISOString().slice(0, 10),
+        endDate: new Date().toISOString().slice(0, 10),
+        assignees: [],
+        manday: 1,
+        type: 'feature',
+        iteration: 'Sprint 1',
+      },
+    ]);
+  };
+
   return (
-    <div className="border rounded bg-white p-4">Task table placeholder</div>
+    <div className="overflow-x-auto bg-white rounded border">
+      <table className="min-w-full text-sm">
+        <thead className="bg-gray-100">
+          <tr>
+            {['name','status','startDate','endDate','assignees','manday','blockedBy','type'].map(k => (
+              <th
+                key={k}
+                className="px-2 py-1 cursor-pointer text-left"
+                onClick={() => handleSort(k as keyof Task)}
+              >
+                {k}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map(t => (
+            <tr key={t.id} className="border-t">
+              <td className="px-2 py-1">{t.name}</td>
+              <td className="px-2 py-1">{t.status}</td>
+              <td className="px-2 py-1">{t.startDate}</td>
+              <td className="px-2 py-1">{t.endDate}</td>
+              <td className="px-2 py-1">{t.assignees.join(', ')}</td>
+              <td className="px-2 py-1">{t.manday}</td>
+              <td className="px-2 py-1">{t.blockedBy || ''}</td>
+              <td className="px-2 py-1">{t.type}</td>
+            </tr>
+          ))}
+          <tr>
+            <td colSpan={8} className="px-2 py-2 text-blue-600 cursor-pointer" onClick={addTask}>+ Add item</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/client/components/TimelineView.tsx
+++ b/client/components/TimelineView.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { Task, sampleIterations } from './sampleData';
+
+interface Props {
+  tasks: Task[];
+}
+
+const zoomLevels = ['day', 'week', 'month'];
+
+export default function TimelineView({ tasks }: Props) {
+  const [zoom, setZoom] = useState<'day' | 'week' | 'month'>('month');
+
+  const dates = tasks.map(t => [new Date(t.startDate), new Date(t.endDate)]).flat();
+  const min = new Date(Math.min(...dates.map(d => d.getTime())));
+  const max = new Date(Math.max(...dates.map(d => d.getTime())));
+  const range = max.getTime() - min.getTime();
+
+  const calcLeft = (d: Date) => ((d.getTime() - min.getTime()) / range) * 100;
+
+  const cells = [] as { label: string; left: number }[];
+  const cur = new Date(min);
+  while (cur <= max) {
+    const label = cur.toISOString().slice(0, 10);
+    cells.push({ label, left: calcLeft(new Date(cur)) });
+    if (zoom === 'month') cur.setMonth(cur.getMonth() + 1);
+    else if (zoom === 'week') cur.setDate(cur.getDate() + 7);
+    else cur.setDate(cur.getDate() + 1);
+  }
+
+  return (
+    <div className="relative border rounded bg-white p-4 overflow-x-auto" style={{minHeight:200}}>
+      <div className="mb-2 flex items-center space-x-2">
+        <label className="text-sm">Zoom:</label>
+        <select value={zoom} onChange={e => setZoom(e.target.value as any)} className="border px-1 text-sm">
+          {zoomLevels.map(z => (
+            <option key={z} value={z}>{z}</option>
+          ))}
+        </select>
+      </div>
+      <div className="relative" style={{height:120}}>
+        {cells.map(c => (
+          <div key={c.label} className="absolute text-xs" style={{left:`${c.left}%`, top:0}}>{c.label}</div>
+        ))}
+        {sampleIterations.map(it => (
+          <div key={it.name} className="absolute border-l border-blue-500" style={{left:`${calcLeft(new Date(it.start))}%`, top:20, bottom:0}} />
+        ))}
+        {tasks.map(t => {
+          const left = calcLeft(new Date(t.startDate));
+          const right = calcLeft(new Date(t.endDate));
+          return (
+            <div key={t.id} className="absolute bg-green-500 text-white text-xs px-1 rounded" style={{left:`${left}%`, width:`${right-left}%`, top:40}}>
+              {t.name}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/client/components/index.tsx
+++ b/client/components/index.tsx
@@ -29,3 +29,7 @@ export { default as SettingsDrawer } from './SettingsDrawer';
 export { default as ProjectPage } from './ProjectPage';
 export { default as TaskTable } from './TaskTable';
 export { default as RoadmapGantt } from './RoadmapGantt';
+export { default as BoardView } from './BoardView';
+export { default as TimelineView } from './TimelineView';
+export { default as IterationsView } from './IterationsView';
+export { default as CapacityView } from './CapacityView';

--- a/client/components/sampleData.ts
+++ b/client/components/sampleData.ts
@@ -1,0 +1,67 @@
+export interface Task {
+  id: string;
+  name: string;
+  status: 'To Do' | 'In Progress' | 'Done';
+  startDate: string;
+  endDate: string;
+  assignees: string[];
+  manday: number;
+  blockedBy?: string;
+  type: string;
+  iteration: string;
+}
+
+export const sampleUsers = ['Alice', 'Bob', 'Carol'];
+
+export const sampleIterations = [
+  { name: 'Sprint 1', start: '2025-06-01', end: '2025-06-14' },
+  { name: 'Sprint 2', start: '2025-06-15', end: '2025-06-28' },
+];
+
+export const sampleTasks: Task[] = [
+  {
+    id: '1',
+    name: 'Setup project repo',
+    status: 'To Do',
+    startDate: '2025-06-01',
+    endDate: '2025-06-03',
+    assignees: ['Alice'],
+    manday: 3,
+    type: 'feature',
+    iteration: 'Sprint 1',
+  },
+  {
+    id: '2',
+    name: 'Design database schema',
+    status: 'In Progress',
+    startDate: '2025-06-02',
+    endDate: '2025-06-06',
+    assignees: ['Bob'],
+    manday: 5,
+    blockedBy: '1',
+    type: 'design',
+    iteration: 'Sprint 1',
+  },
+  {
+    id: '3',
+    name: 'Implement auth module',
+    status: 'To Do',
+    startDate: '2025-06-07',
+    endDate: '2025-06-14',
+    assignees: ['Carol'],
+    manday: 7,
+    type: 'feature',
+    iteration: 'Sprint 2',
+  },
+  {
+    id: '4',
+    name: 'Deploy to staging',
+    status: 'Done',
+    startDate: '2025-06-10',
+    endDate: '2025-06-11',
+    assignees: ['Alice'],
+    manday: 2,
+    type: 'chore',
+    iteration: 'Sprint 2',
+  },
+];

--- a/client/context/ViewContext.tsx
+++ b/client/context/ViewContext.tsx
@@ -1,0 +1,14 @@
+import { createContext, useContext, useState } from 'react';
+
+const ViewContext = createContext<any>(null);
+
+export function ViewProvider({ children }: { children: React.ReactNode }) {
+  const [view, setView] = useState('table');
+  return (
+    <ViewContext.Provider value={{ view, setView }}>
+      {children}
+    </ViewContext.Provider>
+  );
+}
+
+export const useView = () => useContext(ViewContext);

--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,7 @@
     "jointjs": "^3.7.7",
     "next": "15.3.4",
     "react": "^18.0.0",
+    "react-beautiful-dnd": "^13.1.1",
     "react-big-calendar": "^1.11.3",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",


### PR DESCRIPTION
## Summary
- add ViewContext for switching views
- implement sample data for tasks
- create BoardView, TimelineView, IterationsView and CapacityView
- expand TaskTable with sorting and inline add row
- update ProjectPage to support multiple views and filters
- add react-beautiful-dnd dependency

## Testing
- `npm test`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6874dbf1c6108328acc29271394306e7