### PR TITLE
Enhance roadmap timeline UI

### DIFF
--- a/client/components/RoadmapGantt.tsx
+++ b/client/components/RoadmapGantt.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { sampleTasks, sampleIterations, Task } from './sampleData';
 
@@ -12,13 +12,18 @@ const statusColors: Record<string, string> = {
   'Done': 'bg-green-500',
 };
 
+const DAY_WIDTH = 32;
+const ROW_HEIGHT = 28;
+const rowOffset = ROW_HEIGHT;
+
 const zoomOptions = {
-  day: { pxPerDay: 20, gridStep: 1 },
-  week: { pxPerDay: 5, gridStep: 7 },
-  month: { pxPerDay: 2, gridStep: 30 },
+  day: { gridStep: 1 },
+  week: { gridStep: 7 },
+  month: { gridStep: 30 },
 };
 
 export default function RoadmapGantt({ tasks = sampleTasks }: Props) {
+  const [items, setItems] = useState<Task[]>(tasks);
   const [zoom, setZoom] = useState<'day' | 'week' | 'month'>('month');
   const [startField, setStartField] = useState<'startDate' | 'iterationStart'>('startDate');
   const [endField, setEndField] = useState<'endDate' | 'iterationEnd'>('endDate');
@@ -27,6 +32,8 @@ export default function RoadmapGantt({ tasks = sampleTasks }: Props) {
   const [showAdd, setShowAdd] = useState(false);
   const [newName, setNewName] = useState('');
   const [newDesc, setNewDesc] = useState('');
+  const [editing, setEditing] = useState<Task | null>(null);
+  const [editName, setEditName] = useState('');
 
   const fieldStartDate = (t: Task): Date => {
     if (startField === 'startDate') return new Date(t.startDate);
@@ -40,10 +47,12 @@ export default function RoadmapGantt({ tasks = sampleTasks }: Props) {
     return it ? new Date(it.end) : new Date(t.endDate);
   };
 
-  const filtered = tasks
+  const filtered = items
     .filter(t => (statusFilter ? t.status === statusFilter : true))
     .filter(t => {
-      const text = [t.name, t.status, t.type, t.iteration].join(' ').toLowerCase();
+      const text = [t.id, t.name, t.status, t.type, t.iteration]
+        .join(' ')
+        .toLowerCase();
       return text.includes(search.toLowerCase());
     });
 
@@ -57,18 +66,49 @@ export default function RoadmapGantt({ tasks = sampleTasks }: Props) {
   const endRange = new Date(maxDate);
   endRange.setDate(endRange.getDate() + 7);
 
-  const daysDiff = (d1: Date, d2: Date) => Math.floor((d1.getTime() - d2.getTime()) / 86400000);
-  const { pxPerDay, gridStep } = zoomOptions[zoom];
+  const daysDiff = (d1: Date, d2: Date) =>
+    Math.floor((d1.getTime() - d2.getTime()) / 86400000);
+  const { gridStep } = zoomOptions[zoom];
+  const pxPerDay = DAY_WIDTH;
   const totalDays = daysDiff(endRange, startRange) + 1;
   const width = totalDays * pxPerDay;
 
-  const months: { label: string; left: number }[] = [];
-  const m = new Date(startRange.getFullYear(), startRange.getMonth(), 1);
-  while (m <= endRange) {
-    const label = m.toLocaleString('default', { month: 'long', year: 'numeric' });
-    const left = daysDiff(m, startRange) * pxPerDay;
-    months.push({ label, left });
-    m.setMonth(m.getMonth() + 1);
+  const headers: { label: string; left: number }[] = [];
+  const headerCursor = new Date(startRange);
+  if (zoom === 'day') {
+    while (headerCursor <= endRange) {
+      headers.push({
+        label: headerCursor.toLocaleDateString('default', {
+          month: 'short',
+          day: 'numeric',
+        }),
+        left: daysDiff(headerCursor, startRange) * pxPerDay,
+      });
+      headerCursor.setDate(headerCursor.getDate() + 1);
+    }
+  } else if (zoom === 'week') {
+    while (headerCursor <= endRange) {
+      headers.push({
+        label: headerCursor.toLocaleDateString('default', {
+          month: 'short',
+          day: 'numeric',
+        }),
+        left: daysDiff(headerCursor, startRange) * pxPerDay,
+      });
+      headerCursor.setDate(headerCursor.getDate() + 7);
+    }
+  } else {
+    headerCursor.setDate(1);
+    while (headerCursor <= endRange) {
+      headers.push({
+        label: headerCursor.toLocaleString('default', {
+          month: 'long',
+          year: 'numeric',
+        }),
+        left: daysDiff(headerCursor, startRange) * pxPerDay,
+      });
+      headerCursor.setMonth(headerCursor.getMonth() + 1);
+    }
   }
 
   const grids: number[] = [];
@@ -81,17 +121,20 @@ export default function RoadmapGantt({ tasks = sampleTasks }: Props) {
   const handleAdd = () => {
     if (!newName.trim()) return;
     const today = new Date().toISOString().slice(0, 10);
-    tasks.push({
-      id: Date.now().toString(),
-      name: newName,
-      status: 'To Do',
-      startDate: today,
-      endDate: today,
-      assignees: [],
-      manday: 1,
-      type: 'feature',
-      iteration: sampleIterations[0].name,
-    });
+    setItems([
+      ...items,
+      {
+        id: Date.now().toString(),
+        name: newName,
+        status: 'To Do',
+        startDate: today,
+        endDate: today,
+        assignees: [],
+        manday: 1,
+        type: 'feature',
+        iteration: sampleIterations[0].name,
+      },
+    ]);
     setShowAdd(false);
     setNewName('');
     setNewDesc('');
@@ -144,20 +187,31 @@ export default function RoadmapGantt({ tasks = sampleTasks }: Props) {
           placeholder="Search"
           className="ml-2 border px-1 rounded"
         />
-        <button
-          onClick={() => setShowAdd(true)}
-          className="ml-auto px-2 py-1 text-sm border rounded bg-gray-100"
-        >
-          + Add item
-        </button>
+        <div className="ml-auto space-x-2">
+          <button
+            className="px-2 py-1 text-sm border rounded bg-gray-100"
+            onClick={() => setShowAdd(true)}
+          >
+            + Add item
+          </button>
+          <button className="px-2 py-1 text-sm border rounded bg-green-100">
+            Save
+          </button>
+          <button className="px-2 py-1 text-sm border rounded bg-gray-100">
+            Discard
+          </button>
+        </div>
       </div>
 
-      <div className="overflow-x-auto border rounded" style={{ height: filtered.length * 28 + 80 }}>
+      <div
+        className="overflow-x-auto border rounded"
+        style={{ height: (filtered.length + 1) * ROW_HEIGHT + 80 }}
+      >
         <div className="relative" style={{ width }}>
-          {/* month header */}
-          {months.map(m => (
-            <div key={m.label} className="absolute top-0 text-xs" style={{ left: m.left }}>
-              {m.label}
+          {/* header */}
+          {headers.map(h => (
+            <div key={h.label} className="absolute top-0 text-xs" style={{ left: h.left }}>
+              {h.label}
             </div>
           ))}
           {/* grid lines */}
@@ -182,17 +236,62 @@ export default function RoadmapGantt({ tasks = sampleTasks }: Props) {
             }
             return null;
           })()}
+          {/* add row */}
+          <div
+            className="absolute text-sm text-blue-600 cursor-pointer"
+            style={{ top: 20 }}
+            onClick={() => setShowAdd(true)}
+          >
+            + Add item
+          </div>
           {/* tasks */}
           {filtered.map((t, idx) => {
             const start = fieldStartDate(t);
             const end = fieldEndDate(t);
             const left = daysDiff(start, startRange) * pxPerDay;
             const widthBar = (daysDiff(end, start) + 1) * pxPerDay;
-            const color = statusColors[t.status] || 'bg-gray-500';
+            const colorClasses: Record<string, string> = {
+              'To Do': 'border-gray-400 bg-gray-50',
+              'In Progress': 'border-blue-500 bg-blue-50',
+              Done: 'border-green-500 bg-green-50',
+            };
+            const color = colorClasses[t.status] || 'border-gray-300 bg-gray-50';
             return (
-              <div key={t.id} className="absolute" style={{ top: 20 + idx * 28, left }}>
-                <div className={`h-5 text-xs text-white px-1 rounded ${color}`} style={{ width: widthBar }}>
-                  {t.name}
+              <div
+                key={t.id}
+                className="absolute"
+                style={{ top: 20 + rowOffset + idx * ROW_HEIGHT, left }}
+              >
+                <div
+                  className={`h-6 text-xs flex items-center px-2 rounded border ${color} cursor-pointer group`}
+                  style={{ width: widthBar }}
+                  onClick={() => {
+                    setEditing(t);
+                    setEditName(t.name);
+                  }}
+                >
+                  <span className="mr-1">
+                    {t.status === 'Done' ? (
+                      <svg className="w-3 h-3 text-green-600" viewBox="0 0 16 16" fill="currentColor">
+                        <path d="M6 10.3L3.7 8l-1.4 1.4L6 13 14 5l-1.4-1.4z" />
+                      </svg>
+                    ) : (
+                      <svg className="w-3 h-3 text-gray-400" viewBox="0 0 16 16" fill="currentColor">
+                        <circle cx="8" cy="8" r="3" />
+                      </svg>
+                    )}
+                  </span>
+                  <span className="truncate">
+                    {t.name} #{t.id}
+                  </span>
+                  {/* tooltip */}
+                  <div className="absolute left-0 -top-8 hidden group-hover:block bg-white border text-xs p-1 rounded shadow">
+                    <div>
+                      {start.toISOString().slice(0, 10)} - {end.toISOString().slice(0, 10)}
+                    </div>
+                    {t.iteration && <div>Iteration: {t.iteration}</div>}
+                    {t.assignees.length > 0 && <div>Assignee: {t.assignees.join(', ')}</div>}
+                  </div>
                 </div>
               </div>
             );
@@ -223,6 +322,33 @@ export default function RoadmapGantt({ tasks = sampleTasks }: Props) {
                 onClick={handleAdd}
               >
                 Add
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {editing && (
+        <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center">
+          <div className="bg-white p-4 rounded space-y-2 w-64">
+            <div className="font-semibold">Edit Task</div>
+            <input
+              value={editName}
+              onChange={e => setEditName(e.target.value)}
+              className="border w-full px-2 py-1 rounded text-sm"
+            />
+            <div className="text-right space-x-2">
+              <button className="px-2 py-1 text-sm" onClick={() => setEditing(null)}>
+                Cancel
+              </button>
+              <button
+                className="px-2 py-1 text-sm bg-blue-600 text-white rounded"
+                onClick={() => {
+                  setItems(items.map(it => (it.id === editing.id ? { ...it, name: editName } : it)));
+                  setEditing(null);
+                }}
+              >
+                Save
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- restyle roadmap task bars and header
- filter by ID and show tooltip
- add inline `+ Add item` row and edit modal
- show Save/Discard buttons

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6875c4196f5c8328813994dbff53fb71