### PR TITLE
Add Tailwind-based project roadmap interface

### DIFF
--- a/client/components/AllStatusView.tsx
+++ b/client/components/AllStatusView.tsx
@@ -1,0 +1,29 @@
+import { Task } from './sampleData';
+
+interface Props {
+  tasks: Task[];
+}
+
+export default function AllStatusView({ tasks }: Props) {
+  const groups = tasks.reduce<Record<string, Task[]>>((acc, t) => {
+    acc[t.status] = acc[t.status] || [];
+    acc[t.status].push(t);
+    return acc;
+  }, {});
+  return (
+    <div className="space-y-4">
+      {Object.keys(groups).map(status => (
+        <div key={status} className="bg-white border rounded">
+          <div className="border-b px-2 py-1 font-semibold text-sm capitalize">
+            {status.replace('_', ' ')}
+          </div>
+          <ul className="p-2 text-sm list-disc ml-4">
+            {groups[status].map(t => (
+              <li key={t.id}>{t.name}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/components/BoardView.tsx
+++ b/client/components/BoardView.tsx
@@ -6,7 +6,12 @@ interface Props {
   setTasks: (t: Task[]) => void;
 }
 
-const columns = ['To Do', 'In Progress', 'Done'];
+const columns = ['todo', 'in_progress', 'done'];
+const labels: Record<string, string> = {
+  todo: 'To Do',
+  in_progress: 'In Progress',
+  done: 'Done',
+};
 
 export default function BoardView({ tasks, setTasks }: Props) {
   const onDragEnd = (result: DropResult) => {
@@ -30,7 +35,7 @@ export default function BoardView({ tasks, setTasks }: Props) {
                 {...provided.droppableProps}
                 className="flex-1 bg-gray-100 rounded p-2"
               >
-                <h3 className="font-semibold mb-2">{col}</h3>
+                <h3 className="font-semibold mb-2">{labels[col]}</h3>
                 {tasks
                   .filter(t => t.status === col)
                   .map((t, idx) => (

--- a/client/components/NewTaskModal.tsx
+++ b/client/components/NewTaskModal.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { Task } from './sampleData';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onCreate: (task: Omit<Task, 'id'>) => void;
+}
+
+export default function NewTaskModal({ open, onClose, onCreate }: Props) {
+  const [name, setName] = useState('');
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+  const [status, setStatus] = useState<'todo' | 'in_progress' | 'done'>('todo');
+
+  const submit = () => {
+    if (!name || !start) return;
+    onCreate({
+      name,
+      startDate: start,
+      endDate: end || start,
+      status,
+      assignees: [],
+      manday: 1,
+      type: 'feature',
+      iteration: ''
+    });
+    setName('');
+    setStart('');
+    setEnd('');
+    setStatus('todo');
+  };
+
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-30">
+      <div className="bg-white rounded p-4 w-72 space-y-2">
+        <div className="font-semibold">New Task</div>
+        <input
+          className="border w-full px-2 py-1 rounded text-sm"
+          placeholder="Name"
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+        <input
+          type="date"
+          className="border w-full px-2 py-1 rounded text-sm"
+          value={start}
+          onChange={e => setStart(e.target.value)}
+        />
+        <input
+          type="date"
+          className="border w-full px-2 py-1 rounded text-sm"
+          value={end}
+          onChange={e => setEnd(e.target.value)}
+        />
+        <select
+          className="border w-full px-2 py-1 rounded text-sm"
+          value={status}
+          onChange={e => setStatus(e.target.value as any)}
+        >
+          <option value="todo">To Do</option>
+          <option value="in_progress">In Progress</option>
+          <option value="done">Done</option>
+        </select>
+        <div className="text-right space-x-2">
+          <button className="px-2 py-1 text-sm" onClick={onClose}>Cancel</button>
+          <button className="px-2 py-1 text-sm bg-blue-600 text-white rounded" onClick={submit}>
+            Create
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/components/ProjectPage.tsx
+++ b/client/components/ProjectPage.tsx
@@ -2,9 +2,11 @@ import { useState } from 'react';
 import Layout from './Layout';
 import TaskTable from './TaskTable';
 import BoardView from './BoardView';
-import TimelineView from './TimelineView';
+import RoadmapGantt from './RoadmapGantt';
 import IterationsView from './IterationsView';
 import CapacityView from './CapacityView';
+import AllStatusView from './AllStatusView';
+import NewTaskModal from './NewTaskModal';
 import { ViewProvider, useView } from '../context/ViewContext';
 import { sampleTasks, Task } from './sampleData';
 
@@ -14,6 +16,7 @@ const views = [
   { key: 'timeline', label: 'Timeline' },
   { key: 'iterations', label: 'Iterations' },
   { key: 'capacity', label: 'Team Capacity' },
+  { key: 'status', label: 'All Status' },
 ];
 
 function InnerPage() {
@@ -21,6 +24,7 @@ function InnerPage() {
   const [tasks, setTasks] = useState<Task[]>(sampleTasks);
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
+  const [showNew, setShowNew] = useState(false);
 
   const filtered = tasks
     .filter(t =>
@@ -30,6 +34,11 @@ function InnerPage() {
         .includes(search.toLowerCase()),
     )
     .filter(t => (statusFilter ? t.status === statusFilter : true));
+
+  const addTask = (t: Omit<Task, 'id'>) => {
+    const nextId = (tasks.length + 1).toString();
+    setTasks([...tasks, { ...t, id: nextId }]);
+  };
 
   return (
     <Layout>
@@ -53,9 +62,9 @@ function InnerPage() {
             className="ml-auto border px-2 py-1 text-sm rounded"
           >
             <option value="">All Status</option>
-            <option>To Do</option>
-            <option>In Progress</option>
-            <option>Done</option>
+            <option value="todo">To Do</option>
+            <option value="in_progress">In Progress</option>
+            <option value="done">Done</option>
           </select>
           <input
             type="text"
@@ -64,14 +73,29 @@ function InnerPage() {
             placeholder="Search"
             className="ml-2 border px-2 py-1 text-sm rounded"
           />
+          <button
+            className="ml-2 px-3 py-1 text-sm bg-blue-600 text-white rounded"
+            onClick={() => setShowNew(true)}
+          >
+            + New
+          </button>
         </div>
         <div>
           {view === 'table' && <TaskTable tasks={filtered} setTasks={setTasks} />}
           {view === 'board' && <BoardView tasks={filtered} setTasks={setTasks} />}
-          {view === 'timeline' && <TimelineView tasks={filtered} />}
+          {view === 'timeline' && <RoadmapGantt tasks={filtered} />}
           {view === 'iterations' && <IterationsView tasks={filtered} />}
           {view === 'capacity' && <CapacityView tasks={filtered} />}
+          {view === 'status' && <AllStatusView tasks={filtered} />}
         </div>
+        <NewTaskModal
+          open={showNew}
+          onClose={() => setShowNew(false)}
+          onCreate={t => {
+            addTask(t);
+            setShowNew(false);
+          }}
+        />
       </div>
     </Layout>
   );

--- a/client/components/RoadmapGantt.tsx
+++ b/client/components/RoadmapGantt.tsx
@@ -7,9 +7,9 @@ interface Props {
 }
 
 const statusColors: Record<string, string> = {
-  'To Do': 'bg-gray-400',
-  'In Progress': 'bg-blue-500',
-  'Done': 'bg-green-500',
+  todo: 'bg-gray-400',
+  in_progress: 'bg-blue-500',
+  done: 'bg-green-500',
 };
 
 const DAY_WIDTH = 32;
@@ -126,7 +126,7 @@ export default function RoadmapGantt({ tasks = sampleTasks }: Props) {
       {
         id: Date.now().toString(),
         name: newName,
-        status: 'To Do',
+        status: 'todo',
         startDate: today,
         endDate: today,
         assignees: [],
@@ -177,9 +177,9 @@ export default function RoadmapGantt({ tasks = sampleTasks }: Props) {
           className="ml-4 border px-1 rounded"
         >
           <option value="">All</option>
-          <option>To Do</option>
-          <option>In Progress</option>
-          <option>Done</option>
+          <option value="todo">To Do</option>
+          <option value="in_progress">In Progress</option>
+          <option value="done">Done</option>
         </select>
         <input
           value={search}
@@ -251,9 +251,9 @@ export default function RoadmapGantt({ tasks = sampleTasks }: Props) {
             const left = daysDiff(start, startRange) * pxPerDay;
             const widthBar = (daysDiff(end, start) + 1) * pxPerDay;
             const colorClasses: Record<string, string> = {
-              'To Do': 'border-gray-400 bg-gray-50',
-              'In Progress': 'border-blue-500 bg-blue-50',
-              Done: 'border-green-500 bg-green-50',
+              todo: 'border-gray-400 bg-gray-50',
+              in_progress: 'border-blue-500 bg-blue-50',
+              done: 'border-green-500 bg-green-50',
             };
             const color = colorClasses[t.status] || 'border-gray-300 bg-gray-50';
             return (
@@ -271,7 +271,7 @@ export default function RoadmapGantt({ tasks = sampleTasks }: Props) {
                   }}
                 >
                   <span className="mr-1">
-                    {t.status === 'Done' ? (
+                    {t.status === 'done' ? (
                       <svg className="w-3 h-3 text-green-600" viewBox="0 0 16 16" fill="currentColor">
                         <path d="M6 10.3L3.7 8l-1.4 1.4L6 13 14 5l-1.4-1.4z" />
                       </svg>

--- a/client/components/TaskTable.tsx
+++ b/client/components/TaskTable.tsx
@@ -33,7 +33,7 @@ export default function TableView({ tasks, setTasks }: Props) {
       {
         id: nextId,
         name: 'New Task',
-        status: 'To Do',
+        status: 'todo',
         startDate: new Date().toISOString().slice(0, 10),
         endDate: new Date().toISOString().slice(0, 10),
         assignees: [],

--- a/client/components/index.tsx
+++ b/client/components/index.tsx
@@ -34,3 +34,5 @@ export { default as TimelineView } from './TimelineView';
 export { default as IterationsView } from './IterationsView';
 export { default as CapacityView } from './CapacityView';
 export { default as MilestoneTimeline } from './MilestoneTimeline';
+export { default as NewTaskModal } from './NewTaskModal';
+export { default as AllStatusView } from './AllStatusView';

--- a/client/components/sampleData.ts
+++ b/client/components/sampleData.ts
@@ -1,7 +1,7 @@
 export interface Task {
   id: string;
   name: string;
-  status: 'To Do' | 'In Progress' | 'Done';
+  status: 'todo' | 'in_progress' | 'done';
   startDate: string;
   endDate: string;
   assignees: string[];
@@ -22,7 +22,7 @@ export const sampleTasks: Task[] = [
   {
     id: '1',
     name: 'Setup project repo',
-    status: 'To Do',
+    status: 'todo',
     startDate: '2025-06-01',
     endDate: '2025-06-03',
     assignees: ['Alice'],
@@ -33,7 +33,7 @@ export const sampleTasks: Task[] = [
   {
     id: '2',
     name: 'Design database schema',
-    status: 'In Progress',
+    status: 'in_progress',
     startDate: '2025-06-02',
     endDate: '2025-06-06',
     assignees: ['Bob'],
@@ -45,7 +45,7 @@ export const sampleTasks: Task[] = [
   {
     id: '3',
     name: 'Implement auth module',
-    status: 'To Do',
+    status: 'todo',
     startDate: '2025-06-07',
     endDate: '2025-06-14',
     assignees: ['Carol'],
@@ -56,7 +56,7 @@ export const sampleTasks: Task[] = [
   {
     id: '4',
     name: 'Deploy to staging',
-    status: 'Done',
+    status: 'done',
     startDate: '2025-06-10',
     endDate: '2025-06-11',
     assignees: ['Alice'],


### PR DESCRIPTION
## Summary
- change sample task status values to `todo`, `in_progress`, `done`
- update board, table and gantt components to use new status values
- add `AllStatusView` and `NewTaskModal` for creating tasks
- enhance `ProjectPage` with tabs, `+ New` button and RoadmapGantt timeline
- export new components

## Testing
- `npm test` in `client`
- `npm test` in `service`


------
https://chatgpt.com/codex/tasks/task_e_6875fa9633888328ae86621c3d0a3f6e