### PR TITLE
Add project selector for timeline generation

### DIFF
--- a/client/components/GenerateTimelineWithJointJS.tsx
+++ b/client/components/GenerateTimelineWithJointJS.tsx
@@ -26,7 +26,7 @@ export default function GenerateTimelineWithJointJS() {
   useEffect(() => {
     async function loadProjects() {
       try {
-        const { data } = await api.get('/api/projects');
+        const { data } = await api.get('/api/v1/projects');
         setProjects(data);
       } catch (err) {
         console.error(err);
@@ -60,9 +60,17 @@ export default function GenerateTimelineWithJointJS() {
     }
     setLoading(true);
     api
-      .get(`/api/projects/${selected}/timeline`)
+      .get('/api/v1/planning/tasks', { params: { project: selected } })
       .then(res => {
-        setTimeline(res.data);
+        const list = Array.isArray(res.data) ? res.data : [];
+        const converted = list
+          .filter((t: any) => t.startDate || t.endDate)
+          .map((t: any) => ({
+            year: new Date(t.startDate || t.endDate).getFullYear(),
+            title: t.name,
+            description: t.detail,
+          }));
+        setTimeline(converted);
       })
       .catch(err => {
         console.error(err);

--- a/client/pages/plan-management/generate.tsx
+++ b/client/pages/plan-management/generate.tsx
@@ -2,7 +2,7 @@ import Container from '@mui/material/Container';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import { Layout, PageBreadcrumbs } from '../../components';
-import MilestoneTimeline from '../../components/MilestoneTimeline';
+import GenerateTimelineWithJointJS from '../../components/GenerateTimelineWithJointJS';
 import { withAuth } from '../../context/AuthContext';
 
 function GenerateTimeline() {
@@ -16,7 +16,7 @@ function GenerateTimeline() {
           <Typography variant="h5" sx={{ mb: 2 }}>
             Generate Timeline
           </Typography>
-          <MilestoneTimeline />
+          <GenerateTimelineWithJointJS />
         </Paper>
       </Container>
     </Layout>


### PR DESCRIPTION
## Summary
- hook up project selector on Generate Timeline page
- fetch project list and tasks using /api/v1 endpoints
- map tasks to milestone data for timeline view

## Testing
- `npm test` in `service`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6876011881008328b763cbc957f9ae2a