### PR TITLE
Refactor backlog board

### DIFF
--- a/client/components/BoardView.tsx
+++ b/client/components/BoardView.tsx
@@ -1,5 +1,12 @@
-import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
+import { useState } from 'react';
+import {
+  DragDropContext,
+  Droppable,
+  Draggable,
+  DropResult,
+} from 'react-beautiful-dnd';
 import { Task } from './sampleData';
+import TaskDrawer from './TaskDrawer';
 
 interface Props {
   tasks: Task[];
@@ -14,6 +21,8 @@ const labels: Record<string, string> = {
 };
 
 export default function BoardView({ tasks, setTasks }: Props) {
+  const [selected, setSelected] = useState<Task | null>(null);
+
   const onDragEnd = (result: DropResult) => {
     if (!result.destination) return;
     const { draggableId, destination } = result;
@@ -24,41 +33,89 @@ export default function BoardView({ tasks, setTasks }: Props) {
     );
   };
 
+  const handleSave = (t: Task) => {
+    setTasks(tasks.map(task => (task.id === t.id ? t : task)));
+  };
+
+  const addTask = (status: string) => {
+    const nextId = (tasks.length + 1).toString();
+    setTasks([
+      ...tasks,
+      {
+        id: nextId,
+        name: 'New Task',
+        status: status as any,
+        startDate: new Date().toISOString().slice(0, 10),
+        endDate: new Date().toISOString().slice(0, 10),
+        assignees: [],
+        manday: 1,
+        type: 'feature',
+        iteration: '',
+      },
+    ]);
+  };
+
   return (
-    <DragDropContext onDragEnd={onDragEnd}>
-      <div className="flex space-x-4">
-        {columns.map(col => (
-          <Droppable droppableId={col} key={col}>
-            {provided => (
-              <div
-                ref={provided.innerRef}
-                {...provided.droppableProps}
-                className="flex-1 bg-gray-100 rounded p-2"
-              >
-                <h3 className="font-semibold mb-2">{labels[col]}</h3>
-                {tasks
-                  .filter(t => t.status === col)
-                  .map((t, idx) => (
-                    <Draggable key={t.id} draggableId={t.id} index={idx}>
-                      {p => (
-                        <div
-                          ref={p.innerRef}
-                          {...p.draggableProps}
-                          {...p.dragHandleProps}
-                          className="bg-white rounded p-2 mb-2 shadow"
-                        >
-                          <div className="text-sm font-medium">{t.name}</div>
-                          <div className="text-xs text-gray-500">{t.type}</div>
-                        </div>
-                      )}
-                    </Draggable>
-                  ))}
-                {provided.placeholder}
-              </div>
-            )}
-          </Droppable>
-        ))}
-      </div>
-    </DragDropContext>
+    <>
+      <DragDropContext onDragEnd={onDragEnd}>
+        <div className="flex space-x-4 overflow-x-auto pb-4">
+          {columns.map(col => {
+            const colTasks = tasks.filter(t => t.status === col);
+            return (
+              <Droppable droppableId={col} key={col}>
+                {provided => (
+                  <div
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                    className="bg-gray-50 rounded-md p-2 w-64 flex-shrink-0"
+                  >
+                    <div className="flex items-center justify-between mb-2">
+                      <h3 className="font-semibold text-sm">{labels[col]}</h3>
+                      <span className="text-xs text-gray-500">{colTasks.length}</span>
+                    </div>
+                    {colTasks.map((t, idx) => (
+                      <Draggable key={t.id} draggableId={t.id} index={idx}>
+                        {p => (
+                          <div
+                            ref={p.innerRef}
+                            {...p.draggableProps}
+                            {...p.dragHandleProps}
+                            onClick={() => setSelected(t)}
+                            className="bg-white rounded-md shadow-sm p-2 mb-2 cursor-pointer hover:shadow"
+                          >
+                            <div className="text-sm font-medium truncate" title={t.name}>
+                              {t.name}
+                            </div>
+                            <div className="text-xs text-gray-500 truncate">
+                              #{t.id} · {t.manday}pt{t.iteration ? ` · ${t.iteration}` : ''}
+                            </div>
+                          </div>
+                        )}
+                      </Draggable>
+                    ))}
+                    {provided.placeholder}
+                    <button
+                      className="mt-2 text-xs text-blue-600"
+                      onClick={() => addTask(col)}
+                    >
+                      + Add item
+                    </button>
+                  </div>
+                )}
+              </Droppable>
+            );
+          })}
+        </div>
+      </DragDropContext>
+      <TaskDrawer
+        task={selected}
+        onClose={() => setSelected(null)}
+        onSave={t => {
+          handleSave(t);
+          setSelected(null);
+        }}
+      />
+    </>
   );
 }
+

--- a/client/components/TaskDrawer.tsx
+++ b/client/components/TaskDrawer.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import Drawer from '@mui/material/Drawer';
+import { Task } from './sampleData';
+
+interface Props {
+  task: Task | null;
+  onClose: () => void;
+  onSave: (t: Task) => void;
+}
+
+export default function TaskDrawer({ task, onClose, onSave }: Props) {
+  const [name, setName] = useState('');
+  const [manday, setManday] = useState(1);
+
+  useEffect(() => {
+    if (task) {
+      setName(task.name);
+      setManday(task.manday);
+    }
+  }, [task]);
+
+  if (!task) return null;
+
+  const handleSave = () => {
+    onSave({ ...task, name, manday });
+  };
+
+  return (
+    <Drawer anchor="right" open={!!task} onClose={onClose}>
+      <div className="w-80 p-4 space-y-2">
+        <div className="font-semibold text-lg">Task #{task.id}</div>
+        <input
+          className="border w-full px-2 py-1 rounded text-sm"
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+        <input
+          type="number"
+          className="border w-full px-2 py-1 rounded text-sm"
+          value={manday}
+          onChange={e => setManday(Number(e.target.value))}
+        />
+        <div className="text-right space-x-2">
+          <button className="px-2 py-1 text-sm" onClick={onClose}>Cancel</button>
+          <button
+            className="px-2 py-1 text-sm bg-blue-600 text-white rounded"
+            onClick={handleSave}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </Drawer>
+  );
+}

--- a/client/components/index.tsx
+++ b/client/components/index.tsx
@@ -30,6 +30,7 @@ export { default as ProjectPage } from './ProjectPage';
 export { default as TaskTable } from './TaskTable';
 export { default as RoadmapGantt } from './RoadmapGantt';
 export { default as BoardView } from './BoardView';
+export { default as TaskDrawer } from './TaskDrawer';
 export { default as TimelineView } from './TimelineView';
 export { default as IterationsView } from './IterationsView';
 export { default as CapacityView } from './CapacityView';


### PR DESCRIPTION
## Summary
- redesign board view with kanban-style columns
- implement a draggable task card and drawer for editing
- export new TaskDrawer component

## Testing
- `npm --prefix client test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687746e03dc88328a6db17fae658bc02