### PR TITLE
Fix timeline infinite loop

### DIFF
--- a/client/components/RoadmapGantt.tsx
+++ b/client/components/RoadmapGantt.tsx
@@ -152,7 +152,9 @@ export default function RoadmapGantt({ tasks = sampleTasks }: Props) {
 
   const dayCells: { label: string; month: string; left: number; first: boolean }[] = [];
   const cursor = new Date(rangeStart);
-  while (cursor <= rangeEnd) {
+  const MAX_CELLS = 365;
+  let dayCount = 0;
+  while (cursor <= rangeEnd && dayCount < MAX_CELLS) {
     dayCells.push({
       label: String(cursor.getDate()),
       month: cursor.toLocaleString('default', { month: 'short' }),
@@ -160,12 +162,14 @@ export default function RoadmapGantt({ tasks = sampleTasks }: Props) {
       first: cursor.getDate() === 1,
     });
     cursor.setDate(cursor.getDate() + 1);
+    dayCount++;
   }
 
   const monthCells: { label: string; left: number; width: number; days: number }[] = [];
   {
     let curMonth = new Date(rangeStart.getFullYear(), rangeStart.getMonth(), 1);
-    while (curMonth <= rangeEnd) {
+    let monthCount = 0;
+    while (curMonth <= rangeEnd && monthCount < MAX_CELLS) {
       const nextMonth = new Date(curMonth.getFullYear(), curMonth.getMonth() + 1, 1);
       const left = daysDiff(curMonth, rangeStart) * pxPerDay;
       const days = daysDiff(nextMonth, curMonth);
@@ -177,6 +181,7 @@ export default function RoadmapGantt({ tasks = sampleTasks }: Props) {
         days,
       });
       curMonth = nextMonth;
+      monthCount++;
     }
   }
 

--- a/client/components/TimelineView.tsx
+++ b/client/components/TimelineView.tsx
@@ -19,12 +19,15 @@ export default function TimelineView({ tasks }: Props) {
 
   const cells = [] as { label: string; left: number }[];
   const cur = new Date(min);
-  while (cur <= max) {
+  const MAX_CELLS = 365;
+  let safety = 0;
+  while (cur <= max && safety < MAX_CELLS) {
     const label = cur.toISOString().slice(0, 10);
     cells.push({ label, left: calcLeft(new Date(cur)) });
     if (zoom === 'month') cur.setMonth(cur.getMonth() + 1);
     else if (zoom === 'week') cur.setDate(cur.getDate() + 7);
     else cur.setDate(cur.getDate() + 1);
+    safety++;
   }
 
   return (


### PR DESCRIPTION
## Summary
- prevent runaway date iteration when rendering timeline headers
- limit RoadmapGantt and TimelineView loops to 365 cells

## Testing
- `npm test --silent` in `client`
- `npm test` *(fails: Test Suites: 0 of 4 total)*

------
https://chatgpt.com/codex/tasks/task_e_6879c7db40bc8328add4476a9354fba3