### PR TITLE
Fix timeline infinite column rendering

### DIFF
--- a/client/components/TimelineView.tsx
+++ b/client/components/TimelineView.tsx
@@ -1,57 +1,101 @@
-import { useState } from 'react';
-import { Task, sampleIterations } from './sampleData';
+import { useState, useRef, useLayoutEffect } from "react";
+import { Task, sampleIterations } from "./sampleData";
 
 interface Props {
   tasks: Task[];
 }
 
-const zoomLevels = ['day', 'week', 'month'];
+const zoomLevels = ["day", "week", "month"];
 
 export default function TimelineView({ tasks }: Props) {
-  const [zoom, setZoom] = useState<'day' | 'week' | 'month'>('month');
+  const [zoom, setZoom] = useState<"day" | "week" | "month">("month");
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = useState(0);
 
-  const dates = tasks.map(t => [new Date(t.startDate), new Date(t.endDate)]).flat();
-  const min = new Date(Math.min(...dates.map(d => d.getTime())));
-  const max = new Date(Math.max(...dates.map(d => d.getTime())));
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const update = () => setWidth(el.clientWidth);
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const dates = tasks
+    .map((t) => [new Date(t.startDate), new Date(t.endDate)])
+    .flat();
+  const min = new Date(Math.min(...dates.map((d) => d.getTime())));
+  const max = new Date(Math.max(...dates.map((d) => d.getTime())));
   const range = max.getTime() - min.getTime();
 
   const calcLeft = (d: Date) => ((d.getTime() - min.getTime()) / range) * 100;
 
   const cells = [] as { label: string; left: number }[];
   const cur = new Date(min);
+  const COL_WIDTH = 80;
+  const visible = Math.max(1, Math.ceil(width / COL_WIDTH));
   const MAX_CELLS = 365;
   let safety = 0;
-  while (cur <= max && safety < MAX_CELLS) {
+  while (cur <= max && safety < MAX_CELLS && cells.length < visible) {
     const label = cur.toISOString().slice(0, 10);
     cells.push({ label, left: calcLeft(new Date(cur)) });
-    if (zoom === 'month') cur.setMonth(cur.getMonth() + 1);
-    else if (zoom === 'week') cur.setDate(cur.getDate() + 7);
+    if (zoom === "month") cur.setMonth(cur.getMonth() + 1);
+    else if (zoom === "week") cur.setDate(cur.getDate() + 7);
     else cur.setDate(cur.getDate() + 1);
     safety++;
   }
 
   return (
-    <div className="relative border rounded bg-white p-4 overflow-x-auto" style={{minHeight:200}}>
+    <div
+      ref={containerRef}
+      className="relative border rounded bg-white p-4 overflow-x-auto"
+      style={{ minHeight: 200 }}
+    >
       <div className="mb-2 flex items-center space-x-2">
         <label className="text-sm">Zoom:</label>
-        <select value={zoom} onChange={e => setZoom(e.target.value as any)} className="border px-1 text-sm">
-          {zoomLevels.map(z => (
-            <option key={z} value={z}>{z}</option>
+        <select
+          value={zoom}
+          onChange={(e) => setZoom(e.target.value as any)}
+          className="border px-1 text-sm"
+        >
+          {zoomLevels.map((z) => (
+            <option key={z} value={z}>
+              {z}
+            </option>
           ))}
         </select>
       </div>
-      <div className="relative" style={{height:120}}>
-        {cells.map(c => (
-          <div key={c.label} className="absolute text-xs" style={{left:`${c.left}%`, top:0}}>{c.label}</div>
+      <div className="relative" style={{ height: 120 }}>
+        {cells.map((c) => (
+          <div
+            key={c.label}
+            className="absolute text-xs"
+            style={{ left: `${c.left}%`, top: 0 }}
+          >
+            {c.label}
+          </div>
         ))}
-        {sampleIterations.map(it => (
-          <div key={it.name} className="absolute border-l border-blue-500" style={{left:`${calcLeft(new Date(it.start))}%`, top:20, bottom:0}} />
+        {sampleIterations.map((it) => (
+          <div
+            key={it.name}
+            className="absolute border-l border-blue-500"
+            style={{
+              left: `${calcLeft(new Date(it.start))}%`,
+              top: 20,
+              bottom: 0,
+            }}
+          />
         ))}
-        {tasks.map(t => {
+        {tasks.map((t) => {
           const left = calcLeft(new Date(t.startDate));
           const right = calcLeft(new Date(t.endDate));
           return (
-            <div key={t.id} className="absolute bg-green-500 text-white text-xs px-1 rounded" style={{left:`${left}%`, width:`${right-left}%`, top:40}}>
+            <div
+              key={t.id}
+              className="absolute bg-green-500 text-white text-xs px-1 rounded"
+              style={{ left: `${left}%`, width: `${right - left}%`, top: 40 }}
+            >
               {t.name}
             </div>
           );


### PR DESCRIPTION
## Summary
- constrain TimelineView to only render columns that fit in the viewport
- measure container width and cap the number of generated cells

## Testing
- `npm test --silent` in `client`
- `npm test --silent` in `service`


------
https://chatgpt.com/codex/tasks/task_e_687c697619f08328bfc0c7f7bb39a96c