### PR TITLE
Add API-driven tasks to RoadmapGantt

### DIFF
--- a/client/components/ProjectPage.tsx
+++ b/client/components/ProjectPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Layout from './Layout';
 import TaskTable from './TaskTable';
 import BoardView from './BoardView';
@@ -9,6 +9,7 @@ import AllStatusView from './AllStatusView';
 import NewTaskModal from './NewTaskModal';
 import { ViewProvider, useView } from '../context/ViewContext';
 import { sampleTasks, Task } from './sampleData';
+import { fetchTasks } from '../models/planningModel';
 
 const views = [
   { key: 'table', label: 'Table' },
@@ -19,9 +20,23 @@ const views = [
   { key: 'status', label: 'All Status' },
 ];
 
-function InnerPage() {
+interface PageProps {
+  projectId?: string;
+}
+
+function InnerPage({ projectId }: PageProps) {
   const { view, setView } = useView();
   const [tasks, setTasks] = useState<Task[]>(sampleTasks);
+
+  useEffect(() => {
+    if (!projectId) {
+      setTasks(sampleTasks);
+      return;
+    }
+    fetchTasks(projectId)
+      .then(setTasks)
+      .catch(console.error);
+  }, [projectId]);
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
   const [showNew, setShowNew] = useState(false);
@@ -83,7 +98,9 @@ function InnerPage() {
         <div>
           {view === 'table' && <TaskTable tasks={filtered} setTasks={setTasks} />}
           {view === 'board' && <BoardView tasks={filtered} setTasks={setTasks} />}
-          {view === 'timeline' && <RoadmapGantt tasks={filtered} />}
+          {view === 'timeline' && (
+            <RoadmapGantt tasks={filtered} projectId={projectId} />
+          )}
           {view === 'iterations' && <IterationsView tasks={filtered} />}
           {view === 'capacity' && <CapacityView tasks={filtered} />}
           {view === 'status' && <AllStatusView tasks={filtered} />}
@@ -101,10 +118,10 @@ function InnerPage() {
   );
 }
 
-export default function ProjectPage() {
+export default function ProjectPage({ projectId }: PageProps) {
   return (
     <ViewProvider>
-      <InnerPage />
+      <InnerPage projectId={projectId} />
     </ViewProvider>
   );
 }

--- a/client/components/RoadmapGantt.tsx
+++ b/client/components/RoadmapGantt.tsx
@@ -5,7 +5,7 @@ import React, {
   useCallback,
   useLayoutEffect,
 } from 'react';
-import { updateTask } from '../models/planningModel';
+import { fetchTasks, updateTask } from '../models/planningModel';
 
 import { sampleTasks, sampleIterations, Task } from './sampleData';
 import {
@@ -19,6 +19,7 @@ import {
 
 interface Props {
   tasks?: Task[];
+  projectId?: string;
 }
 
 const statusColors: Record<string, string> = {
@@ -29,7 +30,7 @@ const statusColors: Record<string, string> = {
 
 const ROW_HEIGHT = 28;
 
-export default function RoadmapGantt({ tasks = sampleTasks }: Props) {
+export default function RoadmapGantt({ tasks = sampleTasks, projectId }: Props) {
   const [items, setItems] = useState<Task[]>(tasks);
   const [startField, setStartField] = useState<'startDate' | 'iterationStart'>('startDate');
   const [endField, setEndField] = useState<'endDate' | 'iterationEnd'>('endDate');
@@ -47,6 +48,22 @@ export default function RoadmapGantt({ tasks = sampleTasks }: Props) {
     origEnd: Date;
   } | null>(null);
   const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!projectId) {
+      setItems(tasks);
+      return;
+    }
+    fetchTasks(projectId)
+      .then(setItems)
+      .catch(console.error);
+  }, [projectId]);
+
+  useEffect(() => {
+    if (!projectId) {
+      setItems(tasks);
+    }
+  }, [tasks, projectId]);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);

--- a/client/pages/plan-management/roadmap.tsx
+++ b/client/pages/plan-management/roadmap.tsx
@@ -1,8 +1,12 @@
 import { withAuth } from '../../context/AuthContext';
 import { ProjectPage } from '../../components';
+import { useRouter } from 'next/router';
 
 function RoadmapPage() {
-  return <ProjectPage />;
+  const router = useRouter();
+  const { project } = router.query;
+  const projectId = Array.isArray(project) ? project[0] : project;
+  return <ProjectPage projectId={projectId as string | undefined} />;
 }
 
 export default withAuth(RoadmapPage);


### PR DESCRIPTION
## Summary
- fetch tasks from the API when a projectId is provided
- allow ProjectPage and RoadmapGantt to receive a projectId prop
- pass projectId via query string in the roadmap page

## Testing
- `npm test --prefix client`
- `npm test --prefix service`


------
https://chatgpt.com/codex/tasks/task_e_687c86319b988328a46fd0d64ca59268