### PR TITLE
Fix task typing and add tests

### DIFF
--- a/client/__tests__/sanitize.test.ts
+++ b/client/__tests__/sanitize.test.ts
@@ -1,0 +1,23 @@
+import { sanitizeList } from '../utils/sanitize';
+import type { Task } from '../models/taskTypes';
+
+describe('sanitizeList', () => {
+  it('removes onClick property from items', () => {
+    const items: (Task & { onClick?: () => void })[] = [
+      {
+        id: '1',
+        name: 'T',
+        status: 'todo',
+        startDate: '2020-01-01',
+        endDate: '2020-01-02',
+        assignees: [],
+        manday: 1,
+        type: 'feature',
+        iteration: 'Sprint 1',
+        onClick: () => {}
+      }
+    ];
+    const sanitized = sanitizeList(items);
+    expect(sanitized[0]).not.toHaveProperty('onClick');
+  });
+});

--- a/client/components/ProjectPage.tsx
+++ b/client/components/ProjectPage.tsx
@@ -52,7 +52,7 @@ function InnerPage({ projectId }: PageProps) {
 
   const addTask = (t: Omit<Task, 'id'>) => {
     const nextId = (tasks.length + 1).toString();
-    setTasks([...tasks, { ...t, id: nextId }]);
+    setTasks([...tasks, { ...t, id: nextId } as Task]);
   };
 
   return (

--- a/client/components/sampleData.ts
+++ b/client/components/sampleData.ts
@@ -1,15 +1,5 @@
-export interface Task {
-  id: string;
-  name: string;
-  status: 'todo' | 'in_progress' | 'done';
-  startDate: string;
-  endDate: string;
-  assignees: string[];
-  manday: number;
-  blockedBy?: string;
-  type: string;
-  iteration: string;
-}
+import type { Task } from '../models/taskTypes';
+export type { Task };
 
 export const sampleUsers = ['Alice', 'Bob', 'Carol'];
 

--- a/client/models/planningModel.ts
+++ b/client/models/planningModel.ts
@@ -1,5 +1,6 @@
 import api from '../api';
 import { sanitizeList } from '../utils/sanitize';
+import type { Task } from './taskTypes';
 
 export async function fetchPhases(projectId: string) {
   const { data } = await api.get('/api/v1/planning/phases', {
@@ -8,11 +9,11 @@ export async function fetchPhases(projectId: string) {
   return sanitizeList(data);
 }
 
-export async function fetchTasks(projectId: string) {
-  const { data } = await api.get('/api/v1/planning/tasks', {
+export async function fetchTasks(projectId: string): Promise<Task[]> {
+  const { data } = await api.get<Task[]>('/api/v1/planning/tasks', {
     params: { project: projectId },
   });
-  return sanitizeList(data);
+  return sanitizeList<Task>(data);
 }
 
 

--- a/client/models/taskTypes.ts
+++ b/client/models/taskTypes.ts
@@ -1,0 +1,12 @@
+export interface Task extends Record<string, unknown> {
+  id: string;
+  name: string;
+  status: 'todo' | 'in_progress' | 'done';
+  startDate: string;
+  endDate: string;
+  assignees: string[];
+  manday: number;
+  blockedBy?: string;
+  type: string;
+  iteration: string;
+}

--- a/client/models/tasksModel.ts
+++ b/client/models/tasksModel.ts
@@ -1,8 +1,0 @@
-import api from '../api';
-import { sanitizeList } from '../utils/sanitize';
-
-export async function fetchTasks(projectId: string) {
-  const { data } = await api.get('/api/v1/planning/tasks', { params: { project: projectId } });
-  return sanitizeList(data);
-}
-

--- a/client/pages/plan-management/index.tsx
+++ b/client/pages/plan-management/index.tsx
@@ -9,7 +9,7 @@ import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import { fetchEvents } from '../../models/eventsModel';
 import { fetchProjects } from '../../models/projectsModel';
-import { fetchTasks } from '../../models/tasksModel';
+import { fetchTasks } from '../../models/planningModel';
 import { fetchWorkdays } from '../../models/workdayModel';
 import { Layout, AgendaCalendar, PageBreadcrumbs, ProjectTimeline } from '../../components';
 import { differenceInCalendarDays } from 'date-fns';

--- a/service/__tests__/planning.getTasks.test.ts
+++ b/service/__tests__/planning.getTasks.test.ts
@@ -1,0 +1,14 @@
+import { PlanningService } from '../src/planning/planning.service';
+
+describe('PlanningService getTasks', () => {
+  it('returns tasks from repository', async () => {
+    const sample = [{ _id: '1', name: 'T1' }];
+    const tasksRepo = {
+      findByProject: jest.fn().mockResolvedValue(sample),
+    } as any;
+    const service = new PlanningService({} as any, tasksRepo);
+    const result = await service.getTasks('p1');
+    expect(result).toEqual(sample);
+    expect(tasksRepo.findByProject).toHaveBeenCalledWith('p1');
+  });
+});


### PR DESCRIPTION
## Summary
- centralize Task type and use in planning API model
- remove old tasks model and fix ProjectPage task updates
- add unit tests for sanitizeList and PlanningService

## Testing
- `npm run build` (client)
- `npm test` (client)
- `npm run build` (service)
- `npm test` (service)


------
https://chatgpt.com/codex/tasks/task_e_689ec30f15a083289819a6d343dec896